### PR TITLE
Switch bundled media backend to FFmpeg 4.4.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ext/libav"]
 	path = ext/libav
-	url = https://github.com/andoma/libav.git
-	branch = movian-master
+	url = https://github.com/FFmpeg/FFmpeg.git
+	branch = release/4.4
 [submodule "ext/rtmpdump"]
 	path = ext/rtmpdump
 	url = https://github.com/andoma/rtmpdump.git

--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,8 @@ The `movian6` branch includes:
 - raw screenshot HTTP API support;
 - WSL2 GLX runtime compatibility;
 - WebP probing, loading, decoding, and `/api/image` content type support;
+- bundled FFmpeg 4.4.7 media backend with existing `libav` option names kept
+  for compatibility;
 - local SteamOS/Steam Deck Flatpak packaging;
 - a documented plugin debug workflow.
 
@@ -105,8 +107,10 @@ More details:
 - `/api/screenshot?raw=1` and `/api/screenshot?raw=true` use the same raw PNG
   path.
 - Existing `/api/screenshot` upload behavior is preserved.
-- WebP images are recognized by RIFF/WEBP magic, decoded through libav, and
+- WebP images are recognized by RIFF/WEBP magic, decoded through FFmpeg, and
   served from `/api/image` as `image/webp`.
+- Existing command-line names such as `--libav-log` are preserved while the
+  bundled backend uses FFmpeg 4.4.7.
 - Steam launches avoid the X11 fullscreen path that can bounce back to the
   Steam loading screen.
 

--- a/configure.linux
+++ b/configure.linux
@@ -166,8 +166,8 @@ done
 
 case "$ARCH" in
   x86_64|amd64|i?86)
-    # The bundled libav x86 inline asm is rejected by newer GCC/binutils.
-    LIBAV_COMMON_FLAGS="${LIBAV_COMMON_FLAGS} --disable-inline-asm"
+    # The bundled FFmpeg/libav x86 asm is rejected by some newer toolchains.
+    LIBAV_COMMON_FLAGS="${LIBAV_COMMON_FLAGS} --disable-inline-asm --disable-x86asm"
   ;;
 esac
 

--- a/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
+++ b/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
@@ -33,9 +33,12 @@ deferred subsystems:
 The manifest also sets:
 
 ```text
-SKIP_SUBMODULE_UPDATE=1
-LIBAV_COMMON_FLAGS=--disable-inline-asm --disable-hwaccels
 LIBAV_CFLAGS=-Wno-error=incompatible-pointer-types
+LIBAV_COMMON_FLAGS=--disable-x86asm --disable-inline-asm --disable-hwaccels
+                   --disable-vaapi --disable-vdpau --disable-cuda
+                   --disable-cuda-llvm --disable-cuvid --disable-ffnvcodec
+                   --disable-nvdec --disable-v4l2-m2m
+SKIP_SUBMODULE_UPDATE=1
 ```
 
 `SKIP_SUBMODULE_UPDATE=1` keeps Flatpak builds from reaching out to git during

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ The current branch includes:
 - raw screenshot HTTP API on top of the existing screenshot code;
 - WebP probing, image loading, libav decode mapping, and `/api/image` WebP
   content type;
+- bundled FFmpeg 4.4.7 as the media backend, while keeping existing `libav`
+  option names and internal build variables for compatibility;
 - local SteamOS/Steam Deck Flatpak packaging and small Linux runtime fixes used
   by that package;
 - a plugin debug workflow for route smoke tests against `build.debug/movian`.
@@ -69,6 +71,8 @@ The public stack currently includes these user-visible changes:
 - WebP files are recognized by RIFF/WEBP magic in file probing and image
   loading. The libav image decoder maps WebP, and `/api/image` returns
   `image/webp` for WebP payloads.
+- The bundled media backend is FFmpeg 4.4.7. Existing command-line and helper
+  names such as `--libav-log` remain unchanged.
 - Steam launches avoid the X11 fullscreen `override_redirect` path when
   `SteamGameId` or `SteamAppId` is set. `XK_Menu` maps to Movian's menu action
   for Steam Input keyboard layouts.

--- a/src/backend/hls/hls_ts.c
+++ b/src/backend/hls/hls_ts.c
@@ -23,6 +23,7 @@
 #include <libavcodec/avcodec.h>
 #include <libavutil/mathematics.h>
 
+#include "libav_compat.h"
 #include "fileaccess/fa_libav.h"
 #include "media/media.h"
 #include "backend/backend.h"

--- a/src/libav.c
+++ b/src/libav.c
@@ -26,6 +26,7 @@
 #include "main.h"
 #include "media/media.h"
 #include "libav.h"
+#include "libav_compat.h"
 #include "fileaccess/fa_libav.h"
 #include "video/video_decoder.h"
 #include "video/video_settings.h"
@@ -560,5 +561,4 @@ mp_set_mq_meta(media_queue_t *mq, const AVCodec *codec,
   metadata_from_libav(buf, sizeof(buf), codec, avctx);
   prop_set_string(mq->mq_prop_codec, buf);
 }
-
 

--- a/src/libav_compat.h
+++ b/src/libav_compat.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2007-2015 Lonelycoder AB
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This program is also available under a commercial proprietary license.
+ *  For more information, contact andreas@lonelycoder.com
+ */
+#pragma once
+
+#ifndef FF_INPUT_BUFFER_PADDING_SIZE
+#define FF_INPUT_BUFFER_PADDING_SIZE AV_INPUT_BUFFER_PADDING_SIZE
+#endif
+
+#ifndef CODEC_FLAG2_FAST
+#define CODEC_FLAG2_FAST AV_CODEC_FLAG2_FAST
+#endif

--- a/src/ui/glw/glw_rec.c
+++ b/src/ui/glw/glw_rec.c
@@ -267,6 +267,37 @@ encode_vframe(glw_rec_t *gr, struct pixmap *pm)
 /**
  *
  */
+static void
+rec_close_output(glw_rec_t *gr, int write_trailer)
+{
+  if(gr->oc == NULL)
+    return;
+
+  if(write_trailer)
+    av_write_trailer(gr->oc);
+
+  for(int i = 0; i < gr->oc->nb_streams; i++) {
+    AVStream *st = gr->oc->streams[i];
+    avcodec_close(st->codec);
+    free(st->codec);
+    free(st);
+  }
+
+  if(gr->oc->pb != NULL)
+    avio_close(gr->oc->pb);
+
+  free(gr->oc);
+  gr->oc = NULL;
+  gr->v_ctx = NULL;
+  gr->a_ctx = NULL;
+  gr->v_st = NULL;
+  gr->a_st = NULL;
+}
+
+
+/**
+ *
+ */
 static void *
 rec_thread(void *aux)
 {
@@ -350,6 +381,7 @@ rec_thread(void *aux)
     TRACE(TRACE_ERROR, "REC",
           "Unable to record to %s -- Unable to write stream header",
           gr->filename);
+    rec_close_output(gr, 0);
     return NULL;
   }
 
@@ -373,17 +405,7 @@ rec_thread(void *aux)
 
   hts_mutex_unlock(&glw_rec_mutex);
 
-  av_write_trailer(gr->oc);
-
-  for(int i = 0; i < gr->oc->nb_streams; i++) {
-    AVStream *st = gr->oc->streams[i];
-    avcodec_close(st->codec);
-    free(st->codec);
-    free(st);
-  }
-
-  avio_close(gr->oc->pb);
-  free(gr->oc);
+  rec_close_output(gr, 1);
   free(gr);
   return NULL;
 }

--- a/src/ui/glw/glw_rec.c
+++ b/src/ui/glw/glw_rec.c
@@ -346,7 +346,12 @@ rec_thread(void *aux)
   }
 
   /* write the stream header, if any */
-  avformat_write_header(gr->oc, NULL);
+  if(avformat_write_header(gr->oc, NULL) < 0) {
+    TRACE(TRACE_ERROR, "REC",
+          "Unable to record to %s -- Unable to write stream header",
+          gr->filename);
+    return NULL;
+  }
 
 
   hts_mutex_lock(&glw_rec_mutex);

--- a/src/ui/glw/glw_rec.c
+++ b/src/ui/glw/glw_rec.c
@@ -192,7 +192,12 @@ emit_audio(glw_rec_t *gr, int64_t pts)
     if(ts >= 0) {
 
       frame.data[0] = (void *)data;
+      frame.extended_data = frame.data;
       frame.nb_samples = SAMPLES_PER_FRAME;
+      frame.format = gr->a_ctx->sample_fmt;
+      frame.channel_layout = gr->a_ctx->channel_layout;
+      frame.channels = gr->a_ctx->channels;
+      frame.sample_rate = gr->a_ctx->sample_rate;
 
       int got_packet;
       int r = avcodec_encode_audio2(gr->a_ctx, &pkt, &frame, &got_packet);
@@ -203,7 +208,7 @@ emit_audio(glw_rec_t *gr, int64_t pts)
       pkt.pts = pkt.dts = ts;
       pkt.stream_index = gr->a_st->index;
       pkt.duration = av_rescale_q(1, (AVRational){SAMPLES_PER_FRAME, 48000},
-                                  gr->v_st->time_base);
+                                  gr->a_st->time_base);
       av_interleaved_write_frame(gr->oc, &pkt);
       av_free_packet(&pkt);
     }
@@ -232,7 +237,11 @@ encode_vframe(glw_rec_t *gr, struct pixmap *pm)
   memset(&frame, 0, sizeof(frame));
 
   frame.data[0] = pm->pm_data + pm->pm_linesize * (gr->height - 1);
+  frame.extended_data = frame.data;
   frame.linesize[0] = -pm->pm_linesize;
+  frame.width = gr->v_ctx->width;
+  frame.height = gr->v_ctx->height;
+  frame.format = gr->v_ctx->pix_fmt;
   frame.pts = 1000000LL * gr->framenum / gr->fps;
   gr->framenum++;
 
@@ -330,6 +339,7 @@ rec_thread(void *aux)
   gr->v_ctx->height = gr->height;
   gr->v_ctx->time_base.den = gr->fps;
   gr->v_ctx->time_base.num = 1;
+  gr->v_st->time_base = gr->v_ctx->time_base;
   gr->v_ctx->pix_fmt = AV_PIX_FMT_RGB32;
   gr->v_ctx->coder_type = 0;
 
@@ -352,8 +362,10 @@ rec_thread(void *aux)
   gr->a_ctx->sample_rate = 48000;
   gr->a_ctx->sample_fmt = AV_SAMPLE_FMT_S16;
   gr->a_ctx->channel_layout = AV_CH_LAYOUT_STEREO;
+  gr->a_ctx->channels = av_get_channel_layout_nb_channels(gr->a_ctx->channel_layout);
   gr->a_ctx->time_base.den = 48000;
   gr->a_ctx->time_base.num = 1;
+  gr->a_st->time_base = gr->a_ctx->time_base;
 
   c = avcodec_find_encoder(gr->a_ctx->codec_id);
   if(avcodec_open2(gr->a_ctx, c, NULL)) {
@@ -366,6 +378,15 @@ rec_thread(void *aux)
   gr->v_ctx->thread_count = gconf.concurrency;
 
   // Output output file
+
+  if(avcodec_parameters_from_context(gr->v_st->codecpar, gr->v_ctx) < 0 ||
+     avcodec_parameters_from_context(gr->a_st->codecpar, gr->a_ctx) < 0) {
+    TRACE(TRACE_ERROR, "REC",
+          "Unable to record to %s -- Unable to copy codec parameters",
+          gr->filename);
+    rec_close_output(gr, 0);
+    return NULL;
+  }
 
   av_dump_format(gr->oc, 0, gr->filename, 1);
 

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -410,9 +410,7 @@ libav_setup() {
 
     mkdir -p "${LIBAV_BUILD_DIR}"
 
-    #LIBAV_COMMON_FLAGS="--disable-parsers --disable-decoders --disable-demuxers"
-
-    LIBAV_COMMON_FLAGS="${LIBAV_COMMON_FLAGS} --disable-encoders --disable-filters --disable-muxers --disable-devices --disable-demuxer=rtp --disable-protocol=rtp --disable-bzlib --disable-decoder=twinvq --disable-decoder=snow --disable-decoder=cavs --disable-programs --disable-avfilter --enable-decoder=png --enable-decoder=mjpeg --enable-encoder=mjpeg --enable-encoder=png --enable-muxer=spdif --enable-encoder=ac3 --enable-encoder=eac3 --enable-muxer=matroska --enable-encoder=ffvhuff --enable-encoder=pcm_s16le"
+    LIBAV_COMMON_FLAGS="${LIBAV_COMMON_FLAGS} --enable-avresample --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-lzma --disable-encoders --disable-filters --disable-muxers --disable-devices --disable-demuxer=rtp --disable-protocol=rtp --disable-bzlib --disable-decoder=twinvq --disable-decoder=snow --disable-decoder=cavs --disable-programs --disable-avfilter --enable-decoder=png --enable-decoder=mjpeg --enable-encoder=mjpeg --enable-encoder=png --enable-muxer=spdif --enable-encoder=ac3 --enable-encoder=eac3 --enable-muxer=matroska --enable-encoder=ffvhuff --enable-encoder=pcm_s16le"
 
     (cd ${LIBAV_BUILD_DIR} && ${TOPDIR}/ext/libav/configure ${LIBAV_ARCH_FLAGS} ${LIBAV_COMMON_FLAGS} --prefix=${EXT_INSTALL_DIR} --extra-cflags="${LIBAV_CFLAGS} ${EXTRA_CFLAGS}" --extra-ldflags="${LIBAV_LDFLAGS} ${EXTRA_LDFLAGS}" --cc="${CC}") || die
 
@@ -572,7 +570,7 @@ EXT_INSTALL_DIR=${EXT_INSTALL_DIR}
 EOF
 
     if enabled libav; then
-	echo >>${CONFIG_MAK} "LDFLAGS_cfg += -lavresample -lswscale -lavformat -lavcodec -lavutil"
+	echo >>${CONFIG_MAK} "LDFLAGS_cfg += -lavresample -lswscale -lavformat -lavcodec -lswresample -lavutil"
     fi
 
     if enabled libcec; then

--- a/support/flatpak/dev.uzver.Movian.yml
+++ b/support/flatpak/dev.uzver.Movian.yml
@@ -26,8 +26,17 @@ modules:
         SKIP_SUBMODULE_UPDATE: '1'
         LIBAV_CFLAGS: -Wno-error=incompatible-pointer-types
         LIBAV_COMMON_FLAGS: >-
+          --disable-x86asm
           --disable-inline-asm
           --disable-hwaccels
+          --disable-vaapi
+          --disable-vdpau
+          --disable-cuda
+          --disable-cuda-llvm
+          --disable-cuvid
+          --disable-ffnvcodec
+          --disable-nvdec
+          --disable-v4l2-m2m
     build-commands:
       - rm -rf build.flatpak
       - >-


### PR DESCRIPTION
## Summary

- replace the old bundled media backend submodule with official FFmpeg `n4.4.7`
- keep existing `libav` option/build naming where it is part of the public compatibility surface
- add small compatibility guards for renamed FFmpeg constants
- tighten Linux/Flatpak FFmpeg configure flags and document the bundled FFmpeg backend
- update the GLW recorder path for FFmpeg 4.4 muxing and clean failure handling

## Validation

- `git diff --check HEAD~4..HEAD`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `timeout 10s ./build.debug/movian --help`
- `support/flatpak/build-local.sh`
- `flatpak build build.flatpak-builder /app/bin/showtime --help`
- `appstreamcli validate --no-net build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml`
- Flatpak dependency grep found no GTK/WebKit/DVD/RTMP/VAAPI/VDPAU/NVIDIA/CUDA linkage
- local MP4 playback smoke reached H.264 decode, audio resample, and playback completion
- local HLS smoke selected the HLS track and reached EOF playback completion
- WebP `/api/image` smoke returned `image/webp` with byte-identical output
- GLW recorder smoke via `Alt+F12` produced a valid Matroska file; `ffprobe` reported `ffvhuff` video and `pcm_s16le` stereo audio