### PR TITLE
Complete CLI help option coverage

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -604,6 +604,9 @@ parse_opts(int argc, char **argv)
 	     "   --show-usage-events - Log usage events.\n"
 	     "   --upgrade-path <path> - Override upgrade path.\n"
 	     "   --showtime-shell-fd <fd> - Use inherited shell fd.\n"
+#ifdef __APPLE__
+	     "   -psn*               - Ignore macOS process serial number.\n"
+#endif
 	     "\n"
 	     "  URL is any URL-type supported, "
 	     "e.g., \"file:///...\"\n"


### PR DESCRIPTION
## Summary

- document the remaining parser-only CLI option in `--help`
- keep the Apple process serial number handling under `#ifdef __APPLE__`
- verify the source-level parser/help option lists stay aligned

## Validation

- `git diff --check HEAD~1..HEAD`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- source comparison: `parser_not_help=[]`, `help_not_parser=[]`
- smoke-tested each visible Linux option by placing it before `--help`