### PR TITLE
Build on modern GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,10 @@ LIB=${BUILDDIR}/libmovian
 
 include ${BUILDDIR}/config.mak
 
-CFLAGS_std += -Wall -Werror -Wwrite-strings -Wno-deprecated-declarations \
+CFLAGS_std_noerror += -Wall -Wwrite-strings -Wno-deprecated-declarations \
 		-Wmissing-prototypes -Wno-multichar  -Iext/dvd -std=gnu99
+CFLAGS_std += ${CFLAGS_std_noerror} -Werror -Wno-error=attributes \
+		-Wno-error=format-truncation -Wno-error=format-overflow
 
 CFLAGS = ${CFLAGS_std} ${OPTFLAGS}
 
@@ -531,7 +533,7 @@ ${BUILDDIR}/ext/rtmpdump/librtmp/%.o : CFLAGS = ${OPTFLAGS}
 
 SRCS-$(CONFIG_LIBRTMP)  +=      src/backend/rtmp/rtmp.c
 
-${BUILDDIR}/src/backend/rtmp/rtmp.o : CFLAGS = ${OPTFLAGS} -Wall -Werror -Iext/rtmpdump
+${BUILDDIR}/src/backend/rtmp/rtmp.o : CFLAGS = ${OPTFLAGS} -Wall -Werror -Wno-error=attributes -Iext/rtmpdump
 
 
 ##############################################################
@@ -755,7 +757,7 @@ SRCS-${CONFIG_VMIR} += \
 	src/np/np_backend.c \
 	src/np/np_stats.c \
 
-${BUILDDIR}/ext/vmir/src/vmir.o : CFLAGS = ${CFLAGS_std} ${OPTFLAGS} -DVMIR_USE_TLSF -Iext/tlsf
+${BUILDDIR}/ext/vmir/src/vmir.o : CFLAGS = ${CFLAGS_std_noerror} ${OPTFLAGS} -DVMIR_USE_TLSF -Iext/tlsf
 
 ${BUILDDIR}/src/np/%.o : CFLAGS = ${CFLAGS_std} ${OPTFLAGS} -DNATIVEPLUGIN_HOST -Inativeplugin/include/
 

--- a/configure.linux
+++ b/configure.linux
@@ -164,6 +164,12 @@ for opt do
   esac
 done
 
+case "$ARCH" in
+  x86_64|amd64|i?86)
+    # The bundled libav x86 inline asm is rejected by newer GCC/binutils.
+    LIBAV_COMMON_FLAGS="${LIBAV_COMMON_FLAGS} --disable-inline-asm"
+  ;;
+esac
 
 setup_env "$@"
 

--- a/src/api/stpp.c
+++ b/src/api/stpp.c
@@ -1428,6 +1428,7 @@ build_msg(stppmsg_t *msg)
   extern int http_server_port;
   if(stpp_system_name == NULL)
     return -1;
+  memset(msg, 0, sizeof(*msg));
   snprintf(msg->name, sizeof(msg->name), "%s", rstr_get(stpp_system_name));
   snprintf(msg->type, sizeof(msg->type), "%s", arch_get_system_type());
   memcpy(msg->magic, "STPP", 4);

--- a/src/api/stpp.c
+++ b/src/api/stpp.c
@@ -1428,8 +1428,8 @@ build_msg(stppmsg_t *msg)
   extern int http_server_port;
   if(stpp_system_name == NULL)
     return -1;
-  strncpy(msg->name, rstr_get(stpp_system_name), sizeof(msg->name));
-  strncpy(msg->type, arch_get_system_type(), sizeof(msg->type));
+  snprintf(msg->name, sizeof(msg->name), "%s", rstr_get(stpp_system_name));
+  snprintf(msg->type, sizeof(msg->type), "%s", arch_get_system_type());
   memcpy(msg->magic, "STPP", 4);
   memcpy(msg->deviceid, stpp_id, sizeof(msg->deviceid));
   msg->version = STPP_VERSION;

--- a/src/arch/linux/linux.mk
+++ b/src/arch/linux/linux.mk
@@ -24,10 +24,10 @@ SRCS-$(CONFIG_WEBPOPUP) += src/arch/linux/linux_webpopup.c
 SRCS-$(CONFIG_DVD) += src/backend/dvd/linux_dvd.c
 
 ${BUILDDIR}/src/arch/linux/%.o : CFLAGS = $(CFLAGS_GTK) ${OPTFLAGS} \
--Wall -Werror -Wmissing-prototypes -Wno-cast-qual -Wno-deprecated-declarations
+-Wall -Werror -Wno-error=attributes -Wmissing-prototypes -Wno-cast-qual -Wno-deprecated-declarations
 
 ${BUILDDIR}/src/prop/prop_glib_courier.o : CFLAGS = $(CFLAGS_GTK) ${OPTFLAGS} \
--Wall -Werror -Wmissing-prototypes -Wno-cast-qual -Wno-deprecated-declarations
+-Wall -Werror -Wno-error=attributes -Wmissing-prototypes -Wno-cast-qual -Wno-deprecated-declarations
 
 
 DVDCSS_CFLAGS = -DHAVE_LINUX_DVD_STRUCT -DDVD_STRUCT_IN_LINUX_CDROM_H -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE
@@ -79,4 +79,3 @@ $(BUILDDIR)/movian.snap: $(SNAPDEPS)
 	mksquashfs $(SNAPROOT) $@ -noappend -comp xz -all-root -no-xattrs -no-fragments
 
 snap: $(BUILDDIR)/movian.snap
-

--- a/src/arch/linux/linux_main.c
+++ b/src/arch/linux/linux_main.c
@@ -105,7 +105,7 @@ add_xdg_path(const char *class, const char *type)
     service_create_managed(id, title, path, type, NULL, 0, 1,
 			   SVC_ORIGIN_SYSTEM);
   }
-  fclose(fp);
+  pclose(fp);
 }
 
 

--- a/src/arch/posix/posix.c
+++ b/src/arch/posix/posix.c
@@ -73,7 +73,7 @@ linux_get_dist(void)
     }
   }
 
-  fclose(fp);
+  pclose(fp);
   return ret;
 }
 #endif

--- a/src/i18n.c
+++ b/src/i18n.c
@@ -196,7 +196,7 @@ findscore(const char *str, char vec[][4])
     return 0;
 
   for(i = 0; i < 3; i++)
-    if(vec[i] && !strcasecmp(vec[i], str))
+    if(vec[i][0] && !strcasecmp(vec[i], str))
       return 100000 * (3 - i);
   return 0;
 }

--- a/src/ui/glw/glw_renderer.c
+++ b/src/ui/glw/glw_renderer.c
@@ -986,9 +986,12 @@ add_job(glw_root_t *gr,
     // Need more space
     glw_render_job_t *old_jobs = gr->gr_render_jobs;
     int old_capacity = gr->gr_render_jobs_capacity;
+    int *job_offsets = malloc(sizeof(int) * old_capacity);
 
     gr->gr_render_jobs_capacity = 100 + gr->gr_render_jobs_capacity * 2;
 
+    for(int i = 0; i < old_capacity; i++)
+      job_offsets[i] = gr->gr_render_order[i].job - old_jobs;
 
     gr->gr_render_jobs = realloc(gr->gr_render_jobs,
                                  sizeof(glw_render_job_t) *
@@ -996,9 +999,9 @@ add_job(glw_root_t *gr,
 
     // Adjust pointers since we might have relocated job array
     for(int i = 0; i < old_capacity; i++) {
-      gr->gr_render_order[i].job =
-        gr->gr_render_order[i].job - old_jobs + gr->gr_render_jobs;
+      gr->gr_render_order[i].job = gr->gr_render_jobs + job_offsets[i];
     }
+    free(job_offsets);
 
     gr->gr_render_order = realloc(gr->gr_render_order,
                                   sizeof(glw_render_order_t) *


### PR DESCRIPTION
## Summary
- fix the clean `movian6` tree so it builds with current Ubuntu/GCC toolchains
- keep the scope limited to compiler/build compatibility fixes
- avoid runtime feature changes in this step

## Validation
- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`

## Historical Note
This was the first staged review branch. The final default-branch landing for the full public update stack is PR #6.