### PR TITLE
Add DOM-style HTML parser aliases

### DIFF
--- a/docs/Guides/PLUGIN_DEVELOPMENT_NOTES.md
+++ b/docs/Guides/PLUGIN_DEVELOPMENT_NOTES.md
@@ -20,14 +20,13 @@ The current long-standing API exposes these node methods:
 - `getElementByTagName(tagName)` returns an array.
 
 The class and tag helpers return multiple nodes, even though their historical
-names use singular `Element`. Newer Movian builds may also provide DOM-style
-plural aliases:
+names use singular `Element`. Movian also provides DOM-style plural aliases:
 
 - `getElementsByClassName(className)`
 - `getElementsByTagName(tagName)`
 
-For plugins that should run on both newer and older Movian builds, prefer a
-small compatibility wrapper instead of copying the whole built-in HTML module.
+For plugins that should also run on older Movian builds, prefer a small
+compatibility wrapper instead of copying the whole built-in HTML module.
 
 Example `utils/html_compat.js`:
 

--- a/res/ecmascript/modules/movian/html.js
+++ b/res/ecmascript/modules/movian/html.js
@@ -62,11 +62,17 @@ NodeProto.prototype.getElementByClassName = function(cls) {
   });
 }
 
+NodeProto.prototype.getElementsByClassName =
+  NodeProto.prototype.getElementByClassName;
+
 NodeProto.prototype.getElementByTagName = function(tag) {
   return gumbo.findByTagName(this._gumboNode, tag).map(function(n) {
     return new Node(n);
   });
 }
+
+NodeProto.prototype.getElementsByTagName =
+  NodeProto.prototype.getElementByTagName;
 
 var nodeProto = new NodeProto();
 


### PR DESCRIPTION
## Summary

- add `getElementsByClassName()` as an alias for the long-standing `getElementByClassName()` helper
- add `getElementsByTagName()` as an alias for the long-standing `getElementByTagName()` helper
- update plugin development notes to describe the built-in aliases and older-build compatibility wrapper

## Compatibility

The existing singular method names are preserved unchanged. New code can use the DOM-style plural names, while plugins targeting older Movian builds can keep using the documented local wrapper.

## Validation

- `node --check res/ecmascript/modules/movian/html.js`
- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- ECMAScript smoke covering old and new HTML parser method names