### PR TITLE
Add plugin debug smoke workflow

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,21 +4,19 @@ Movian is a media player for plugins, streams, and local files. This repository
 is a clean public fork based on `andoma/movian:movian6`.
 
 The goal of this fork is to keep changes small, reviewable, and based on public
-upstream source. Changes are developed as a stacked set of branches on top of
-the upstream `movian6` branch.
+upstream source.
 
-## Current Branch Stack
+## Current Public Baseline
 
-- `movian6` - clean upstream baseline from `andoma/movian:movian6`.
-- `public/gcc-modernize` - modern GCC and Ubuntu build fixes.
-- `public/linux-build-cleanup` - reproducible Linux debug configure helper and
-  build notes.
-- `public/screenshot-api` - raw screenshot HTTP API plus WSL2 GLX runtime
-  compatibility.
-- `public/webp-image-support` - WebP probing, loading, decoding, and
-  `/api/image` content type support.
-- `public/flatpak-steamos` - local SteamOS/Steam Deck Flatpak packaging and
-  small Linux runtime fixes used by that package.
+The `movian6` branch includes:
+
+- modern GCC and Ubuntu build fixes;
+- a reproducible Linux debug configure helper;
+- raw screenshot HTTP API support;
+- WSL2 GLX runtime compatibility;
+- WebP probing, loading, decoding, and `/api/image` content type support;
+- local SteamOS/Steam Deck Flatpak packaging;
+- a documented plugin debug workflow.
 
 ## Linux Debug Build
 
@@ -80,6 +78,26 @@ Movian stores legacy settings under:
 ~/.hts/showtime
 ```
 
+## Plugin Debug Workflow
+
+For plugin development, use the direct debug binary instead of a packaged app:
+
+```sh
+PLUGIN_PATH=/path/to/plugin \
+START_URL=plugin:start \
+EXPECTED_TITLE="Plugin Title" \
+support/plugin-smoke/run-plugin-smoke.sh
+```
+
+The runner starts Movian with an isolated profile, opens the requested route
+through the HTTP API, checks page state, captures logs, and attempts a raw
+screenshot.
+
+More details:
+
+- `docs/Guides/PLUGIN_DEBUG_WORKFLOW.md`
+- `support/plugin-smoke/run-plugin-smoke.sh`
+
 ## Runtime Features In This Stack
 
 - WSL2 GLX handling is detected at runtime; there is no WSL configure option.
@@ -129,6 +147,7 @@ More details:
 
 - `docs/README.md`
 - `docs/Guides/FLATPAK_STEAMOS_GUIDE.md`
+- `docs/Guides/PLUGIN_DEBUG_WORKFLOW.md`
 - `support/flatpak/README.md`
 
 ## Project Scope

--- a/docs/Guides/PLUGIN_DEBUG_WORKFLOW.md
+++ b/docs/Guides/PLUGIN_DEBUG_WORKFLOW.md
@@ -1,0 +1,196 @@
+# Plugin Debug Workflow
+
+This guide describes a repeatable local workflow for developing and testing
+Movian plugins against a debug Linux build.
+
+The workflow is intentionally separate from Flatpak, Snap, and distribution
+packages. Plugin development is fastest when Movian runs directly from
+`build.debug/movian` with an isolated profile.
+
+## Build
+
+From the repository root:
+
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
+
+The helper configures the Linux debug build with:
+
+```sh
+./configure.linux --build=debug --disable-vdpau --enable-polarssl
+```
+
+Append extra configure flags when needed:
+
+```sh
+./support/configure-linux-debug.sh --disable-webkit
+```
+
+## Manual Plugin Launch
+
+Use a temporary persistent profile and cache so a smoke run does not modify a
+normal user profile:
+
+```sh
+ART=/tmp/movian-plugin-debug
+rm -rf "$ART"
+mkdir -p "$ART"
+
+./build.debug/movian \
+  -d \
+  --disable-upgrades \
+  --persistent "$ART/persistent" \
+  --cache "$ART/cache" \
+  -p /path/to/plugin \
+  plugin:start
+```
+
+Useful launch flags:
+
+- `-d` enables high-signal debug trace output.
+- `--disable-upgrades` removes plugin repository and upgrade noise from logs.
+- `--persistent` and `--cache` isolate the run.
+- `-p` loads a development plugin directory.
+- `--debug-glw` adds GLW focus and event-routing logs.
+- `--libav-log` is useful for playback, probe, HLS, and decoder issues.
+
+Use `--libav-log` only when media probing or playback is part of the test. It
+can make ordinary route smoke logs much larger.
+
+## Smoke Runner
+
+The repository includes a small generic runner:
+
+```sh
+support/plugin-smoke/run-plugin-smoke.sh
+```
+
+Minimal usage:
+
+```sh
+PLUGIN_PATH=/path/to/plugin \
+START_URL=plugin:start \
+EXPECTED_TITLE="Plugin Title" \
+support/plugin-smoke/run-plugin-smoke.sh
+```
+
+Optional environment variables:
+
+- `MOVIAN_BIN` - Movian binary, default `./build.debug/movian`.
+- `ARTIFACTS` - artifact directory, default `/tmp/movian-plugin-smoke`.
+- `READY_LOG_PATTERN` - optional extended-regex log pattern that must appear
+  before the route is opened.
+- `EXPECTED_TYPE` - optional expected `currentpage.model.type`.
+- `MIN_NODES` - optional minimum node count under `currentpage.model.nodes`.
+- `REQUIRE_SCREENSHOT=1` - fail if `/api/screenshot/raw` cannot be captured.
+- `DEBUG_GLW=1` - add `--debug-glw`.
+- `LIBAV_LOG=1` - add `--libav-log`.
+- `ALLOW_EXISTING_MOVIAN=1` - allow another Movian process to already be
+  running.
+
+The runner saves:
+
+- `movian.log`
+- `open.html`
+- `title.txt`
+- `loading.txt`
+- `type.txt`
+- `nodes.txt`
+- `screenshot.png` when available
+- `log-signals.txt`
+- `movian-tail.txt` on failure
+
+## Pass Criteria
+
+A route smoke should prove the smallest useful flow:
+
+- Movian starts and prints the HTTP control port.
+- The development plugin loads.
+- `/api/open?url=<START_URL>` reaches the expected route.
+- `currentpage.model.metadata.title` contains `EXPECTED_TITLE`.
+- `currentpage.model.loading` becomes not-busy.
+- `currentpage.model.type` matches `EXPECTED_TYPE` when provided.
+- `currentpage.model.nodes` has at least `MIN_NODES` entries when provided.
+- Logs do not contain common JavaScript crash signatures.
+- `/api/screenshot/raw` returns a PNG when visual proof is required.
+
+The runner treats screenshot capture as optional unless `REQUIRE_SCREENSHOT=1`
+is set. This keeps non-visual route checks usable in headless or GL-limited
+environments.
+
+## HTTP And Prop Surface
+
+Useful endpoints during manual diagnosis:
+
+```text
+/api/open?url=<encoded-url>
+/api/prop/global/navigators/current/currentpage/model/metadata/title
+/api/prop/global/navigators/current/currentpage/model/loading
+/api/prop/global/navigators/current/currentpage/model/type
+/api/prop/global/navigators/current/currentpage/model/nodes
+/api/screenshot/raw
+/api/screenshot?raw=1
+/api/image?url=<encoded-image-url>
+/api/stpp
+```
+
+For action rows and popup buttons, send action events as POST body fields:
+
+```sh
+curl -fsS -X POST -d action=Activate \
+  "$BASE/api/prop/global/navigators/current/currentpage/model/nodes/*0/eventSink"
+
+curl -fsS -X POST -d action=Ok \
+  "$BASE/api/prop/global/popups/*0/eventSink"
+```
+
+For normal rows created with `page.appendItem(url, ...)`, prefer reading the
+row URL and opening it through `/api/open`. Reserve `eventSink` activation for
+action rows, popups, and option-like controls.
+
+## STPP Notes
+
+The WebSocket endpoint is:
+
+```text
+ws://127.0.0.1:<port>/api/stpp
+```
+
+JSON subscriptions use dot-separated paths relative to root propref `0`, for
+example:
+
+```json
+[1, 1, 0, "navigators.current.currentpage.model.metadata.title"]
+[1, 2, 0, "navigators.current.currentpage.model.loading"]
+```
+
+Do not use slash-separated paths for JSON STPP subscriptions.
+
+## Escalation
+
+Stay in the normal `build.debug` workflow for JavaScript route failures,
+missing metadata, missing nodes, and view/layout issues.
+
+Use a separate debug profile for native crashes or unclear native stacks:
+
+```sh
+LIBAV_COMMON_FLAGS="--disable-inline-asm" ./configure.linux \
+  --build=debug-gdb \
+  --disable-vdpau \
+  --disable-avahi \
+  --disable-webkit \
+  --enable-polarssl \
+  --optlevel=g \
+  --extra-cflags=-fno-omit-frame-pointer \
+  --enable-bughunt
+
+make BUILD=debug-gdb -j$(nproc)
+gdb --args ./build.debug-gdb/movian -d --disable-upgrades
+```
+
+Use AddressSanitizer only for memory corruption or use-after-free
+investigations, because it changes runtime behavior and can make ordinary
+plugin route smoke much noisier.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,21 @@
 # Movian Public Branch Notes
 
-This directory documents the public branch stack in this checkout. The notes
-are based on code, scripts, and packaging files present in this repository.
+This directory documents the public `movian6` branch in this checkout. The
+notes are based on code, scripts, and packaging files present in this
+repository.
 
-## Branch Stack
+## Current Public Baseline
 
-The current public work is organized as small reviewable branches:
+The current branch includes:
 
-- `public/gcc-modernize` - modern GCC and Ubuntu build fixes only.
-- `public/linux-build-cleanup` - reproducible Linux debug configure helper and
-  README build notes.
-- `public/screenshot-api` - raw screenshot HTTP API on top of the existing
-  screenshot code.
-- `public/webp-image-support` - WebP probing, image loading, libav decode
-  mapping, and `/api/image` WebP content type.
-- `public/flatpak-steamos` - local SteamOS/Steam Deck Flatpak packaging and
-  small Linux runtime fixes needed by that package.
-
-Each branch is intended to stay narrow and easy to review.
+- modern GCC and Ubuntu build fixes;
+- reproducible Linux debug configure helper and README build notes;
+- raw screenshot HTTP API on top of the existing screenshot code;
+- WebP probing, image loading, libav decode mapping, and `/api/image` WebP
+  content type;
+- local SteamOS/Steam Deck Flatpak packaging and small Linux runtime fixes used
+  by that package;
+- a plugin debug workflow for route smoke tests against `build.debug/movian`.
 
 ## Linux Build
 
@@ -37,6 +35,25 @@ The helper runs:
 ```
 
 Extra configure flags can be appended to the helper command.
+
+## Plugin Debug Workflow
+
+Use the direct debug binary for plugin development and route smoke tests:
+
+```sh
+PLUGIN_PATH=/path/to/plugin \
+START_URL=plugin:start \
+EXPECTED_TITLE="Plugin Title" \
+support/plugin-smoke/run-plugin-smoke.sh
+```
+
+The main guide is:
+
+- `Guides/PLUGIN_DEBUG_WORKFLOW.md`
+
+The reusable runner lives under:
+
+- `support/plugin-smoke/`
 
 ## Runtime Changes
 

--- a/support/plugin-smoke/run-plugin-smoke.sh
+++ b/support/plugin-smoke/run-plugin-smoke.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MOVIAN_BIN=${MOVIAN_BIN:-./build.debug/movian}
+PLUGIN_PATH=${PLUGIN_PATH:-}
+START_URL=${START_URL:-}
+EXPECTED_TITLE=${EXPECTED_TITLE:-}
+EXPECTED_TYPE=${EXPECTED_TYPE:-}
+MIN_NODES=${MIN_NODES:-0}
+ARTIFACTS=${ARTIFACTS:-/tmp/movian-plugin-smoke}
+READY_LOG_PATTERN=${READY_LOG_PATTERN:-}
+DEBUG_GLW=${DEBUG_GLW:-0}
+LIBAV_LOG=${LIBAV_LOG:-0}
+REQUIRE_SCREENSHOT=${REQUIRE_SCREENSHOT:-0}
+ALLOW_EXISTING_MOVIAN=${ALLOW_EXISTING_MOVIAN:-0}
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  PLUGIN_PATH=/path/to/plugin START_URL=plugin:start EXPECTED_TITLE="Title" \
+    support/plugin-smoke/run-plugin-smoke.sh
+
+Environment:
+  MOVIAN_BIN             Movian binary (default: ./build.debug/movian)
+  ARTIFACTS              Artifact directory (default: /tmp/movian-plugin-smoke)
+  READY_LOG_PATTERN      Optional grep -E pattern to wait for before /api/open
+  EXPECTED_TYPE          Optional expected currentpage.model.type
+  MIN_NODES              Optional minimum node count (default: 0)
+  REQUIRE_SCREENSHOT=1   Fail when /api/screenshot/raw is unavailable
+  DEBUG_GLW=1            Add --debug-glw
+  LIBAV_LOG=1            Add --libav-log
+  ALLOW_EXISTING_MOVIAN=1 Allow another Movian process to already be running
+USAGE
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  if [ -n "${LOG:-}" ] && [ -f "$LOG" ]; then
+    tail -n 200 "$LOG" >"$ARTIFACTS/movian-tail.txt" || true
+    echo "Saved log tail: $ARTIFACTS/movian-tail.txt" >&2
+  fi
+  exit 1
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+[ -n "$PLUGIN_PATH" ] || { usage >&2; exit 2; }
+[ -n "$START_URL" ] || { usage >&2; exit 2; }
+[ -n "$EXPECTED_TITLE" ] || { usage >&2; exit 2; }
+[ -x "$MOVIAN_BIN" ] || fail "Movian binary is not executable: $MOVIAN_BIN"
+[ -d "$PLUGIN_PATH" ] || fail "Plugin directory does not exist: $PLUGIN_PATH"
+
+case "$MIN_NODES" in
+  ''|*[!0-9]*) fail "MIN_NODES must be a non-negative integer, got: $MIN_NODES" ;;
+esac
+
+if [ "$ALLOW_EXISTING_MOVIAN" != "1" ]; then
+  existing=$(pgrep -a -f '/movian( |$)|build\.(debug|release|debug-gdb|asan)/movian' || true)
+  [ -z "$existing" ] || fail "Movian already appears to be running. Set ALLOW_EXISTING_MOVIAN=1 to continue.
+$existing"
+fi
+
+rm -rf "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
+
+LOG="$ARTIFACTS/movian.log"
+PERSIST="$ARTIFACTS/persistent"
+CACHE="$ARTIFACTS/cache"
+mkdir -p "$PERSIST" "$CACHE"
+
+cmd=(
+  "$MOVIAN_BIN"
+  -d
+  --disable-upgrades
+  --persistent "$PERSIST"
+  --cache "$CACHE"
+)
+
+[ "$DEBUG_GLW" = "1" ] && cmd+=(--debug-glw)
+[ "$LIBAV_LOG" = "1" ] && cmd+=(--libav-log)
+
+cmd+=(
+  -p "$PLUGIN_PATH"
+  "$START_URL"
+)
+
+printf '%q ' "${cmd[@]}" >"$ARTIFACTS/command.txt"
+printf '\n' >>"$ARTIFACTS/command.txt"
+
+"${cmd[@]}" >"$LOG" 2>&1 &
+PID=$!
+
+cleanup() {
+  if kill -0 "$PID" 2>/dev/null; then
+    kill "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+wait_log() {
+  pattern=$1
+  label=$2
+
+  for _ in $(seq 1 160); do
+    if grep -Eq "$pattern" "$LOG"; then
+      return 0
+    fi
+    if ! kill -0 "$PID" 2>/dev/null; then
+      wait "$PID" || true
+      fail "Movian exited while waiting for $label"
+    fi
+    sleep 0.25
+  done
+
+  fail "Timed out waiting for $label: $pattern"
+}
+
+wait_log 'http-server: Listening on port [0-9]+' 'HTTP port'
+PORT=$(sed -n 's/.*http-server: Listening on port \([0-9][0-9]*\).*/\1/p' "$LOG" | tail -1)
+[ -n "$PORT" ] || fail "Could not parse HTTP port"
+printf '%s\n' "$PORT" >"$ARTIFACTS/port.txt"
+
+if [ -n "$READY_LOG_PATTERN" ]; then
+  wait_log "$READY_LOG_PATTERN" 'plugin ready log pattern'
+fi
+
+BASE="http://127.0.0.1:$PORT"
+printf '%s\n' "$BASE" >"$ARTIFACTS/base-url.txt"
+
+prop_get() {
+  curl -fsS "$BASE/api/prop/$1"
+}
+
+prop_value() {
+  sed -n -E '1{
+    s/^.* is an? //
+    s/^.* is //
+    p
+  }'
+}
+
+open_url() {
+  curl -fsS --get --data-urlencode "url=$1" "$BASE/api/open" >"$ARTIFACTS/open.html"
+}
+
+current_title() {
+  prop_get 'global/navigators/current/currentpage/model/metadata/title' | prop_value
+}
+
+current_loading() {
+  prop_get 'global/navigators/current/currentpage/model/loading' | prop_value
+}
+
+current_type() {
+  prop_get 'global/navigators/current/currentpage/model/type' | prop_value
+}
+
+is_loading_done() {
+  value=$1
+  case "$value" in
+    1|true|TRUE|True|*' 1'|*true*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+open_url "$START_URL" || fail "Failed to open route: $START_URL"
+
+for _ in $(seq 1 120); do
+  title=$(current_title || true)
+  loading=$(current_loading || true)
+  printf 'title=%s\nloading=%s\n' "$title" "$loading" >"$ARTIFACTS/current-state.txt"
+
+  if printf '%s\n' "$title" | grep -Fq "$EXPECTED_TITLE" && is_loading_done "$loading"; then
+    break
+  fi
+  sleep 0.5
+done
+
+title=$(current_title || true)
+loading=$(current_loading || true)
+type=$(current_type || true)
+
+printf '%s\n' "$title" >"$ARTIFACTS/title.txt"
+printf '%s\n' "$loading" >"$ARTIFACTS/loading.txt"
+printf '%s\n' "$type" >"$ARTIFACTS/type.txt"
+
+printf '%s\n' "$title" | grep -Fq "$EXPECTED_TITLE" || \
+  fail "Expected title containing '$EXPECTED_TITLE', got '$title'"
+
+is_loading_done "$loading" || fail "Page is still loading: $loading"
+
+if [ -n "$EXPECTED_TYPE" ] && [ "$type" != "$EXPECTED_TYPE" ]; then
+  fail "Expected type '$EXPECTED_TYPE', got '$type'"
+fi
+
+if prop_get 'global/navigators/current/currentpage/model/nodes' >"$ARTIFACTS/nodes.txt"; then
+  node_count=$(grep -Ec '^  ' "$ARTIFACTS/nodes.txt" || true)
+else
+  node_count=0
+  : >"$ARTIFACTS/nodes.txt"
+fi
+
+if [ "$MIN_NODES" -gt 0 ] && [ "$node_count" -lt "$MIN_NODES" ]; then
+  fail "Expected at least $MIN_NODES nodes, got $node_count"
+fi
+
+if timeout 8s curl -fsS -o "$ARTIFACTS/screenshot.png" \
+  "$BASE/api/screenshot/raw" 2>"$ARTIFACTS/screenshot-error.txt"; then
+  rm -f "$ARTIFACTS/screenshot-error.txt"
+  file "$ARTIFACTS/screenshot.png" >"$ARTIFACTS/screenshot-file.txt" || true
+else
+  rm -f "$ARTIFACTS/screenshot.png"
+  if [ "$REQUIRE_SCREENSHOT" = "1" ]; then
+    fail "Screenshot capture failed"
+  fi
+  echo "WARNING: screenshot capture failed" >"$ARTIFACTS/screenshot-warning.txt"
+fi
+
+grep -Ein 'TypeError|ReferenceError|Cannot read propert|Route .*exception|JavaScript error' \
+  "$LOG" >"$ARTIFACTS/log-signals.txt" || true
+
+if [ -s "$ARTIFACTS/log-signals.txt" ]; then
+  fail "JavaScript crash signatures found in log"
+fi
+
+cat <<EOF
+PASS
+ARTIFACTS=$ARTIFACTS
+PORT=$PORT
+TITLE=$title
+LOADING=$loading
+TYPE=$type
+NODE_COUNT=$node_count
+EOF


### PR DESCRIPTION
## Summary
- document a direct `build.debug/movian` workflow for plugin development
- add a generic plugin smoke runner that opens routes through the HTTP API and captures artifacts
- update README/docs pointers for the plugin debug workflow

## Validation
- `bash -n support/plugin-smoke/run-plugin-smoke.sh`
- `git diff --check HEAD~1..HEAD`
- grep for retired branding/provenance wording in README/docs/support/plugin-smoke
- `./build.debug/movian --help`
- `ALLOW_EXISTING_MOVIAN=1 PLUGIN_PATH=plugin_examples/music START_URL='example:music:' EXPECTED_TITLE='Music examples' MIN_NODES=5 ARTIFACTS=/tmp/movian-public-plugin-smoke support/plugin-smoke/run-plugin-smoke.sh`

## Notes
The runner does not require packaged builds and is meant for local plugin route/debug smoke tests.