### PR TITLE
Document Linux and Flatpak smoke checklist

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -156,6 +156,7 @@ The GLW recorder hotkey is disabled in the Flatpak package. Use
 More details:
 
 - `docs/README.md`
+- `docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md`
 - `docs/Guides/FLATPAK_STEAMOS_GUIDE.md`
 - `docs/Guides/PLUGIN_DEBUG_WORKFLOW.md`
 - `support/flatpak/README.md`

--- a/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
+++ b/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
@@ -122,6 +122,12 @@ sha256sum build.flatpak/dev.uzver.Movian.flatpak
 
 The dependency grep should print nothing for the current MVP profile.
 
+For the full Linux, Flatpak, runtime, and manual Steam Deck checklist, see:
+
+```text
+docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+```
+
 ## Install And Run
 
 Install the generated bundle:

--- a/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+++ b/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
@@ -1,0 +1,218 @@
+# Linux and Flatpak Smoke Checklist
+
+Use this checklist for Linux, WSL, Flatpak, SteamOS, media, image, screenshot,
+and packaging changes. Keep the completed commands in the pull request body so
+reviewers can reproduce the same path.
+
+## Baseline Linux Build
+
+Run these for ordinary Linux build, C code, configure, module, plugin runtime,
+image, screenshot, and media changes:
+
+```sh
+git diff --check
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
+
+Expected result:
+
+- `git diff --check` prints nothing.
+- configure completes with the current bundled FFmpeg/libav submodule.
+- `make` produces `build.debug/movian`.
+- `--help` prints the Movian version and option list.
+
+For release-policy changes that touch the GLW recorder, also verify the
+recorder defaults:
+
+```sh
+grep -n "ENABLE_GLW_REC" build.debug/config.h
+
+SKIP_SUBMODULE_UPDATE=1 ./configure.linux \
+  --build=release-smoke \
+  --release \
+  --disable-vdpau \
+  --enable-polarssl
+grep -n "ENABLE_GLW_REC" build.release-smoke/config.h
+
+SKIP_SUBMODULE_UPDATE=1 ./configure.linux \
+  --build=release-smoke-rec \
+  --release \
+  --enable-glw-rec \
+  --disable-vdpau \
+  --enable-polarssl
+grep -n "ENABLE_GLW_REC" build.release-smoke-rec/config.h
+```
+
+Expected result:
+
+- debug build: `ENABLE_GLW_REC 1`
+- release build: `ENABLE_GLW_REC 0`
+- explicit release override: `ENABLE_GLW_REC 1`
+
+## Flatpak Build
+
+Run these for Flatpak manifest, SteamOS, packaging, sandbox, AppStream, icon,
+runtime dependency, or release-profile changes:
+
+```sh
+support/flatpak/build-local.sh
+
+flatpak build build.flatpak-builder /app/bin/showtime --help
+
+desktop-file-validate \
+  support/flatpak/dev.uzver.Movian.desktop \
+  support/flatpak/dev.uzver.Movian.GameMode.desktop
+
+appstreamcli validate --no-net \
+  build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml
+
+flatpak build build.flatpak-builder ldd /app/bin/showtime | \
+  grep -Ei 'gtk|gdk|webkit|rtmp|dvd|vaapi|vdpau|libva|nvidia|cuda' || true
+
+find build.flatpak/state/build \
+  -path '*/build.flatpak/config.h' \
+  -exec grep -n "ENABLE_GLW_REC" {} \;
+
+find build.flatpak/state/build \
+  -path '*/build.flatpak/src/ui/glw/glw_rec.o' \
+  -print
+
+sha256sum build.flatpak/dev.uzver.Movian.flatpak
+```
+
+Expected result:
+
+- Flatpak bundle exists at `build.flatpak/dev.uzver.Movian.flatpak`.
+- `/app/bin/showtime --help` prints the same version family as the build.
+- desktop-file validation succeeds.
+- AppStream validation succeeds.
+- dependency grep is empty for the current minimal Flatpak profile.
+- Flatpak config shows `ENABLE_GLW_REC 0`.
+- `glw_rec.o` is absent from the Flatpak build object list.
+- SHA256 is recorded in the PR when a bundle is used for manual smoke.
+
+## Runtime Smoke Matrix
+
+Choose the smallest runtime smoke that matches the files changed.
+
+| Change type | Minimum runtime smoke |
+| --- | --- |
+| Docs only | No runtime smoke required; run `git diff --check`. |
+| Linux build/configure/C code | Baseline Linux build and `./build.debug/movian --help`. |
+| Flatpak manifest, AppStream, icon, sandbox, release profile | Flatpak build checks plus manual Steam Deck smoke when behavior is user-visible. |
+| WSL/X11/GLW UI behavior | Launch GLW on the target X11/WSL environment and capture logs. |
+| Screenshot API or UI capture | Verify `/api/screenshot/raw` returns a PNG. |
+| WebP or image pipeline | Verify direct WebP URL and `/api/image` content type. |
+| FFmpeg, HLS, demux, decode, audio, or media playback | Play a small local file or HLS URL and capture logs. Screenshots alone are not enough. |
+| GLW recorder, muxing, encoder, or packet timestamps | Use a debug build with recorder enabled and verify the output container with `ffprobe`. |
+| Plugin route or plugin API behavior | Use `support/plugin-smoke/run-plugin-smoke.sh` with an isolated profile. |
+
+## HTTP Screenshot Smoke
+
+When a display is available and the HTTP API is enabled, start Movian with an
+isolated profile:
+
+```sh
+rm -rf /tmp/movian-screenshot-smoke
+mkdir -p /tmp/movian-screenshot-smoke
+
+./build.debug/movian \
+  -d \
+  --disable-upgrades \
+  --persistent /tmp/movian-screenshot-smoke/persistent \
+  --cache /tmp/movian-screenshot-smoke/cache \
+  > /tmp/movian-screenshot-smoke/movian.log 2>&1 &
+MOVIAN_PID=$!
+```
+
+Wait for the log line containing `http-server: Listening on port`, then fetch a
+PNG:
+
+```sh
+PORT=$(sed -n 's/.*http-server: Listening on port \([0-9][0-9]*\).*/\1/p' \
+  /tmp/movian-screenshot-smoke/movian.log | tail -1)
+
+curl -fsS "http://127.0.0.1:${PORT}/api/screenshot/raw" \
+  -o /tmp/movian-screenshot-smoke/screenshot.png
+
+file /tmp/movian-screenshot-smoke/screenshot.png
+kill "$MOVIAN_PID"
+```
+
+Expected result:
+
+- `file` reports a PNG image.
+- Keep `movian.log` and `screenshot.png` if the smoke is used as PR evidence.
+
+If startup or capture takes more than two minutes, stop the run, keep the log,
+and treat it as a manual follow-up.
+
+## Media Smoke
+
+For FFmpeg, HLS, demux, decode, audio, Flatpak runtime, or image decoder
+changes, record the exact media input used. Prefer a small local sample or a
+stable short HLS URL:
+
+```sh
+rm -rf /tmp/movian-media-smoke
+mkdir -p /tmp/movian-media-smoke
+
+./build.debug/movian \
+  -d \
+  --disable-upgrades \
+  --persistent /tmp/movian-media-smoke/persistent \
+  --cache /tmp/movian-media-smoke/cache \
+  "file:///absolute/path/to/sample.mp4" \
+  > /tmp/movian-media-smoke/movian.log 2>&1
+```
+
+Expected result:
+
+- playback starts without crash or decoder fatal errors;
+- the log does not contain unexpected media pipeline errors;
+- if the change is Flatpak-specific, repeat the same input through the Flatpak
+  package when practical.
+
+## Steam Deck Manual Smoke
+
+Use this when the branch affects Flatpak launch behavior, fullscreen, Steam
+Input, sandbox permissions, installed metadata, or anything visible to Deck
+users.
+
+Install the generated bundle in Desktop Mode:
+
+```sh
+flatpak install --user --reinstall --bundle \
+  ~/Downloads/dev.uzver.Movian.flatpak
+```
+
+Checklist:
+
+- Discover shows the same version as `flatpak info` and Movian About/log.
+- Desktop Mode launch opens the GLW UI.
+- Gaming Mode launch opens through `Movian (GameMode)` or a Non-Steam Game.
+- Fullscreen does not loop or bounce back to the Steam loading screen.
+- Steam Input keyboard mapping can navigate the UI.
+- Installed plugins and settings survive restart.
+- A direct WebP URL opens as an image.
+- `/api/screenshot/raw` returns a PNG when the HTTP API is enabled.
+- `Alt+F12` does not record or crash the Flatpak build.
+
+Record the bundle SHA256 and any manual notes in the PR.
+
+## Evidence To Keep
+
+For every PR, keep the evidence proportional to the change:
+
+- branch name and commit SHA;
+- exact configure/build commands;
+- `./build.debug/movian --help` or Flatpak `/app/bin/showtime --help` version;
+- AppStream and desktop validation result for Flatpak changes;
+- bundle SHA256 when manually installed;
+- runtime log directory for UI/media/plugin smoke;
+- screenshot or media output details when the PR touches those paths.
+
+Do not include local-only source trees or personal paths as public evidence. Use
+paths from this checkout or temporary smoke directories.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,14 @@ The reusable runner lives under:
 
 - `support/plugin-smoke/`
 
+## Smoke Checklist
+
+Use the Linux/Flatpak smoke checklist when preparing public branches that touch
+build, packaging, media, image, screenshot, plugin runtime, WSL, or Flatpak
+behavior:
+
+- `Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md`
+
 ## Runtime Changes
 
 The public stack currently includes these user-visible changes:

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -52,6 +52,12 @@ flatpak build build.flatpak-builder ldd /app/bin/showtime | \
 
 The dependency grep should be empty for this MVP profile.
 
+The full smoke checklist for Linux, Flatpak, runtime, and Steam Deck checks is:
+
+```text
+docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+```
+
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary

- Add a public Linux and Flatpak smoke checklist covering baseline builds, Flatpak validation, runtime smoke selection, screenshots, media playback, Steam Deck manual checks, and evidence to keep in PRs.
- Link the checklist from the root README, docs index, Flatpak/SteamOS guide, and Flatpak support README.

Closes #20.

## Checks

- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- `support/flatpak/build-local.sh`
- `flatpak build build.flatpak-builder /app/bin/showtime --help`
- `desktop-file-validate support/flatpak/dev.uzver.Movian.desktop support/flatpak/dev.uzver.Movian.GameMode.desktop`
- `appstreamcli validate --no-net build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml`
- forbidden dependency grep for `gtk|gdk|webkit|rtmp|dvd|vaapi|vdpau|libva|nvidia|cuda` was empty
- Flatpak config: `#define ENABLE_GLW_REC 0`
- Flatpak object list did not contain `glw_rec.o`

Flatpak bundle SHA256: `09e87669a35d5f01fdba3c4e25bcd26b1259dac278a19abfdb2ebc7e1921b5b0`