### PR TITLE
Land public Movian updates onto movian6

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,107 +1,164 @@
-Movian mediaplayer
-==================
+# Movian Public Fork
 
-(c) 2006 - 2018 Lonelycoder AB
+Movian is a media player for plugins, streams, and local files. This repository
+is a clean public fork based on `andoma/movian:movian6`.
 
-[![Build status](https://doozer.io/badge/andoma/movian/buildstatus/master)](https://doozer.io/user/andoma/movian)
+The goal of this fork is to keep changes small, reviewable, and based on public
+upstream source. Changes are developed as a stacked set of branches on top of
+the upstream `movian6` branch.
 
-For more information and latest versions, please visit:
+## Current Branch Stack
 
-[https://movian.tv/](https://movian.tv/)
+- `movian6` - clean upstream baseline from `andoma/movian:movian6`.
+- `public/gcc-modernize` - modern GCC and Ubuntu build fixes.
+- `public/linux-build-cleanup` - reproducible Linux debug configure helper and
+  build notes.
+- `public/screenshot-api` - raw screenshot HTTP API plus WSL2 GLX runtime
+  compatibility.
+- `public/webp-image-support` - WebP probing, loading, decoding, and
+  `/api/image` content type support.
+- `public/flatpak-steamos` - local SteamOS/Steam Deck Flatpak packaging and
+  small Linux runtime fixes used by that package.
 
-## How to build for Linux
+## Linux Debug Build
 
-First you need to satisfy some dependencies (for Ubuntu 16.04.3 LTS)
+Install the usual build tools and development headers. Package names vary by
+distribution; on Ubuntu the useful starting point is:
 
-	sudo apt-get install libfreetype6-dev libfontconfig1-dev libxext-dev libgl1-mesa-dev libasound2-dev libgtk2.0-dev libxss-dev libxxf86vm-dev libxv-dev libvdpau-dev yasm libpulse-dev libssl-dev curl libwebkitgtk-dev libsqlite3-dev libavahi-client-dev
+```sh
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  pkg-config \
+  git \
+  curl \
+  yasm \
+  python-is-python3 \
+  libsqlite3-dev \
+  libfreetype6-dev \
+  libfontconfig1-dev \
+  libx11-dev \
+  libxext-dev \
+  libgl1-mesa-dev \
+  libpulse-dev \
+  libssl-dev \
+  libavahi-client-dev \
+  libxss-dev \
+  libxxf86vm-dev
+```
 
-Then you need to configure:
+Configure and build:
 
-	./configure
-
-On newer Ubuntu releases, including WSL environments where VDPAU headers are
-not installed and the system OpenSSL is too new for bundled librtmp, use the
-built-in PolarSSL and disable VDPAU:
-
-	sudo apt-get install build-essential pkg-config git curl yasm python-is-python3 libfreetype6-dev libfontconfig1-dev libxext-dev libgl1-mesa-dev libasound2-dev libgtk2.0-dev libxss-dev libxxf86vm-dev libxv-dev libpulse-dev libssl-dev libsqlite3-dev libavahi-client-dev libwebkitgtk-dev
-	./support/configure-linux-debug.sh
-	make BUILD=debug -j$(nproc)
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
 
 The helper runs:
 
-	./configure.linux --build=debug --disable-vdpau --enable-polarssl
+```sh
+./configure.linux --build=debug --disable-vdpau --enable-polarssl
+```
 
-The debug binary is written to `./build.debug/movian`. Extra configure
-options can be appended to the helper command; for example, use
-`./support/configure-linux-debug.sh --disable-webkit` if WebKitGTK is not
-available on your distribution.
+Extra configure flags can be appended. For example, if your distribution no
+longer packages legacy WebKitGTK development headers:
 
-If your system lacks libwebkitgtk or some other lib you can configure like this:
+```sh
+./support/configure-linux-debug.sh --disable-webkit
+```
 
-	./configure --disable-webkit
+The debug binary is written to:
 
-If any dependencies are missing the configure script will complain.
-You then have the option to disable that particular module/subsystem.
+```text
+build.debug/movian
+```
 
-	make
+Movian stores legacy settings under:
 
-Build the binary, after build the binary resides in `./build.linux/`.
-Thus, to start it, just type:
+```text
+~/.hts/showtime
+```
 
-	./build.linux/movian
+## Runtime Features In This Stack
 
-Settings are stored in `~/.hts/showtime`
+- WSL2 GLX handling is detected at runtime; there is no WSL configure option.
+- `/api/screenshot/raw` returns a PNG directly.
+- `/api/screenshot?raw=1` and `/api/screenshot?raw=true` use the same raw PNG
+  path.
+- Existing `/api/screenshot` upload behavior is preserved.
+- WebP images are recognized by RIFF/WEBP magic, decoded through libav, and
+  served from `/api/image` as `image/webp`.
+- Steam launches avoid the X11 fullscreen path that can bounce back to the
+  Steam loading screen.
 
-If you want to build with extra debugging options for development these options might be of interest:
+## Flatpak / SteamOS
 
-	--cc=gcc-5 --extra-cflags=-fno-omit-frame-pointer --optlevel=g --sanitize=address --enable-bughunt
+The Flatpak work is a local sideload package for SteamOS and Desktop Linux
+testing. It is not a Flathub-ready manifest.
 
+Build from the repository root:
 
-## How to build for Mac OS X
+```sh
+support/flatpak/build-local.sh
+```
 
-To build for Mac OS X you need Xcode and yasm. Xcode should be installed from Mac Appstore.
+The bundle is written to:
 
-To install yasm, install [Brew](http://brew.sh/) and then
+```text
+build.flatpak/dev.uzver.Movian.flatpak
+```
 
-	$ brew install yasm
+Install and run:
 
-Now run configure
+```sh
+flatpak install --user --reinstall --bundle \
+  build.flatpak/dev.uzver.Movian.flatpak
 
-	$ ./configure
+flatpak run --user dev.uzver.Movian
+flatpak run --user --command=showtime dev.uzver.Movian --help
+flatpak info --user dev.uzver.Movian
+```
 
-Or if you build for release
+The package installs the bundled Movian binary as `/app/bin/showtime`, persists
+legacy state with `--persist=.hts` and `--persist=.cache/movian`, generates
+AppStream metadata from the current git version, and installs the PNG icon from
+`res/showtime/showtime.png`.
 
-	$ ./configure --release
+More details:
 
-If configured successfully run:
+- `docs/README.md`
+- `docs/Guides/FLATPAK_STEAMOS_GUIDE.md`
+- `support/flatpak/README.md`
 
-	$ make
+## Project Scope
 
-Run Movian binary from build directory
+This fork is developed from public upstream source. New behavior should be
+implemented as small patches on top of that public base.
 
-	$ build.osx/Movian.app/Contents/MacOS/movian
+Out of scope for the current stack:
 
-Note that in this case Movian loads all resources from current directory
-so this binary can't be run elsewhere.
+- Flathub-ready pinned source archives and hashes.
+- VAAPI or other hardware decode paths.
+- Native `/dev/input/event*` controller input in the Flatpak sandbox.
+- DVD and RTMP support in the Flatpak profile.
+- Broad filesystem access beyond common read-only XDG media folders.
 
-If you want a build that can be run as a normal Mac Application you shold do
+## Upstream
 
-	$ make dist
+Original project:
 
-This will generate a DMG
+```text
+https://github.com/andoma/movian
+```
 
-## How to build for PS3 with PSL1GHT
+Upstream branch used here:
 
-$ ./Autobuild.sh -t ps3 -v 5.0.500
+```text
+https://github.com/andoma/movian/tree/movian6
+```
 
-## How to build for Raspberry Pi
+## License
 
-First you need to satisfy some dependencies (for Ubuntu 16.04.3 LTS 64bit):
-
-	sudo apt-get install git-core build-essential autoconf bison flex libelf-dev libtool pkg-config texinfo libncurses5-dev libz-dev python-dev libssl-dev libgmp3-dev ccache zip squashfs-tools
-
-$ ./Autobuild.sh -t rpi -v 5.0.500
-
-To update Movian on rpi with compiled one, enable Binreplace in settings:dev and issue:
-
-	curl --data-binary @build.rpi/showtime.sqfs http://rpi_ip_address:42000/api/replace
+Movian is distributed under the GNU General Public License version 3 or later.
+See `LICENSE` for the full license text.

--- a/README.markdown
+++ b/README.markdown
@@ -13,11 +13,28 @@ For more information and latest versions, please visit:
 
 First you need to satisfy some dependencies (for Ubuntu 16.04.3 LTS)
 
-	sudo apt-get install libfreetype6-dev libfontconfig1-dev libxext-dev libgl1-mesa-dev libasound2-dev libasound2-dev libgtk2.0-dev libxss-dev libxxf86vm-dev libxv-dev libvdpau-dev yasm libpulse-dev libssl-dev curl libwebkitgtk-dev libsqlite3-dev libavahi-client-dev
+	sudo apt-get install libfreetype6-dev libfontconfig1-dev libxext-dev libgl1-mesa-dev libasound2-dev libgtk2.0-dev libxss-dev libxxf86vm-dev libxv-dev libvdpau-dev yasm libpulse-dev libssl-dev curl libwebkitgtk-dev libsqlite3-dev libavahi-client-dev
 
 Then you need to configure:
 
 	./configure
+
+On newer Ubuntu releases, including WSL environments where VDPAU headers are
+not installed and the system OpenSSL is too new for bundled librtmp, use the
+built-in PolarSSL and disable VDPAU:
+
+	sudo apt-get install build-essential pkg-config git curl yasm python-is-python3 libfreetype6-dev libfontconfig1-dev libxext-dev libgl1-mesa-dev libasound2-dev libgtk2.0-dev libxss-dev libxxf86vm-dev libxv-dev libpulse-dev libssl-dev libsqlite3-dev libavahi-client-dev libwebkitgtk-dev
+	./support/configure-linux-debug.sh
+	make BUILD=debug -j$(nproc)
+
+The helper runs:
+
+	./configure.linux --build=debug --disable-vdpau --enable-polarssl
+
+The debug binary is written to `./build.debug/movian`. Extra configure
+options can be appended to the helper command; for example, use
+`./support/configure-linux-debug.sh --disable-webkit` if WebKitGTK is not
+available on your distribution.
 
 If your system lacks libwebkitgtk or some other lib you can configure like this:
 
@@ -88,4 +105,3 @@ $ ./Autobuild.sh -t rpi -v 5.0.500
 To update Movian on rpi with compiled one, enable Binreplace in settings:dev and issue:
 
 	curl --data-binary @build.rpi/showtime.sqfs http://rpi_ip_address:42000/api/replace
-

--- a/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
+++ b/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
@@ -1,0 +1,200 @@
+# SteamOS Flatpak Guide
+
+This guide covers the local Movian Flatpak used for SteamOS and Steam Deck
+smoke testing. It is a sideload package built from this checkout, not a
+Flathub-ready manifest.
+
+## Files
+
+- Manifest: `support/flatpak/dev.uzver.Movian.yml`
+- Desktop entry: `support/flatpak/dev.uzver.Movian.desktop`
+- Fullscreen desktop entry: `support/flatpak/dev.uzver.Movian.GameMode.desktop`
+- AppStream template: `support/flatpak/dev.uzver.Movian.metainfo.xml.in`
+- Build wrapper: `support/flatpak/build-local.sh`
+- Optional diagnostic launcher: `support/flatpak/steam-deck-gamemode-launcher.sh`
+- Icon source: `res/showtime/showtime.png`
+
+## Build Profile
+
+The Flatpak profile builds the GLW/X11/OpenGL frontend and disables older or
+deferred subsystems:
+
+```sh
+--disable-gu
+--disable-webkit
+--disable-dvd
+--disable-vdpau
+--disable-avahi
+--disable-libxss
+--disable-libxxf86vm
+--disable-librtmp
+```
+
+The manifest also sets:
+
+```text
+SKIP_SUBMODULE_UPDATE=1
+LIBAV_COMMON_FLAGS=--disable-inline-asm --disable-hwaccels
+LIBAV_CFLAGS=-Wno-error=incompatible-pointer-types
+```
+
+`SKIP_SUBMODULE_UPDATE=1` keeps Flatpak builds from reaching out to git during
+packaging, so the submodules must already be populated in the checkout.
+
+The build installs `build.flatpak/movian.bundle` as `/app/bin/showtime`.
+AppStream metadata is generated during the build from `git describe`, which
+keeps Discover's version aligned with Movian's About/log output.
+The app icon is installed from `res/showtime/showtime.png` as a hicolor
+`256x256` PNG under the Flatpak app id.
+
+## Sandbox
+
+The manifest keeps permissions narrow:
+
+```text
+shared=network;ipc;
+sockets=x11;wayland;pulseaudio;
+devices=dri;
+filesystems=xdg-download:ro;xdg-pictures:ro;xdg-videos:ro;xdg-music:ro;
+persistent=.hts;.cache/movian;
+```
+
+The persisted directories preserve Movian's legacy settings, plugin state, and
+image cache inside the Flatpak app home.
+
+## Host Setup
+
+On Ubuntu or WSL Ubuntu:
+
+```sh
+sudo apt update
+sudo apt install -y \
+  flatpak \
+  flatpak-builder \
+  desktop-file-utils \
+  appstream \
+  dbus-user-session
+```
+
+Add Flathub and install the runtime:
+
+```sh
+flatpak remote-add --user --if-not-exists flathub \
+  https://dl.flathub.org/repo/flathub.flatpakrepo
+
+flatpak install --user -y flathub \
+  org.freedesktop.Platform//25.08 \
+  org.freedesktop.Sdk//25.08
+```
+
+## Build
+
+From the repository root:
+
+```sh
+support/flatpak/build-local.sh
+```
+
+Expected artifact:
+
+```text
+build.flatpak/dev.uzver.Movian.flatpak
+```
+
+Useful local checks after a build:
+
+```sh
+flatpak build build.flatpak-builder /app/bin/showtime --help
+appstreamcli validate --no-net \
+  build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml
+flatpak build build.flatpak-builder ldd /app/bin/showtime | \
+  grep -Ei 'gtk|gdk|webkit|rtmp|dvd|vaapi|vdpau|libva|nvidia' || true
+sha256sum build.flatpak/dev.uzver.Movian.flatpak
+```
+
+The dependency grep should print nothing for the current MVP profile.
+
+## Install And Run
+
+Install the generated bundle:
+
+```sh
+flatpak install --user --reinstall --bundle \
+  build.flatpak/dev.uzver.Movian.flatpak
+```
+
+Run from CLI:
+
+```sh
+flatpak run --user dev.uzver.Movian
+flatpak run --user --command=showtime dev.uzver.Movian --help
+flatpak info --user dev.uzver.Movian
+flatpak info --user --show-permissions dev.uzver.Movian
+```
+
+`flatpak info` should show the same version that Movian prints in About/log.
+
+## Steam Deck Smoke
+
+Build on Ubuntu/WSL/VM, copy the bundle to the Deck, then install it in Desktop
+Mode through Discover or CLI:
+
+```sh
+flatpak install --user --reinstall --bundle \
+  ~/Downloads/dev.uzver.Movian.flatpak
+```
+
+Minimum smoke checklist:
+
+- Discover shows the same version as `flatpak info` and Movian About/log.
+- Desktop Mode launch opens the GLW UI.
+- Gaming Mode launch opens through `Movian (GameMode)` or a Non-Steam Game.
+- Fullscreen does not loop or bounce back to the Steam loading screen.
+- Basic navigation works through a Steam Input keyboard-style layout.
+- Installed plugins and settings survive a restart.
+- A direct WebP URL opens as an image.
+- `/api/screenshot/raw` returns a PNG when the HTTP API is enabled.
+
+## Steam Input
+
+Movian's Linux GLW UI consumes keyboard and pointer events. For Steam Deck
+Gaming Mode, map the controller to keyboard actions:
+
+```text
+D-pad / Left Stick: Arrow Up / Down / Left / Right
+A: Enter
+B: Escape
+X: Backspace
+Y or Menu: Menu key
+L1 / R1: Page Up / Page Down
+```
+
+If arrows and Enter move focus inside Movian, input is reaching the app. Native
+raw controller input is out of scope for this Flatpak branch.
+
+## Diagnostic Launcher
+
+If Gaming Mode does not show a window, copy
+`support/flatpak/steam-deck-gamemode-launcher.sh` to the Deck and add it as a
+Non-Steam Game. It runs:
+
+```sh
+flatpak run dev.uzver.Movian --fullscreen -d
+```
+
+and writes environment and launch diagnostics to:
+
+```text
+~/movian-gamemode.log
+```
+
+## Known Limits
+
+- The manifest uses local `type: dir` sources; Flathub needs pinned source
+  archives and hashes.
+- Hardware acceleration is disabled for this first package profile.
+- DVD, RTMP, GU/WebKit, Avahi, VDPAU, libXss, and libXxf86vm are disabled.
+- The sandbox exposes common XDG media folders read-only, not every removable
+  media path.
+- Native `/dev/input/event*` controller access is not requested; use Steam
+  Input keyboard mapping.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,81 @@
+# Movian Public Branch Notes
+
+This directory documents the public branch stack in this checkout. The notes
+are based on code, scripts, and packaging files present in this repository.
+
+## Branch Stack
+
+The current public work is organized as small reviewable branches:
+
+- `public/gcc-modernize` - modern GCC and Ubuntu build fixes only.
+- `public/linux-build-cleanup` - reproducible Linux debug configure helper and
+  README build notes.
+- `public/screenshot-api` - raw screenshot HTTP API on top of the existing
+  screenshot code.
+- `public/webp-image-support` - WebP probing, image loading, libav decode
+  mapping, and `/api/image` WebP content type.
+- `public/flatpak-steamos` - local SteamOS/Steam Deck Flatpak packaging and
+  small Linux runtime fixes needed by that package.
+
+Each branch is intended to stay narrow and easy to review.
+
+## Linux Build
+
+For current Ubuntu or WSL environments, use the helper added by the build
+cleanup branch:
+
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
+
+The helper runs:
+
+```sh
+./configure.linux --build=debug --disable-vdpau --enable-polarssl
+```
+
+Extra configure flags can be appended to the helper command.
+
+## Runtime Changes
+
+The public stack currently includes these user-visible changes:
+
+- WSL2 GLX handling is detected at runtime in `src/ui/glw/glw_x11.c`; there is
+  no WSL configure flag.
+- `/api/screenshot/raw` returns a PNG directly. `/api/screenshot?raw=1` and
+  `/api/screenshot?raw=true` use the same path. The old `/api/screenshot`
+  upload flow remains.
+- WebP files are recognized by RIFF/WEBP magic in file probing and image
+  loading. The libav image decoder maps WebP, and `/api/image` returns
+  `image/webp` for WebP payloads.
+- Steam launches avoid the X11 fullscreen `override_redirect` path when
+  `SteamGameId` or `SteamAppId` is set. `XK_Menu` maps to Movian's menu action
+  for Steam Input keyboard layouts.
+
+## Flatpak / SteamOS
+
+The Flatpak work is a local sideload package, not a Flathub recipe. The main
+guide is:
+
+- `Guides/FLATPAK_STEAMOS_GUIDE.md`
+
+The source-of-truth packaging files live under:
+
+- `support/flatpak/`
+
+The package installs the bundled Movian binary as `/app/bin/showtime`, keeps
+state through `--persist=.hts` and `--persist=.cache/movian`, and generates
+AppStream metadata from the current `git describe` version so Discover matches
+Movian's About/log output.
+
+## Out Of Scope
+
+These are intentionally left for later branches:
+
+- Flathub-ready pinned source archives and hashes.
+- VAAPI or other hardware decode paths.
+- Native `/dev/input/event*` controller input in the Flatpak sandbox.
+- DVD and RTMP support in the Flatpak profile.
+- Broader filesystem permissions such as removable media paths.

--- a/src/api/httpcontrol.c
+++ b/src/api/httpcontrol.c
@@ -206,6 +206,9 @@ hc_image(http_connection_t *hc, const char *remain, void *opaque,
   case IMAGE_BMP:
     content = "image/bmp";
     break;
+  case IMAGE_WEBP:
+    content = "image/webp";
+    break;
   default:
     content = "image";
     break;

--- a/src/api/screenshot.c
+++ b/src/api/screenshot.c
@@ -34,7 +34,103 @@
 #include <libswscale/swscale.h>
 
 static hts_mutex_t screenshot_mutex;
+static hts_cond_t screenshot_cond;
 static http_connection_t *screenshot_connection;
+static int screenshot_raw_waiting;
+static int screenshot_raw_done;
+static buf_t *screenshot_raw_image;
+static char *screenshot_raw_error;
+
+
+/**
+ *
+ */
+static void
+screenshot_raw_complete(buf_t *image, const char *errmsg)
+{
+  hts_mutex_lock(&screenshot_mutex);
+  if(screenshot_raw_waiting) {
+    if(screenshot_raw_image != NULL)
+      buf_release(screenshot_raw_image);
+    free(screenshot_raw_error);
+    screenshot_raw_image = image;
+    screenshot_raw_error = errmsg ? strdup(errmsg) : NULL;
+    screenshot_raw_done = 1;
+    hts_cond_signal(&screenshot_cond);
+  } else if(image != NULL) {
+    buf_release(image);
+  }
+  hts_mutex_unlock(&screenshot_mutex);
+}
+
+
+/**
+ *
+ */
+static int
+hc_screenshot_raw(http_connection_t *hc)
+{
+  hts_mutex_lock(&screenshot_mutex);
+  if(screenshot_raw_waiting || screenshot_connection != NULL) {
+    hts_mutex_unlock(&screenshot_mutex);
+    return 502;
+  }
+  screenshot_raw_waiting = 1;
+  screenshot_raw_done = 0;
+  if(screenshot_raw_image != NULL) {
+    buf_release(screenshot_raw_image);
+    screenshot_raw_image = NULL;
+  }
+  free(screenshot_raw_error);
+  screenshot_raw_error = NULL;
+  hts_mutex_unlock(&screenshot_mutex);
+
+  event_to_ui(event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t)));
+
+  hts_mutex_lock(&screenshot_mutex);
+  int timedout = 0;
+  while(!screenshot_raw_done) {
+    if(hts_cond_wait_timeout(&screenshot_cond, &screenshot_mutex, 5000)) {
+      timedout = 1;
+      break;
+    }
+  }
+
+  buf_t *image = screenshot_raw_image;
+  screenshot_raw_image = NULL;
+  char *error = screenshot_raw_error;
+  screenshot_raw_error = NULL;
+  screenshot_raw_waiting = 0;
+  screenshot_raw_done = 0;
+  hts_mutex_unlock(&screenshot_mutex);
+
+  if(timedout) {
+    if(image != NULL)
+      buf_release(image);
+    free(error);
+    return http_error(hc, 504, "Screenshot timed out");
+  }
+
+  if(image == NULL) {
+    int r = http_error(hc, 500, "%s",
+                       error != NULL ? error : "Screenshot capture failed");
+    free(error);
+    return r;
+  }
+
+  htsbuf_queue_t out;
+  htsbuf_queue_init(&out, 0);
+  htsbuf_append(&out, buf_data(image), buf_len(image));
+  struct http_header_list headers;
+  LIST_INIT(&headers);
+  http_header_add(&headers, "Content-Type", "image/png", 0);
+  http_header_add_int(&headers, "Content-Length", buf_len(image));
+  http_header_add(&headers, "Connection", "Close", 0);
+  int r = http_send_raw(hc, 200, "OK", &headers, &out);
+  buf_release(image);
+  free(error);
+  return r;
+}
 
 
 /**
@@ -44,8 +140,15 @@ static int
 hc_screenshot(http_connection_t *hc, const char *remain,
               void *opaque, http_cmd_t method)
 {
+  const char *raw = http_arg_get_req(hc, "raw");
+  int want_raw = (remain != NULL && !strcmp(remain, "raw")) ||
+                 (raw != NULL && (!strcmp(raw, "1") || !strcmp(raw, "true")));
+
+  if(want_raw)
+    return hc_screenshot_raw(hc);
+
   hts_mutex_lock(&screenshot_mutex);
-  if(screenshot_connection != NULL) {
+  if(screenshot_raw_waiting || screenshot_connection != NULL) {
     hts_mutex_unlock(&screenshot_mutex);
     return 502;
   }
@@ -142,6 +245,9 @@ screenshot_compress(pixmap_t *pm, int codecid)
   }
 
   AVFrame *oframe = av_frame_alloc();
+  oframe->format = ctx->pix_fmt;
+  oframe->width  = width;
+  oframe->height = height;
 
   avpicture_alloc((AVPicture *)oframe, ctx->pix_fmt, width, height);
 
@@ -192,6 +298,14 @@ screenshot_process(void *task)
   pixmap_t *pm = task;
 
   if(pm == NULL) {
+    hts_mutex_lock(&screenshot_mutex);
+    int raw_waiting = screenshot_raw_waiting;
+    hts_mutex_unlock(&screenshot_mutex);
+    if(raw_waiting) {
+      screenshot_raw_complete(NULL,
+                              "Screenshot not supported on this platform");
+      return;
+    }
     screenshot_response(NULL, "Screenshot not supported on this platform");
     return;
   }
@@ -199,18 +313,32 @@ screenshot_process(void *task)
   TRACE(TRACE_DEBUG, "Screenshot", "Processing image %d x %d",
         pm->pm_width, pm->pm_height);
 
+  hts_mutex_lock(&screenshot_mutex);
+  int has_connection = screenshot_connection != NULL;
+  int raw_waiting = screenshot_raw_waiting;
+  hts_mutex_unlock(&screenshot_mutex);
+
   int codecid = AV_CODEC_ID_PNG;
-  if(screenshot_connection)
+  if(has_connection && !raw_waiting)
     codecid = AV_CODEC_ID_MJPEG;
 
   buf_t *b = screenshot_compress(pm, codecid);
   pixmap_release(pm);
   if(b == NULL) {
+    if(raw_waiting) {
+      screenshot_raw_complete(NULL, "Unable to compress image");
+      return;
+    }
     screenshot_response(NULL, "Unable to compress image");
     return;
   }
 
-  if(!screenshot_connection) {
+  if(raw_waiting) {
+    screenshot_raw_complete(b, NULL);
+    return;
+  }
+
+  if(!has_connection) {
     char path[512];
     char errbuf[512];
     snprintf(path, sizeof(path), "%s/screenshot.png",
@@ -295,6 +423,7 @@ static void
 screenshot_init(void)
 {
   hts_mutex_init(&screenshot_mutex);
+  hts_cond_init(&screenshot_cond, &screenshot_mutex);
   http_path_add("/api/screenshot", NULL, hc_screenshot, 0);
 }
 

--- a/src/api/screenshot.c
+++ b/src/api/screenshot.c
@@ -85,7 +85,9 @@ hc_screenshot_raw(http_connection_t *hc)
   screenshot_raw_error = NULL;
   hts_mutex_unlock(&screenshot_mutex);
 
-  event_to_ui(event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t)));
+  event_t *e = event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t));
+  e->e_flags |= EVENT_SCREENSHOT_RAW;
+  event_to_ui(e);
 
   hts_mutex_lock(&screenshot_mutex);
   int timedout = 0;
@@ -155,7 +157,9 @@ hc_screenshot(http_connection_t *hc, const char *remain,
   screenshot_connection = hc;
   hts_mutex_unlock(&screenshot_mutex);
 
-  event_to_ui(event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t)));
+  event_t *e = event_create(EVENT_MAKE_SCREENSHOT, sizeof(event_t));
+  e->e_flags |= EVENT_SCREENSHOT_UPLOAD;
+  event_to_ui(e);
   return 0;
 }
 
@@ -289,24 +293,32 @@ screenshot_compress(pixmap_t *pm, int codecid)
 }
 
 
+typedef struct screenshot_task {
+  pixmap_t *pm;
+  int flags;
+} screenshot_task_t;
+
+
 /**
  *
  */
 static void
 screenshot_process(void *task)
 {
-  pixmap_t *pm = task;
+  screenshot_task_t *st = task;
+  pixmap_t *pm = st->pm;
+  int raw_request = st->flags & EVENT_SCREENSHOT_RAW;
+  int upload_request = st->flags & EVENT_SCREENSHOT_UPLOAD;
+  free(st);
 
   if(pm == NULL) {
-    hts_mutex_lock(&screenshot_mutex);
-    int raw_waiting = screenshot_raw_waiting;
-    hts_mutex_unlock(&screenshot_mutex);
-    if(raw_waiting) {
+    if(raw_request) {
       screenshot_raw_complete(NULL,
                               "Screenshot not supported on this platform");
       return;
     }
-    screenshot_response(NULL, "Screenshot not supported on this platform");
+    if(upload_request)
+      screenshot_response(NULL, "Screenshot not supported on this platform");
     return;
   }
 
@@ -318,27 +330,38 @@ screenshot_process(void *task)
   int raw_waiting = screenshot_raw_waiting;
   hts_mutex_unlock(&screenshot_mutex);
 
+  if(raw_request && !raw_waiting) {
+    pixmap_release(pm);
+    return;
+  }
+
+  if(upload_request && !has_connection) {
+    pixmap_release(pm);
+    return;
+  }
+
   int codecid = AV_CODEC_ID_PNG;
-  if(has_connection && !raw_waiting)
+  if(upload_request)
     codecid = AV_CODEC_ID_MJPEG;
 
   buf_t *b = screenshot_compress(pm, codecid);
   pixmap_release(pm);
   if(b == NULL) {
-    if(raw_waiting) {
+    if(raw_request) {
       screenshot_raw_complete(NULL, "Unable to compress image");
       return;
     }
-    screenshot_response(NULL, "Unable to compress image");
+    if(upload_request)
+      screenshot_response(NULL, "Unable to compress image");
     return;
   }
 
-  if(raw_waiting) {
+  if(raw_request) {
     screenshot_raw_complete(b, NULL);
     return;
   }
 
-  if(!has_connection) {
+  if(!upload_request) {
     char path[512];
     char errbuf[512];
     snprintf(path, sizeof(path), "%s/screenshot.png",
@@ -410,9 +433,12 @@ screenshot_process(void *task)
  *
  */
 void
-screenshot_deliver(pixmap_t *pm)
+screenshot_deliver(pixmap_t *pm, int flags)
 {
-  task_run(screenshot_process, pm ? pixmap_dup(pm) : NULL);
+  screenshot_task_t *st = malloc(sizeof(screenshot_task_t));
+  st->pm = pm ? pixmap_dup(pm) : NULL;
+  st->flags = flags;
+  task_run(screenshot_process, st);
 }
 
 

--- a/src/api/screenshot.h
+++ b/src/api/screenshot.h
@@ -1,4 +1,4 @@
 #pragma once
 
 struct pixmap;
-void screenshot_deliver(struct pixmap *pm);
+void screenshot_deliver(struct pixmap *pm, int flags);

--- a/src/arch/posix/posix.c
+++ b/src/arch/posix/posix.c
@@ -50,30 +50,52 @@ static char *
 linux_get_dist(void)
 {
   char buf[1024] = {0};
-  FILE *fp = popen("lsb_release -d", "r");
-  if(fp == NULL)
-    return NULL;
-
+  FILE *fp = popen("lsb_release -d 2>/dev/null", "r");
   char *ret = NULL;
-  while(1) {
-    int r = fread(buf, 1, sizeof(buf) - 1, fp);
-    if(r == 0)
-      break;
 
-    const char *s;
-    if((s = mystrbegins(buf, "Description:")) != NULL) {
-      while(*s && *s <= 32)
-        s++;
-
-      if(*s) {
-        ret = strdup(s);
-        ret[strcspn(ret, "\n\r")] = 0;
+  if(fp != NULL) {
+    while(1) {
+      int r = fread(buf, 1, sizeof(buf) - 1, fp);
+      if(r == 0)
         break;
+
+      const char *s;
+      if((s = mystrbegins(buf, "Description:")) != NULL) {
+        while(*s && *s <= 32)
+          s++;
+
+        if(*s) {
+          ret = strdup(s);
+          ret[strcspn(ret, "\n\r")] = 0;
+          break;
+        }
       }
     }
+
+    pclose(fp);
   }
 
-  pclose(fp);
+  if(ret == NULL && (fp = fopen("/etc/os-release", "r")) != NULL) {
+    while(fgets(buf, sizeof(buf), fp) != NULL) {
+      const char *s = mystrbegins(buf, "PRETTY_NAME=");
+      if(s == NULL)
+        continue;
+
+      if(*s == '"' || *s == '\'') {
+        const char quote = *s++;
+        ret = strdup(s);
+        char *e = strchr(ret, quote);
+        if(e != NULL)
+          *e = 0;
+      } else {
+        ret = strdup(s);
+        ret[strcspn(ret, "\n\r")] = 0;
+      }
+      break;
+    }
+    fclose(fp);
+  }
+
   return ret;
 }
 #endif

--- a/src/event.h
+++ b/src/event.h
@@ -195,6 +195,8 @@ typedef struct event {
 #define EVENT_KEYPRESS        0x1 // Came from user keypress
 #define EVENT_MOUSE           0x2 // Came from mouse input
 #define EVENT_SCREEN_POSITION 0x4 // e_screen_[xy] is valid
+#define EVENT_SCREENSHOT_UPLOAD 0x8 // Only valid for EVENT_MAKE_SCREENSHOT
+#define EVENT_SCREENSHOT_RAW 0x10 // Only valid for EVENT_MAKE_SCREENSHOT
   event_type_t e_type;
 } event_t;
 

--- a/src/fileaccess/fa_imageloader.c
+++ b/src/fileaccess/fa_imageloader.c
@@ -46,6 +46,8 @@
 static const uint8_t pngsig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 static const uint8_t gif89sig[6] = {'G', 'I', 'F', '8', '9', 'a'};
 static const uint8_t gif87sig[6] = {'G', 'I', 'F', '8', '7', 'a'};
+static const uint8_t webpsig1[4] = {'R', 'I', 'F', 'F'};
+static const uint8_t webpsig2[4] = {'W', 'E', 'B', 'P'};
 
 static const uint8_t svgsig1[5] = {'<', '?', 'x', 'm', 'l'};
 static const uint8_t svgsig2[4] = {'<', 's', 'v', 'g'};
@@ -117,6 +119,9 @@ fa_imageloader_buf(buf_t *buf, char *errbuf, size_t errlen)
     fmt = IMAGE_GIF;
   } else if(p[0] == 'B' && p[1] == 'M') {
     fmt = IMAGE_BMP;
+  } else if(!memcmp(webpsig1, p, sizeof(webpsig1)) &&
+	    !memcmp(webpsig2, p + 8, sizeof(webpsig2))) {
+    fmt = IMAGE_WEBP;
   } else if(!memcmp(svgsig1, p, sizeof(svgsig1)) ||
 	    !memcmp(svgsig2, p, sizeof(svgsig2))) {
     fmt = IMAGE_SVG;
@@ -278,6 +283,9 @@ fa_imageloader(const char *url, const struct image_meta *im,
     fmt = IMAGE_GIF;
   } else if(p[0] == 'B' && p[1] == 'M') {
     fmt = IMAGE_BMP;
+  } else if(!memcmp(webpsig1, p, sizeof(webpsig1)) &&
+	    !memcmp(webpsig2, p + 8, sizeof(webpsig2))) {
+    fmt = IMAGE_WEBP;
   } else if(!memcmp(svgsig1, p, sizeof(svgsig1)) ||
 	    !memcmp(svgsig2, p, sizeof(svgsig2))) {
     fmt = IMAGE_SVG;

--- a/src/fileaccess/fa_probe.c
+++ b/src/fileaccess/fa_probe.c
@@ -88,6 +88,8 @@ codecname(enum AVCodecID id)
 static const uint8_t pngsig[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 static const uint8_t isosig[8] = {0x1, 0x43, 0x44, 0x30, 0x30, 0x31, 0x1, 0x0};
 static const uint8_t gifsig[6] = {'G', 'I', 'F', '8', '9', 'a'};
+static const uint8_t webpsig1[4] = {'R', 'I', 'F', 'F'};
+static const uint8_t webpsig2[4] = {'W', 'E', 'B', 'P'};
 static const uint8_t ttfsig[5] = {0,1,0,0,0};
 static const uint8_t otfsig[4] = {'O', 'T', 'T', 'O'};
 static const uint8_t pdfsig[] = {'%', 'P', 'D', 'F', '-'};
@@ -310,6 +312,13 @@ fa_probe_header(metadata_t *md, const char *url, fa_handle_t *fh,
 
   if(!memcmp(buf, pngsig, 8)) {
     /* PNG */
+    md->md_contenttype = CONTENT_IMAGE;
+    return 1;
+  }
+
+  if(l > 12 && !memcmp(buf, webpsig1, sizeof(webpsig1)) &&
+     !memcmp(buf + 8, webpsig2, sizeof(webpsig2))) {
+    /* WebP */
     md->md_contenttype = CONTENT_IMAGE;
     return 1;
   }

--- a/src/image/image.h
+++ b/src/image/image.h
@@ -80,6 +80,7 @@ typedef enum image_coded_type {
   IMAGE_GIF = 3,
   IMAGE_SVG = 4,
   IMAGE_BMP = 5,
+  IMAGE_WEBP = 6,
 } image_coded_type_t;
 
 

--- a/src/image/image_decoder_libav.c
+++ b/src/image/image_decoder_libav.c
@@ -424,6 +424,9 @@ image_decode_libav(image_coded_type_t type,
   case IMAGE_BMP:
     codec = avcodec_find_decoder(AV_CODEC_ID_BMP);
     break;
+  case IMAGE_WEBP:
+    codec = avcodec_find_decoder(AV_CODEC_ID_WEBP);
+    break;
   default:
     codec = NULL;
     break;

--- a/src/networking/net_openssl.c
+++ b/src/networking/net_openssl.c
@@ -23,9 +23,12 @@
 #include "net_i.h"
 #include "net_openssl.h"
 
+#include <openssl/opensslv.h>
 #include <openssl/x509v3.h>
 
 static SSL_CTX *app_ssl_ctx;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static pthread_mutex_t *ssl_locks;
 
 static unsigned long
@@ -42,6 +45,7 @@ ssl_lock_fn(int mode, int n, const char *file, int line)
   else
     pthread_mutex_unlock(&ssl_locks[n]);
 }
+#endif
 
 
 
@@ -245,12 +249,14 @@ net_ssl_init(void)
 
   SSL_CTX_load_verify_locations(app_ssl_ctx, NULL, "/etc/ssl/certs");
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
   int i, n = CRYPTO_num_locks();
   ssl_locks = malloc(sizeof(pthread_mutex_t) * n);
   for(i = 0; i < n; i++)
     pthread_mutex_init(&ssl_locks[i], NULL);
   CRYPTO_set_locking_callback(ssl_lock_fn);
   CRYPTO_set_id_callback(ssl_tid_fn);
+#endif
 }
 
 

--- a/src/ui/glw/glw.c
+++ b/src/ui/glw/glw.c
@@ -2375,15 +2375,15 @@ glw_kill_screensaver(glw_root_t *gr)
  *
  */
 static void
-glw_screenshot(glw_root_t *gr)
+glw_screenshot(glw_root_t *gr, int flags)
 {
   if(gr->gr_br_read_pixels == NULL) {
-    screenshot_deliver(NULL);
+    screenshot_deliver(NULL, flags);
     return;
   }
 
   pixmap_t *pm = gr->gr_br_read_pixels(gr);
-  screenshot_deliver(pm);
+  screenshot_deliver(pm, flags);
   pixmap_release(pm);
 }
 
@@ -2434,7 +2434,8 @@ glw_dispatch_event(glw_root_t *gr, event_t *e)
   }
 
   if(e->e_type == EVENT_MAKE_SCREENSHOT) {
-    glw_screenshot(gr);
+    glw_screenshot(gr, e->e_flags & (EVENT_SCREENSHOT_UPLOAD |
+                                     EVENT_SCREENSHOT_RAW));
     return;
   }
 

--- a/src/ui/glw/glw_x11.c
+++ b/src/ui/glw/glw_x11.c
@@ -294,14 +294,17 @@ window_open(glw_x11_t *gx11, int fullscreen)
   mask = CWBackPixmap | CWBorderPixel | CWColormap | CWEventMask;
 
   if(fullscreen) {
+    int steam_game = getenv("SteamGameId") || getenv("SteamAppId");
 
     x = 0;
     y = 0;
     w = gx11->screen_width;
     h = gx11->screen_height;
 
-    winAttr.override_redirect = True;
-    mask |= CWOverrideRedirect;
+    if(!steam_game) {
+      winAttr.override_redirect = True;
+      mask |= CWOverrideRedirect;
+    }
 
   } else {
 
@@ -797,6 +800,7 @@ window_change_fullscreen(glw_x11_t *gx11)
     window_shutdown(gx11);
     if(window_open(gx11, gx11->want_fullscreen))
       exit(1);
+    gx11->is_fullscreen = gx11->want_fullscreen;
   }
   glw_set_fullscreen(&gx11->gr, gx11->is_fullscreen);
 }
@@ -844,6 +848,7 @@ static const struct {
 
   { XK_Home,         0,           ACTION_TOP},
   { XK_End,          0,           ACTION_BOTTOM},
+  { XK_Menu,         0,           ACTION_MENU},
 
   { XK_plus,         ControlMask, ACTION_ZOOM_UI_INCR},
   { XK_minus,        ControlMask, ACTION_ZOOM_UI_DECR},

--- a/src/ui/glw/glw_x11.c
+++ b/src/ui/glw/glw_x11.c
@@ -54,6 +54,30 @@
 
 #include "glw_rec.h"
 
+static int
+running_under_wsl(void)
+{
+  const char *interop = getenv("WSL_INTEROP");
+  const char *distro = getenv("WSL_DISTRO_NAME");
+
+  if((interop != NULL && interop[0] != 0) ||
+     (distro != NULL && distro[0] != 0))
+    return 1;
+
+  FILE *fp = fopen("/proc/sys/kernel/osrelease", "r");
+  if(fp == NULL)
+    return 0;
+
+  char buf[256];
+  char *r = fgets(buf, sizeof(buf), fp);
+  fclose(fp);
+
+  return r != NULL &&
+    (strstr(buf, "Microsoft") != NULL ||
+     strstr(buf, "microsoft") != NULL ||
+     strstr(buf, "WSL") != NULL);
+}
+
 typedef struct glw_x11 {
 
   glw_root_t gr;
@@ -67,6 +91,8 @@ typedef struct glw_x11 {
   int screen_height;
   int root;
   XVisualInfo *xvi;
+  GLXFBConfig fbconfig;
+  int use_fbconfig;
   Window win;
   GLXContext glxctx;
   Cursor blank_cursor;
@@ -297,7 +323,12 @@ window_open(glw_x11_t *gx11, int fullscreen)
   gx11->gr.gr_width  = w;
   gx11->gr.gr_height = h;
 
-  gx11->glxctx = glXCreateContext(gx11->display, gx11->xvi, NULL, 1);
+  if(gx11->use_fbconfig) {
+    gx11->glxctx = glXCreateNewContext(gx11->display, gx11->fbconfig,
+                                       GLX_RGBA_TYPE, NULL, True);
+  } else {
+    gx11->glxctx = glXCreateContext(gx11->display, gx11->xvi, NULL, 1);
+  }
 
   if(gx11->glxctx == NULL) {
     TRACE(TRACE_ERROR, "GLW", "Unable to create GLX context on \"%s\"\n",
@@ -305,8 +336,19 @@ window_open(glw_x11_t *gx11, int fullscreen)
     return 1;
   }
 
+  int current_ok;
+  if(gx11->use_fbconfig) {
+    current_ok = glXMakeContextCurrent(gx11->display, gx11->win, gx11->win,
+                                       gx11->glxctx);
+  } else {
+    current_ok = glXMakeCurrent(gx11->display, gx11->win, gx11->glxctx);
+  }
 
-  glXMakeCurrent(gx11->display, gx11->win, gx11->glxctx);
+  if(!current_ok) {
+    TRACE(TRACE_ERROR, "GLW", "Unable to make GLX context current on \"%s\"\n",
+          gx11->displayname_real);
+    return 1;
+  }
 
   XMapWindow(gx11->display, gx11->win);
 
@@ -328,8 +370,17 @@ window_open(glw_x11_t *gx11, int fullscreen)
 
   glw_opengl_init_context(&gx11->gr);
 
-  if(gx11->glXSwapIntervalSGI != NULL)
+  const char *renderer = (const char *)glGetString(GL_RENDERER);
+  int skip_swap_interval =
+    running_under_wsl() ||
+    (renderer != NULL && strstr(renderer, "D3D12") != NULL);
+
+  if(gx11->glXSwapIntervalSGI != NULL && !skip_swap_interval) {
     gx11->glXSwapIntervalSGI(1);
+  } else if(gx11->glXSwapIntervalSGI != NULL) {
+    TRACE(TRACE_INFO, "GLW",
+          "Skipping GLX_SGI_swap_control under WSL");
+  }
 
   gx11->working_vsync = check_vsync(gx11);
 
@@ -573,8 +624,10 @@ vdpau_preempted(void *aux)
 static int
 glw_x11_init(glw_x11_t *gx11)
 {
-  int attribs[10];
+  int attribs[16];
   int na = 0;
+  int glx_major = 0;
+  int glx_minor = 0;
 
   int use_locales = XSupportsLocale() && XSetLocaleModifiers("@im=none") != NULL;
 
@@ -591,23 +644,65 @@ glw_x11_init(glw_x11_t *gx11)
     return 1;
   }
 
+  if(!glXQueryVersion(gx11->display, &glx_major, &glx_minor)) {
+    TRACE(TRACE_ERROR, "GLW", "Unable to query GLX version on \"%s\"\n",
+          gx11->displayname_real);
+    return 1;
+  }
 
   gx11->screen        = DefaultScreen(gx11->display);
   gx11->screen_width  = DisplayWidth(gx11->display, gx11->screen);
   gx11->screen_height = DisplayHeight(gx11->display, gx11->screen);
   gx11->root          = RootWindow(gx11->display, gx11->screen);
 
-  attribs[na++] = GLX_RGBA;
-  attribs[na++] = GLX_RED_SIZE;
-  attribs[na++] = 1;
-  attribs[na++] = GLX_GREEN_SIZE;
-  attribs[na++] = 1;
-  attribs[na++] = GLX_BLUE_SIZE;
-  attribs[na++] = 1;
-  attribs[na++] = GLX_DOUBLEBUFFER;
-  attribs[na++] = None;
+  if(glx_major > 1 || (glx_major == 1 && glx_minor >= 3)) {
+    attribs[na++] = GLX_X_RENDERABLE;
+    attribs[na++] = True;
+    attribs[na++] = GLX_DRAWABLE_TYPE;
+    attribs[na++] = GLX_WINDOW_BIT;
+    attribs[na++] = GLX_RENDER_TYPE;
+    attribs[na++] = GLX_RGBA_BIT;
+    attribs[na++] = GLX_RED_SIZE;
+    attribs[na++] = 8;
+    attribs[na++] = GLX_GREEN_SIZE;
+    attribs[na++] = 8;
+    attribs[na++] = GLX_BLUE_SIZE;
+    attribs[na++] = 8;
+    attribs[na++] = GLX_DOUBLEBUFFER;
+    attribs[na++] = True;
+    attribs[na++] = None;
 
-  gx11->xvi = glXChooseVisual(gx11->display, gx11->screen, attribs);
+    int num_fbc = 0;
+    GLXFBConfig *fbconfigs =
+      glXChooseFBConfig(gx11->display, gx11->screen, attribs, &num_fbc);
+
+    if(fbconfigs != NULL && num_fbc > 0) {
+      gx11->fbconfig = fbconfigs[0];
+      gx11->xvi = glXGetVisualFromFBConfig(gx11->display, gx11->fbconfig);
+      XFree(fbconfigs);
+      if(gx11->xvi != NULL) {
+        gx11->use_fbconfig = 1;
+        TRACE(TRACE_DEBUG, "GLW", "Using GLX FBConfig visual");
+      }
+    }
+  }
+
+  if(gx11->xvi == NULL) {
+    TRACE(TRACE_INFO, "GLW",
+          "Unable to get GLX FBConfig visual, trying legacy GLX visual");
+
+    na = 0;
+    attribs[na++] = GLX_RGBA;
+    attribs[na++] = GLX_RED_SIZE;
+    attribs[na++] = 1;
+    attribs[na++] = GLX_GREEN_SIZE;
+    attribs[na++] = 1;
+    attribs[na++] = GLX_BLUE_SIZE;
+    attribs[na++] = 1;
+    attribs[na++] = GLX_DOUBLEBUFFER;
+    attribs[na++] = None;
+    gx11->xvi = glXChooseVisual(gx11->display, gx11->screen, attribs);
+  }
 
   if(gx11->xvi == NULL) {
     TRACE(TRACE_ERROR, "GLW", "Unable to find an adequate Visual on \"%s\"\n",

--- a/support/configure-linux-debug.sh
+++ b/support/configure-linux-debug.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Configure a Linux debug build with defaults that work on newer Ubuntu
+# installs where VDPAU headers are often absent and OpenSSL is too new for
+# bundled librtmp.
+
+set -eu
+
+TOPDIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$TOPDIR"
+
+exec ./configure.linux --build=debug --disable-vdpau --enable-polarssl "$@"

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -383,6 +383,14 @@ EOF
 
 
 update_ext_submodule() {
+    if [ "x${SKIP_SUBMODULE_UPDATE}" = "x1" ]; then
+	echo "Skipping $1 submodule update (SKIP_SUBMODULE_UPDATE=1)"
+	if [ ! -d "ext/$1" ]; then
+	    echo "ext/$1 is missing"
+	    die
+	fi
+	return
+    fi
     echo "Updating $1, submodule status before update"
     git submodule status ext/$1
     git submodule update -f --init ext/$1

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -1,0 +1,88 @@
+# Movian Flatpak
+
+This directory contains the local/sideload Flatpak packaging for Movian.
+The manifest builds the GLW/X11/OpenGL UI and installs the bundled binary as
+`/app/bin/showtime`.
+
+## Files
+
+- `dev.uzver.Movian.yml` - Flatpak manifest.
+- `dev.uzver.Movian.desktop` - normal launcher.
+- `dev.uzver.Movian.GameMode.desktop` - fullscreen launcher.
+- `dev.uzver.Movian.metainfo.xml.in` - AppStream template.
+- `build-local.sh` - local builder wrapper.
+- `steam-deck-gamemode-launcher.sh` - optional host-side diagnostic launcher.
+- `../../res/showtime/showtime.png` - installed app icon source.
+
+## Build
+
+From the repository root:
+
+```sh
+support/flatpak/build-local.sh
+```
+
+The bundle is written to:
+
+```text
+build.flatpak/dev.uzver.Movian.flatpak
+```
+
+The build log is written to:
+
+```text
+build.flatpak/flatpak-build.log
+```
+
+## Validate
+
+```sh
+desktop-file-validate \
+  support/flatpak/dev.uzver.Movian.desktop \
+  support/flatpak/dev.uzver.Movian.GameMode.desktop
+
+appstreamcli validate --no-net \
+  build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml
+
+flatpak build build.flatpak-builder /app/bin/showtime --help
+
+flatpak build build.flatpak-builder ldd /app/bin/showtime | \
+  grep -Ei 'gtk|gdk|webkit|rtmp|dvd|vaapi|vdpau|libva|nvidia' || true
+```
+
+The dependency grep should be empty for this MVP profile.
+
+## Install
+
+```sh
+flatpak install --user --reinstall --bundle \
+  build.flatpak/dev.uzver.Movian.flatpak
+
+flatpak run --user dev.uzver.Movian
+flatpak info --user dev.uzver.Movian
+flatpak info --user --show-permissions dev.uzver.Movian
+```
+
+## Manifest Notes
+
+The package persists Movian's legacy state and cache:
+
+```text
+--persist=.hts
+--persist=.cache/movian
+```
+
+AppStream metadata is generated from `dev.uzver.Movian.metainfo.xml.in`
+during the build. The version comes from:
+
+```sh
+git describe --dirty --abbrev=5 | sed -e 's/-/./g'
+```
+
+That keeps Discover, `flatpak info`, and Movian's About/log version aligned.
+
+The app icon is installed as:
+
+```text
+/app/share/icons/hicolor/256x256/apps/dev.uzver.Movian.png
+```

--- a/support/flatpak/build-local.sh
+++ b/support/flatpak/build-local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+log_dir="$repo_root/build.flatpak"
+log_file="$log_dir/flatpak-build.log"
+repo_dir="$log_dir/repo"
+state_dir="$log_dir/state"
+bundle_file="$log_dir/dev.uzver.Movian.flatpak"
+
+mkdir -p "$log_dir" "$repo_dir" "$state_dir"
+rm -f "$bundle_file"
+
+cd "$script_dir"
+
+{
+  flatpak-builder \
+    --user \
+    --verbose \
+    --keep-build-dirs \
+    --force-clean \
+    --state-dir="$state_dir" \
+    --repo="$repo_dir" \
+    --install-deps-from=flathub \
+    "$repo_root/build.flatpak-builder" \
+    dev.uzver.Movian.yml
+
+  flatpak build-bundle \
+    "$repo_dir" \
+    "$bundle_file" \
+    dev.uzver.Movian
+} 2>&1 | tee "$log_file"

--- a/support/flatpak/dev.uzver.Movian.GameMode.desktop
+++ b/support/flatpak/dev.uzver.Movian.GameMode.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Movian (GameMode)
+GenericName=Media Player
+Comment=Fullscreen Movian launcher for Steam Deck Gaming Mode
+Exec=showtime --fullscreen %U
+Icon=dev.uzver.Movian
+Terminal=false
+Categories=AudioVideo;Player;
+StartupWMClass=showtime
+MimeType=application/ogg;application/x-matroska;audio/mp4;audio/mpeg;audio/ogg;audio/x-flac;audio/x-matroska;video/mp4;video/mpeg;video/ogg;video/quicktime;video/webm;video/x-matroska;

--- a/support/flatpak/dev.uzver.Movian.desktop
+++ b/support/flatpak/dev.uzver.Movian.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Movian
+GenericName=Media Player
+Comment=Media player for plugins, streams, and local files
+Exec=showtime %U
+Icon=dev.uzver.Movian
+Terminal=false
+Categories=AudioVideo;Player;
+StartupWMClass=showtime
+MimeType=application/ogg;application/x-matroska;audio/mp4;audio/mpeg;audio/ogg;audio/x-flac;audio/x-matroska;video/mp4;video/mpeg;video/ogg;video/quicktime;video/webm;video/x-matroska;x-content/video-dvd;

--- a/support/flatpak/dev.uzver.Movian.metainfo.xml.in
+++ b/support/flatpak/dev.uzver.Movian.metainfo.xml.in
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>dev.uzver.Movian</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Movian</name>
+  <summary>Media player for plugins, streams, and local files</summary>
+  <developer id="dev.uzver">
+    <name>Movian contributors</name>
+  </developer>
+  <launchable type="desktop-id">dev.uzver.Movian.desktop</launchable>
+  <description>
+    <p>
+      Movian is a GLW-based media player build intended for local media,
+      network streams, and JavaScript plugin development.
+    </p>
+  </description>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Player</category>
+  </categories>
+  <provides>
+    <binary>showtime</binary>
+  </provides>
+  <content_rating type="oars-1.1"/>
+  <url type="homepage">https://movian.eu/</url>
+  <releases>
+    <release version="@MOVIAN_VERSION@" date="2026-05-17"/>
+  </releases>
+</component>

--- a/support/flatpak/dev.uzver.Movian.yml
+++ b/support/flatpak/dev.uzver.Movian.yml
@@ -1,0 +1,64 @@
+id: dev.uzver.Movian
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: showtime
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --socket=pulseaudio
+  - --share=network
+  - --filesystem=xdg-videos:ro
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-pictures:ro
+  - --filesystem=xdg-download:ro
+  - --persist=.hts
+  - --persist=.cache/movian
+
+modules:
+  - name: movian
+    buildsystem: simple
+    build-options:
+      env:
+        SKIP_SUBMODULE_UPDATE: '1'
+        LIBAV_CFLAGS: -Wno-error=incompatible-pointer-types
+        LIBAV_COMMON_FLAGS: >-
+          --disable-inline-asm
+          --disable-hwaccels
+    build-commands:
+      - rm -rf build.flatpak
+      - >-
+        ./configure.linux
+        --build=flatpak
+        --release
+        --prefix=/app
+        --disable-gu
+        --disable-webkit
+        --disable-dvd
+        --disable-vdpau
+        --disable-avahi
+        --disable-libxss
+        --disable-libxxf86vm
+        --disable-librtmp
+      - make BUILD=flatpak "$PWD/build.flatpak/movian.bundle" -j${FLATPAK_BUILDER_N_JOBS}
+      - install -Dm755 build.flatpak/movian.bundle /app/bin/showtime
+      - install -Dm644 support/flatpak/dev.uzver.Movian.desktop /app/share/applications/dev.uzver.Movian.desktop
+      - install -Dm644 support/flatpak/dev.uzver.Movian.GameMode.desktop /app/share/applications/dev.uzver.Movian.GameMode.desktop
+      - >-
+        movian_version=$(git describe --always --dirty --abbrev=5 2>/dev/null || printf '0.0.0') &&
+        movian_version=$(printf '%s' "$movian_version" | sed -e 's/-/./g') &&
+        sed "s/@MOVIAN_VERSION@/${movian_version}/g" support/flatpak/dev.uzver.Movian.metainfo.xml.in > build.flatpak/dev.uzver.Movian.metainfo.xml &&
+        install -Dm644 build.flatpak/dev.uzver.Movian.metainfo.xml /app/share/metainfo/dev.uzver.Movian.metainfo.xml
+      - install -Dm644 res/showtime/showtime.png /app/share/icons/hicolor/256x256/apps/dev.uzver.Movian.png
+      - rm -f /app/share/applications/showtime.desktop /app/share/icons/hicolor/scalable/apps/showtime.svg /app/share/icons/hicolor/256x256/apps/showtime.png
+    sources:
+      - type: dir
+        path: ../..
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - '*.a'

--- a/support/flatpak/steam-deck-gamemode-launcher.sh
+++ b/support/flatpak/steam-deck-gamemode-launcher.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${HOME}/movian-gamemode.log"
+
+{
+  echo "=== $(date -Iseconds) ==="
+  echo "DISPLAY=${DISPLAY:-}"
+  echo "WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-}"
+  echo "XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-}"
+  echo "SteamAppId=${SteamAppId:-}"
+  echo "SteamGameId=${SteamGameId:-}"
+  echo "STEAM_COMPAT_CLIENT_INSTALL_PATH=${STEAM_COMPAT_CLIENT_INSTALL_PATH:-}"
+  /usr/bin/flatpak info dev.uzver.Movian || true
+  exec /usr/bin/flatpak run dev.uzver.Movian --fullscreen -d "$@"
+} >>"${log_file}" 2>&1


### PR DESCRIPTION
## Summary
- land the previously staged public updates directly onto `movian6`
- keep build/API/WebP/runtime changes as separate commits without squashing
- add SteamOS Flatpak packaging in its final plain Movian identity (`dev.uzver.Movian`)
- rewrite the root README and public packaging docs with neutral upstream wording

## Why
Earlier PRs #2-#5 were merged into their stacked base branches instead of the default `movian6` branch. As a result, only PR #1 reached `movian6`. This branch reapplied the missing public work directly on top of `origin/movian6` with a cleaner public history.

## Validation
- `git diff --check origin/movian6..HEAD`
- grep for retired branding/provenance wording in tracked files and commit messages
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- `desktop-file-validate support/flatpak/dev.uzver.Movian.desktop support/flatpak/dev.uzver.Movian.GameMode.desktop`
- `appstreamcli validate --no-net` on generated Flatpak metainfo

## Result
Merged into `movian6` as the final public landing PR for this stack.