### PR TITLE
Disable GLW recorder in Flatpak release builds

### DIFF
--- a/configure.linux
+++ b/configure.linux
@@ -346,7 +346,9 @@ if enabled glw_frontend_x11; then
     fi
 
     enable glw_backend_opengl
-    enable glw_rec
+    if [ "x${glw_rec}" != "xno" ]; then
+	enable glw_rec
+    fi
     enable glw
 else
     disable vdpau

--- a/src/event.c
+++ b/src/event.c
@@ -195,6 +195,7 @@ static struct strtab actionnames[] = {
   { "ReloadData",            ACTION_RELOAD_DATA },
   { "Playqueue",             ACTION_PLAYQUEUE },
   { "Sysinfo",               ACTION_SYSINFO },
+  { "RecordUI",              ACTION_RECORD_UI },
 
 };
 

--- a/src/ui/glw/glw.c
+++ b/src/ui/glw/glw.c
@@ -2439,12 +2439,14 @@ glw_dispatch_event(glw_root_t *gr, event_t *e)
     return;
   }
 
-#if CONFIG_GLW_REC
   if(event_is_action(e, ACTION_RECORD_UI)) {
+#if CONFIG_GLW_REC
     glw_rec_toggle(gr);
+#else
+    TRACE(TRACE_DEBUG, "GLW", "Recording is disabled in this build");
+#endif
     return;
   }
-#endif
 
   if(e->e_type == EVENT_KEYDESC) {
 

--- a/support/flatpak/dev.uzver.Movian.yml
+++ b/support/flatpak/dev.uzver.Movian.yml
@@ -52,6 +52,7 @@ modules:
         --disable-libxss
         --disable-libxxf86vm
         --disable-librtmp
+        --disable-glw-rec
       - make BUILD=flatpak "$PWD/build.flatpak/movian.bundle" -j${FLATPAK_BUILDER_N_JOBS}
       - install -Dm755 build.flatpak/movian.bundle /app/bin/showtime
       - install -Dm644 support/flatpak/dev.uzver.Movian.desktop /app/share/applications/dev.uzver.Movian.desktop


### PR DESCRIPTION
## Summary

- disable the hidden GLW recorder in Flatpak release builds with `--disable-glw-rec`
- make `configure.linux` respect an explicit `--disable-glw-rec` instead of re-enabling it when GLW/X11 is enabled
- consume the recorder hotkey as a no-op when recorder support is not compiled in, preventing `Alt+F12` from reaching the generic event path and crashing
- give `ACTION_RECORD_UI` a string name so event logging/mapping code cannot see a NULL action name

## Why

The GLW recorder is currently a debug-oriented hidden feature. It writes large lossless `capture.mkv` files and should not ship as an accidental Flatpak release feature.

Steam Deck smoke testing confirmed that disabling the recorder stopped file creation, but `Alt+F12` still crashed because `ACTION_RECORD_UI` was no longer handled when `CONFIG_GLW_REC=0`. This PR makes the disabled path explicit and harmless.

Related backlog: #19

## Validation

- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- `support/flatpak/build-local.sh`
- Flatpak `/app/bin/showtime --help`
- `appstreamcli validate --no-net build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml`
- verified latest Flatpak build has `#define ENABLE_GLW_REC 0`
- verified latest Flatpak build has no `glw_rec.o`
- Steam Deck smoke: Flatpak no longer records on `Alt+F12`; follow-up build makes `Alt+F12` a no-op instead of crashing