### PR TITLE
Use HTTPS for GitHub submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "ext/libav"]
 	path = ext/libav
-	url = git://github.com/andoma/libav.git
+	url = https://github.com/andoma/libav.git
 [submodule "ext/rtmpdump"]
 	path = ext/rtmpdump
-	url = git://github.com/andoma/rtmpdump.git
+	url = https://github.com/andoma/rtmpdump.git
 [submodule "ext/libntfs_ext"]
 	path = ext/libntfs_ext
 	url = https://github.com/andoma/libntfs_ext.git


### PR DESCRIPTION
## Summary
- switch the GitHub-hosted `libav` and `rtmpdump` submodule URLs from `git://` to `https://`
- keep all submodule pins unchanged

## Validation
- `git submodule sync --recursive`
- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`

## Notes
This only changes transport URLs in `.gitmodules`; no submodule commits are updated.