### PR TITLE
Add raw screenshot API

### DIFF
--- a/src/api/screenshot.c
+++ b/src/api/screenshot.c
@@ -34,7 +34,103 @@
 #include <libswscale/swscale.h>
 
 static hts_mutex_t screenshot_mutex;
+static hts_cond_t screenshot_cond;
 static http_connection_t *screenshot_connection;
+static int screenshot_raw_waiting;
+static int screenshot_raw_done;
+static buf_t *screenshot_raw_image;
+static char *screenshot_raw_error;
+
+
+/**
+ *
+ */
+static void
+screenshot_raw_complete(buf_t *image, const char *errmsg)
+{
+  hts_mutex_lock(&screenshot_mutex);
+  if(screenshot_raw_waiting) {
+    if(screenshot_raw_image != NULL)
+      buf_release(screenshot_raw_image);
+    free(screenshot_raw_error);
+    screenshot_raw_image = image;
+    screenshot_raw_error = errmsg ? strdup(errmsg) : NULL;
+    screenshot_raw_done = 1;
+    hts_cond_signal(&screenshot_cond);
+  } else if(image != NULL) {
+    buf_release(image);
+  }
+  hts_mutex_unlock(&screenshot_mutex);
+}
+
+
+/**
+ *
+ */
+static int
+hc_screenshot_raw(http_connection_t *hc)
+{
+  hts_mutex_lock(&screenshot_mutex);
+  if(screenshot_raw_waiting || screenshot_connection != NULL) {
+    hts_mutex_unlock(&screenshot_mutex);
+    return 502;
+  }
+  screenshot_raw_waiting = 1;
+  screenshot_raw_done = 0;
+  if(screenshot_raw_image != NULL) {
+    buf_release(screenshot_raw_image);
+    screenshot_raw_image = NULL;
+  }
+  free(screenshot_raw_error);
+  screenshot_raw_error = NULL;
+  hts_mutex_unlock(&screenshot_mutex);
+
+  event_to_ui(event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t)));
+
+  hts_mutex_lock(&screenshot_mutex);
+  int timedout = 0;
+  while(!screenshot_raw_done) {
+    if(hts_cond_wait_timeout(&screenshot_cond, &screenshot_mutex, 5000)) {
+      timedout = 1;
+      break;
+    }
+  }
+
+  buf_t *image = screenshot_raw_image;
+  screenshot_raw_image = NULL;
+  char *error = screenshot_raw_error;
+  screenshot_raw_error = NULL;
+  screenshot_raw_waiting = 0;
+  screenshot_raw_done = 0;
+  hts_mutex_unlock(&screenshot_mutex);
+
+  if(timedout) {
+    if(image != NULL)
+      buf_release(image);
+    free(error);
+    return http_error(hc, 504, "Screenshot timed out");
+  }
+
+  if(image == NULL) {
+    int r = http_error(hc, 500, "%s",
+                       error != NULL ? error : "Screenshot capture failed");
+    free(error);
+    return r;
+  }
+
+  htsbuf_queue_t out;
+  htsbuf_queue_init(&out, 0);
+  htsbuf_append(&out, buf_data(image), buf_len(image));
+  struct http_header_list headers;
+  LIST_INIT(&headers);
+  http_header_add(&headers, "Content-Type", "image/png", 0);
+  http_header_add_int(&headers, "Content-Length", buf_len(image));
+  http_header_add(&headers, "Connection", "Close", 0);
+  int r = http_send_raw(hc, 200, "OK", &headers, &out);
+  buf_release(image);
+  free(error);
+  return r;
+}
 
 
 /**
@@ -44,8 +140,15 @@ static int
 hc_screenshot(http_connection_t *hc, const char *remain,
               void *opaque, http_cmd_t method)
 {
+  const char *raw = http_arg_get_req(hc, "raw");
+  int want_raw = (remain != NULL && !strcmp(remain, "raw")) ||
+                 (raw != NULL && (!strcmp(raw, "1") || !strcmp(raw, "true")));
+
+  if(want_raw)
+    return hc_screenshot_raw(hc);
+
   hts_mutex_lock(&screenshot_mutex);
-  if(screenshot_connection != NULL) {
+  if(screenshot_raw_waiting || screenshot_connection != NULL) {
     hts_mutex_unlock(&screenshot_mutex);
     return 502;
   }
@@ -142,6 +245,9 @@ screenshot_compress(pixmap_t *pm, int codecid)
   }
 
   AVFrame *oframe = av_frame_alloc();
+  oframe->format = ctx->pix_fmt;
+  oframe->width  = width;
+  oframe->height = height;
 
   avpicture_alloc((AVPicture *)oframe, ctx->pix_fmt, width, height);
 
@@ -192,6 +298,14 @@ screenshot_process(void *task)
   pixmap_t *pm = task;
 
   if(pm == NULL) {
+    hts_mutex_lock(&screenshot_mutex);
+    int raw_waiting = screenshot_raw_waiting;
+    hts_mutex_unlock(&screenshot_mutex);
+    if(raw_waiting) {
+      screenshot_raw_complete(NULL,
+                              "Screenshot not supported on this platform");
+      return;
+    }
     screenshot_response(NULL, "Screenshot not supported on this platform");
     return;
   }
@@ -199,18 +313,32 @@ screenshot_process(void *task)
   TRACE(TRACE_DEBUG, "Screenshot", "Processing image %d x %d",
         pm->pm_width, pm->pm_height);
 
+  hts_mutex_lock(&screenshot_mutex);
+  int has_connection = screenshot_connection != NULL;
+  int raw_waiting = screenshot_raw_waiting;
+  hts_mutex_unlock(&screenshot_mutex);
+
   int codecid = AV_CODEC_ID_PNG;
-  if(screenshot_connection)
+  if(has_connection && !raw_waiting)
     codecid = AV_CODEC_ID_MJPEG;
 
   buf_t *b = screenshot_compress(pm, codecid);
   pixmap_release(pm);
   if(b == NULL) {
+    if(raw_waiting) {
+      screenshot_raw_complete(NULL, "Unable to compress image");
+      return;
+    }
     screenshot_response(NULL, "Unable to compress image");
     return;
   }
 
-  if(!screenshot_connection) {
+  if(raw_waiting) {
+    screenshot_raw_complete(b, NULL);
+    return;
+  }
+
+  if(!has_connection) {
     char path[512];
     char errbuf[512];
     snprintf(path, sizeof(path), "%s/screenshot.png",
@@ -295,6 +423,7 @@ static void
 screenshot_init(void)
 {
   hts_mutex_init(&screenshot_mutex);
+  hts_cond_init(&screenshot_cond, &screenshot_mutex);
   http_path_add("/api/screenshot", NULL, hc_screenshot, 0);
 }
 

--- a/src/api/screenshot.c
+++ b/src/api/screenshot.c
@@ -85,7 +85,9 @@ hc_screenshot_raw(http_connection_t *hc)
   screenshot_raw_error = NULL;
   hts_mutex_unlock(&screenshot_mutex);
 
-  event_to_ui(event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t)));
+  event_t *e = event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t));
+  e->e_flags |= EVENT_SCREENSHOT_RAW;
+  event_to_ui(e);
 
   hts_mutex_lock(&screenshot_mutex);
   int timedout = 0;
@@ -155,7 +157,9 @@ hc_screenshot(http_connection_t *hc, const char *remain,
   screenshot_connection = hc;
   hts_mutex_unlock(&screenshot_mutex);
 
-  event_to_ui(event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t)));
+  event_t *e = event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t));
+  e->e_flags |= EVENT_SCREENSHOT_UPLOAD;
+  event_to_ui(e);
   return 0;
 }
 
@@ -289,24 +293,32 @@ screenshot_compress(pixmap_t *pm, int codecid)
 }
 
 
+typedef struct screenshot_task {
+  pixmap_t *pm;
+  int flags;
+} screenshot_task_t;
+
+
 /**
  *
  */
 static void
 screenshot_process(void *task)
 {
-  pixmap_t *pm = task;
+  screenshot_task_t *st = task;
+  pixmap_t *pm = st->pm;
+  int raw_request = st->flags & EVENT_SCREENSHOT_RAW;
+  int upload_request = st->flags & EVENT_SCREENSHOT_UPLOAD;
+  free(st);
 
   if(pm == NULL) {
-    hts_mutex_lock(&screenshot_mutex);
-    int raw_waiting = screenshot_raw_waiting;
-    hts_mutex_unlock(&screenshot_mutex);
-    if(raw_waiting) {
+    if(raw_request) {
       screenshot_raw_complete(NULL,
                               "Screenshot not supported on this platform");
       return;
     }
-    screenshot_response(NULL, "Screenshot not supported on this platform");
+    if(upload_request)
+      screenshot_response(NULL, "Screenshot not supported on this platform");
     return;
   }
 
@@ -318,27 +330,38 @@ screenshot_process(void *task)
   int raw_waiting = screenshot_raw_waiting;
   hts_mutex_unlock(&screenshot_mutex);
 
+  if(raw_request && !raw_waiting) {
+    pixmap_release(pm);
+    return;
+  }
+
+  if(upload_request && !has_connection) {
+    pixmap_release(pm);
+    return;
+  }
+
   int codecid = AV_CODEC_ID_PNG;
-  if(has_connection && !raw_waiting)
+  if(upload_request)
     codecid = AV_CODEC_ID_MJPEG;
 
   buf_t *b = screenshot_compress(pm, codecid);
   pixmap_release(pm);
   if(b == NULL) {
-    if(raw_waiting) {
+    if(raw_request) {
       screenshot_raw_complete(NULL, "Unable to compress image");
       return;
     }
-    screenshot_response(NULL, "Unable to compress image");
+    if(upload_request)
+      screenshot_response(NULL, "Unable to compress image");
     return;
   }
 
-  if(raw_waiting) {
+  if(raw_request) {
     screenshot_raw_complete(b, NULL);
     return;
   }
 
-  if(!has_connection) {
+  if(!upload_request) {
     char path[512];
     char errbuf[512];
     snprintf(path, sizeof(path), "%s/screenshot.png",
@@ -410,9 +433,12 @@ screenshot_process(void *task)
  *
  */
 void
-screenshot_deliver(pixmap_t *pm)
+screenshot_deliver(pixmap_t *pm, int flags)
 {
-  task_run(screenshot_process, pm ? pixmap_dup(pm) : NULL);
+  screenshot_task_t *st = malloc(sizeof(screenshot_task_t));
+  st->pm = pm ? pixmap_dup(pm) : NULL;
+  st->flags = flags;
+  task_run(screenshot_process, st);
 }
 
 

--- a/src/api/screenshot.h
+++ b/src/api/screenshot.h
@@ -1,4 +1,4 @@
 #pragma once
 
 struct pixmap;
-void screenshot_deliver(struct pixmap *pm);
+void screenshot_deliver(struct pixmap *pm, int flags);

--- a/src/event.h
+++ b/src/event.h
@@ -195,6 +195,8 @@ typedef struct event {
 #define EVENT_KEYPRESS        0x1 // Came from user keypress
 #define EVENT_MOUSE           0x2 // Came from mouse input
 #define EVENT_SCREEN_POSITION 0x4 // e_screen_[xy] is valid
+#define EVENT_SCREENSHOT_UPLOAD 0x8 // Only valid for EVENT_MAKE_SCREENSHOT
+#define EVENT_SCREENSHOT_RAW 0x10 // Only valid for EVENT_MAKE_SCREENSHOT
   event_type_t e_type;
 } event_t;
 

--- a/src/ui/glw/glw.c
+++ b/src/ui/glw/glw.c
@@ -2375,15 +2375,15 @@ glw_kill_screensaver(glw_root_t *gr)
  *
  */
 static void
-glw_screenshot(glw_root_t *gr)
+glw_screenshot(glw_root_t *gr, int flags)
 {
   if(gr->gr_br_read_pixels == NULL) {
-    screenshot_deliver(NULL);
+    screenshot_deliver(NULL, flags);
     return;
   }
 
   pixmap_t *pm = gr->gr_br_read_pixels(gr);
-  screenshot_deliver(pm);
+  screenshot_deliver(pm, flags);
   pixmap_release(pm);
 }
 
@@ -2434,7 +2434,8 @@ glw_dispatch_event(glw_root_t *gr, event_t *e)
   }
 
   if(e->e_type == EVENT_MAKE_SCREENSHOT) {
-    glw_screenshot(gr);
+    glw_screenshot(gr, e->e_flags & (EVENT_SCREENSHOT_UPLOAD |
+                                     EVENT_SCREENSHOT_RAW));
     return;
   }
 

--- a/src/ui/glw/glw_x11.c
+++ b/src/ui/glw/glw_x11.c
@@ -54,6 +54,30 @@
 
 #include "glw_rec.h"
 
+static int
+running_under_wsl(void)
+{
+  const char *interop = getenv("WSL_INTEROP");
+  const char *distro = getenv("WSL_DISTRO_NAME");
+
+  if((interop != NULL && interop[0] != 0) ||
+     (distro != NULL && distro[0] != 0))
+    return 1;
+
+  FILE *fp = fopen("/proc/sys/kernel/osrelease", "r");
+  if(fp == NULL)
+    return 0;
+
+  char buf[256];
+  char *r = fgets(buf, sizeof(buf), fp);
+  fclose(fp);
+
+  return r != NULL &&
+    (strstr(buf, "Microsoft") != NULL ||
+     strstr(buf, "microsoft") != NULL ||
+     strstr(buf, "WSL") != NULL);
+}
+
 typedef struct glw_x11 {
 
   glw_root_t gr;
@@ -67,6 +91,8 @@ typedef struct glw_x11 {
   int screen_height;
   int root;
   XVisualInfo *xvi;
+  GLXFBConfig fbconfig;
+  int use_fbconfig;
   Window win;
   GLXContext glxctx;
   Cursor blank_cursor;
@@ -297,7 +323,12 @@ window_open(glw_x11_t *gx11, int fullscreen)
   gx11->gr.gr_width  = w;
   gx11->gr.gr_height = h;
 
-  gx11->glxctx = glXCreateContext(gx11->display, gx11->xvi, NULL, 1);
+  if(gx11->use_fbconfig) {
+    gx11->glxctx = glXCreateNewContext(gx11->display, gx11->fbconfig,
+                                       GLX_RGBA_TYPE, NULL, True);
+  } else {
+    gx11->glxctx = glXCreateContext(gx11->display, gx11->xvi, NULL, 1);
+  }
 
   if(gx11->glxctx == NULL) {
     TRACE(TRACE_ERROR, "GLW", "Unable to create GLX context on \"%s\"\n",
@@ -305,8 +336,19 @@ window_open(glw_x11_t *gx11, int fullscreen)
     return 1;
   }
 
+  int current_ok;
+  if(gx11->use_fbconfig) {
+    current_ok = glXMakeContextCurrent(gx11->display, gx11->win, gx11->win,
+                                       gx11->glxctx);
+  } else {
+    current_ok = glXMakeCurrent(gx11->display, gx11->win, gx11->glxctx);
+  }
 
-  glXMakeCurrent(gx11->display, gx11->win, gx11->glxctx);
+  if(!current_ok) {
+    TRACE(TRACE_ERROR, "GLW", "Unable to make GLX context current on \"%s\"\n",
+          gx11->displayname_real);
+    return 1;
+  }
 
   XMapWindow(gx11->display, gx11->win);
 
@@ -328,8 +370,17 @@ window_open(glw_x11_t *gx11, int fullscreen)
 
   glw_opengl_init_context(&gx11->gr);
 
-  if(gx11->glXSwapIntervalSGI != NULL)
+  const char *renderer = (const char *)glGetString(GL_RENDERER);
+  int skip_swap_interval =
+    running_under_wsl() ||
+    (renderer != NULL && strstr(renderer, "D3D12") != NULL);
+
+  if(gx11->glXSwapIntervalSGI != NULL && !skip_swap_interval) {
     gx11->glXSwapIntervalSGI(1);
+  } else if(gx11->glXSwapIntervalSGI != NULL) {
+    TRACE(TRACE_INFO, "GLW",
+          "Skipping GLX_SGI_swap_control under WSL");
+  }
 
   gx11->working_vsync = check_vsync(gx11);
 
@@ -573,8 +624,10 @@ vdpau_preempted(void *aux)
 static int
 glw_x11_init(glw_x11_t *gx11)
 {
-  int attribs[10];
+  int attribs[16];
   int na = 0;
+  int glx_major = 0;
+  int glx_minor = 0;
 
   int use_locales = XSupportsLocale() && XSetLocaleModifiers("@im=none") != NULL;
 
@@ -591,23 +644,65 @@ glw_x11_init(glw_x11_t *gx11)
     return 1;
   }
 
+  if(!glXQueryVersion(gx11->display, &glx_major, &glx_minor)) {
+    TRACE(TRACE_ERROR, "GLW", "Unable to query GLX version on \"%s\"\n",
+          gx11->displayname_real);
+    return 1;
+  }
 
   gx11->screen        = DefaultScreen(gx11->display);
   gx11->screen_width  = DisplayWidth(gx11->display, gx11->screen);
   gx11->screen_height = DisplayHeight(gx11->display, gx11->screen);
   gx11->root          = RootWindow(gx11->display, gx11->screen);
 
-  attribs[na++] = GLX_RGBA;
-  attribs[na++] = GLX_RED_SIZE;
-  attribs[na++] = 1;
-  attribs[na++] = GLX_GREEN_SIZE;
-  attribs[na++] = 1;
-  attribs[na++] = GLX_BLUE_SIZE;
-  attribs[na++] = 1;
-  attribs[na++] = GLX_DOUBLEBUFFER;
-  attribs[na++] = None;
+  if(glx_major > 1 || (glx_major == 1 && glx_minor >= 3)) {
+    attribs[na++] = GLX_X_RENDERABLE;
+    attribs[na++] = True;
+    attribs[na++] = GLX_DRAWABLE_TYPE;
+    attribs[na++] = GLX_WINDOW_BIT;
+    attribs[na++] = GLX_RENDER_TYPE;
+    attribs[na++] = GLX_RGBA_BIT;
+    attribs[na++] = GLX_RED_SIZE;
+    attribs[na++] = 8;
+    attribs[na++] = GLX_GREEN_SIZE;
+    attribs[na++] = 8;
+    attribs[na++] = GLX_BLUE_SIZE;
+    attribs[na++] = 8;
+    attribs[na++] = GLX_DOUBLEBUFFER;
+    attribs[na++] = True;
+    attribs[na++] = None;
 
-  gx11->xvi = glXChooseVisual(gx11->display, gx11->screen, attribs);
+    int num_fbc = 0;
+    GLXFBConfig *fbconfigs =
+      glXChooseFBConfig(gx11->display, gx11->screen, attribs, &num_fbc);
+
+    if(fbconfigs != NULL && num_fbc > 0) {
+      gx11->fbconfig = fbconfigs[0];
+      gx11->xvi = glXGetVisualFromFBConfig(gx11->display, gx11->fbconfig);
+      XFree(fbconfigs);
+      if(gx11->xvi != NULL) {
+        gx11->use_fbconfig = 1;
+        TRACE(TRACE_DEBUG, "GLW", "Using GLX FBConfig visual");
+      }
+    }
+  }
+
+  if(gx11->xvi == NULL) {
+    TRACE(TRACE_INFO, "GLW",
+          "Unable to get GLX FBConfig visual, trying legacy GLX visual");
+
+    na = 0;
+    attribs[na++] = GLX_RGBA;
+    attribs[na++] = GLX_RED_SIZE;
+    attribs[na++] = 1;
+    attribs[na++] = GLX_GREEN_SIZE;
+    attribs[na++] = 1;
+    attribs[na++] = GLX_BLUE_SIZE;
+    attribs[na++] = 1;
+    attribs[na++] = GLX_DOUBLEBUFFER;
+    attribs[na++] = None;
+    gx11->xvi = glXChooseVisual(gx11->display, gx11->screen, attribs);
+  }
 
   if(gx11->xvi == NULL) {
     TRACE(TRACE_ERROR, "GLW", "Unable to find an adequate Visual on \"%s\"\n",


### PR DESCRIPTION
## Summary
- add a minimal WSL2 GLX runtime fix needed for local smoke testing on WSL Ubuntu
- add `/api/screenshot/raw` plus `/api/screenshot?raw=1` for direct PNG screenshot capture
- preserve the existing `/api/screenshot` imgur upload behavior

## Validation
- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- smoke checked `/api/screenshot/raw` returns `image/png`

## Historical Note
This was an intermediate stacked review branch. The final default-branch landing for these changes is PR #6.