### PR TITLE
Set GLW recorder release policy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -113,6 +113,9 @@ More details:
   bundled backend uses FFmpeg 4.4.7.
 - Steam launches avoid the X11 fullscreen path that can bounce back to the
   Steam loading screen.
+- The hidden GLW recorder is treated as a developer/debug aid. Linux debug
+  builds keep it enabled by default; release and Flatpak builds disable it
+  unless `--enable-glw-rec` is passed explicitly.
 
 ## Flatpak / SteamOS
 
@@ -146,6 +149,9 @@ The package installs the bundled Movian binary as `/app/bin/showtime`, persists
 legacy state with `--persist=.hts` and `--persist=.cache/movian`, generates
 AppStream metadata from the current git version, and installs the PNG icon from
 `res/showtime/showtime.png`.
+
+The GLW recorder hotkey is disabled in the Flatpak package. Use
+`/api/screenshot/raw` or a direct debug build for runtime smoke/debug captures.
 
 More details:
 

--- a/configure.linux
+++ b/configure.linux
@@ -42,6 +42,8 @@ show_help(){
   echo "  --glw-frontend=FRONTEND  Build GLW for FRONTEND [$GLWFRONTEND]"
   echo "                            x11      X11 Windows"
   echo "                            none     Disable GLW"
+  echo "  --enable-glw-rec         Enable GLW recorder, including release builds"
+  echo "  --disable-glw-rec        Disable GLW recorder"
   echo "  --pkg-config-path=PATH   Extra paths for pkg-config"
   exit 1
 }
@@ -172,6 +174,12 @@ case "$ARCH" in
 esac
 
 setup_env "$@"
+
+# Keep the hidden GLW recorder as a developer/debug aid unless explicitly
+# requested in a release build.
+if enabled release && disabled glw_rec; then
+    disable glw_rec
+fi
 
 
 #

--- a/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
+++ b/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
@@ -28,6 +28,7 @@ deferred subsystems:
 --disable-libxss
 --disable-libxxf86vm
 --disable-librtmp
+--disable-glw-rec
 ```
 
 The manifest also sets:
@@ -49,6 +50,10 @@ AppStream metadata is generated during the build from `git describe`, which
 keeps Discover's version aligned with Movian's About/log output.
 The app icon is installed from `res/showtime/showtime.png` as a hicolor
 `256x256` PNG under the Flatpak app id.
+
+The hidden GLW recorder is disabled in this release-oriented profile. It is a
+developer/debug aid that writes large `capture.mkv` files in builds where it is
+enabled. Use `/api/screenshot/raw` for Flatpak smoke captures.
 
 ## Sandbox
 
@@ -157,6 +162,7 @@ Minimum smoke checklist:
 - Installed plugins and settings survive a restart.
 - A direct WebP URL opens as an image.
 - `/api/screenshot/raw` returns a PNG when the HTTP API is enabled.
+- Pressing `Alt+F12` does not start recording or crash the Flatpak build.
 
 ## Steam Input
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,9 @@ The public stack currently includes these user-visible changes:
 - Steam launches avoid the X11 fullscreen `override_redirect` path when
   `SteamGameId` or `SteamAppId` is set. `XK_Menu` maps to Movian's menu action
   for Steam Input keyboard layouts.
+- The hidden GLW recorder is kept as a developer/debug aid. Linux debug builds
+  enable it by default; release and Flatpak builds disable it unless
+  `--enable-glw-rec` is passed explicitly.
 
 ## Flatpak / SteamOS
 
@@ -92,6 +95,9 @@ The package installs the bundled Movian binary as `/app/bin/showtime`, keeps
 state through `--persist=.hts` and `--persist=.cache/movian`, and generates
 AppStream metadata from the current `git describe` version so Discover matches
 Movian's About/log output.
+
+The Flatpak package disables the GLW recorder hotkey. Use
+`/api/screenshot/raw` for smoke/debug captures in that profile.
 
 ## Out Of Scope
 

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -65,6 +65,15 @@ flatpak info --user --show-permissions dev.uzver.Movian
 
 ## Manifest Notes
 
+The manifest disables the hidden GLW recorder:
+
+```text
+--disable-glw-rec
+```
+
+That keeps the release-oriented Flatpak from writing large debug
+`capture.mkv` files. The `Alt+F12` recorder hotkey is a no-op in this build.
+
 The package persists Movian's legacy state and cache:
 
 ```text


### PR DESCRIPTION
## Summary

- disable the hidden GLW recorder by default for Linux `--release` builds
- keep `--enable-glw-rec` as an explicit developer override
- document the debug/release/Flatpak recorder policy and steer Flatpak smoke captures toward `/api/screenshot/raw`

## Rationale

The GLW recorder is currently a developer/debug tool that writes large lossless `capture.mkv` files. Release-oriented builds should not expose it by default, while debug builds should keep it available for local testing.

Closes #19.

Follow-up compressed recorder work is tracked separately in #27.

## Checks

- `git diff --check`
- `./support/configure-linux-debug.sh`
- `grep ENABLE_GLW_REC build.debug/config.h` -> `1`
- `SKIP_SUBMODULE_UPDATE=1 ./configure.linux --build=release-policy --release --disable-vdpau --enable-polarssl`
- `grep ENABLE_GLW_REC build.release-policy/config.h` -> `0`
- `SKIP_SUBMODULE_UPDATE=1 ./configure.linux --build=release-policy-rec --release --enable-glw-rec --disable-vdpau --enable-polarssl`
- `grep ENABLE_GLW_REC build.release-policy-rec/config.h` -> `1`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- `support/flatpak/build-local.sh`
- `flatpak build build.flatpak-builder /app/bin/showtime --help`
- `appstreamcli validate --no-net build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml`
- Flatpak config has `#define ENABLE_GLW_REC 0`
- Flatpak object list has no `glw_rec.o`