### PR TITLE
Add WebP image support

### DIFF
--- a/src/api/httpcontrol.c
+++ b/src/api/httpcontrol.c
@@ -206,6 +206,9 @@ hc_image(http_connection_t *hc, const char *remain, void *opaque,
   case IMAGE_BMP:
     content = "image/bmp";
     break;
+  case IMAGE_WEBP:
+    content = "image/webp";
+    break;
   default:
     content = "image";
     break;

--- a/src/fileaccess/fa_imageloader.c
+++ b/src/fileaccess/fa_imageloader.c
@@ -46,6 +46,8 @@
 static const uint8_t pngsig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 static const uint8_t gif89sig[6] = {'G', 'I', 'F', '8', '9', 'a'};
 static const uint8_t gif87sig[6] = {'G', 'I', 'F', '8', '7', 'a'};
+static const uint8_t webpsig1[4] = {'R', 'I', 'F', 'F'};
+static const uint8_t webpsig2[4] = {'W', 'E', 'B', 'P'};
 
 static const uint8_t svgsig1[5] = {'<', '?', 'x', 'm', 'l'};
 static const uint8_t svgsig2[4] = {'<', 's', 'v', 'g'};
@@ -117,6 +119,9 @@ fa_imageloader_buf(buf_t *buf, char *errbuf, size_t errlen)
     fmt = IMAGE_GIF;
   } else if(p[0] == 'B' && p[1] == 'M') {
     fmt = IMAGE_BMP;
+  } else if(!memcmp(webpsig1, p, sizeof(webpsig1)) &&
+	    !memcmp(webpsig2, p + 8, sizeof(webpsig2))) {
+    fmt = IMAGE_WEBP;
   } else if(!memcmp(svgsig1, p, sizeof(svgsig1)) ||
 	    !memcmp(svgsig2, p, sizeof(svgsig2))) {
     fmt = IMAGE_SVG;
@@ -278,6 +283,9 @@ fa_imageloader(const char *url, const struct image_meta *im,
     fmt = IMAGE_GIF;
   } else if(p[0] == 'B' && p[1] == 'M') {
     fmt = IMAGE_BMP;
+  } else if(!memcmp(webpsig1, p, sizeof(webpsig1)) &&
+	    !memcmp(webpsig2, p + 8, sizeof(webpsig2))) {
+    fmt = IMAGE_WEBP;
   } else if(!memcmp(svgsig1, p, sizeof(svgsig1)) ||
 	    !memcmp(svgsig2, p, sizeof(svgsig2))) {
     fmt = IMAGE_SVG;

--- a/src/fileaccess/fa_probe.c
+++ b/src/fileaccess/fa_probe.c
@@ -88,6 +88,8 @@ codecname(enum AVCodecID id)
 static const uint8_t pngsig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 static const uint8_t isosig[8] = {0x1, 0x43, 0x44, 0x30, 0x30, 0x31, 0x1, 0x0};
 static const uint8_t gifsig[6] = {'G', 'I', 'F', '8', '9', 'a'};
+static const uint8_t webpsig1[4] = {'R', 'I', 'F', 'F'};
+static const uint8_t webpsig2[4] = {'W', 'E', 'B', 'P'};
 static const uint8_t ttfsig[5] = {0,1,0,0,0};
 static const uint8_t otfsig[4] = {'O', 'T', 'T', 'O'};
 static const uint8_t pdfsig[] = {'%', 'P', 'D', 'F', '-'};
@@ -310,6 +312,13 @@ fa_probe_header(metadata_t *md, const char *url, fa_handle_t *fh,
 
   if(!memcmp(buf, pngsig, 8)) {
     /* PNG */
+    md->md_contenttype = CONTENT_IMAGE;
+    return 1;
+  }
+
+  if(l > 12 && !memcmp(buf, webpsig1, sizeof(webpsig1)) &&
+     !memcmp(buf + 8, webpsig2, sizeof(webpsig2))) {
+    /* WebP */
     md->md_contenttype = CONTENT_IMAGE;
     return 1;
   }

--- a/src/image/image.h
+++ b/src/image/image.h
@@ -80,6 +80,7 @@ typedef enum image_coded_type {
   IMAGE_GIF = 3,
   IMAGE_SVG = 4,
   IMAGE_BMP = 5,
+  IMAGE_WEBP = 6,
 } image_coded_type_t;
 
 

--- a/src/image/image_decoder_libav.c
+++ b/src/image/image_decoder_libav.c
@@ -424,6 +424,9 @@ image_decode_libav(image_coded_type_t type,
   case IMAGE_BMP:
     codec = avcodec_find_decoder(AV_CODEC_ID_BMP);
     break;
+  case IMAGE_WEBP:
+    codec = avcodec_find_decoder(AV_CODEC_ID_WEBP);
+    break;
   default:
     codec = NULL;
     break;


### PR DESCRIPTION
## Summary
- recognize WebP images in the file probe path and image loader
- route WebP through the libav decoder path
- return `image/webp` from `/api/image` for WebP resources

## Validation
- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- smoke checked direct WebP URL loading
- smoke checked `/api/image` returns WebP bytes with `image/webp`
- smoke checked direct WebP navigation reaches `model/type=image`

## Historical Note
This was an intermediate stacked review branch. The final default-branch landing for these changes is PR #6.