### PR TITLE
Add FFmpeg-backed RTMP protocol support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ SRCS-$(CONFIG_FTPCLIENT) += src/fileaccess/fa_ftp.c \
 
 SRCS-$(CONFIG_LIBAV) += \
 	src/fileaccess/fa_libav.c \
+	src/fileaccess/fa_ffmpeg_rtmp.c \
 	src/fileaccess/fa_backend.c \
 	src/fileaccess/fa_video.c \
 	src/fileaccess/fa_audio.c \

--- a/src/fileaccess/fa_ffmpeg_rtmp.c
+++ b/src/fileaccess/fa_ffmpeg_rtmp.c
@@ -1,0 +1,218 @@
+/*
+ *  Copyright (C) 2007-2015 Lonelycoder AB
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This program is also available under a commercial proprietary license.
+ *  For more information, contact andreas@lonelycoder.com
+ */
+
+#include "config.h"
+
+#if !ENABLE_LIBRTMP
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <libavformat/avio.h>
+#include <libavformat/avformat.h>
+
+#include "main.h"
+#include "fileaccess.h"
+#include "fa_proto.h"
+
+typedef struct ffmpeg_rtmp_handle {
+  fa_handle_t h;
+  AVIOContext *avio;
+  int64_t size;
+} ffmpeg_rtmp_handle_t;
+
+
+static const char *ffmpeg_rtmp_protocols[] = {
+  "rtmp",
+  "rtmpt",
+  "rtmpe",
+  "rtmps",
+  "rtmpte",
+  "rtmpts",
+  NULL,
+};
+
+
+static int
+ffmpeg_rtmp_match_proto(const char *prefix)
+{
+  for(int i = 0; ffmpeg_rtmp_protocols[i] != NULL; i++)
+    if(!strcmp(prefix, ffmpeg_rtmp_protocols[i]))
+      return 0;
+
+  return 1;
+}
+
+
+static void
+ffmpeg_rtmp_error(char *errbuf, size_t errlen, const char *prefix, int err)
+{
+  if(errbuf == NULL || errlen == 0)
+    return;
+
+  char msg[256];
+  if(av_strerror(err, msg, sizeof(msg)))
+    snprintf(msg, sizeof(msg), "libav error %d", err);
+
+  snprintf(errbuf, errlen, "%s: %s", prefix, msg);
+}
+
+
+static void
+ffmpeg_rtmp_init(void)
+{
+  avformat_network_init();
+}
+
+
+static fa_handle_t *
+ffmpeg_rtmp_open(fa_protocol_t *fap, const char *url, char *errbuf,
+                 size_t errlen, int flags, fa_open_extra_t *foe)
+{
+  (void)flags;
+  (void)foe;
+
+  AVIOContext *avio = NULL;
+  int err = avio_open2(&avio, url, AVIO_FLAG_READ, NULL, NULL);
+  if(err < 0) {
+    ffmpeg_rtmp_error(errbuf, errlen, "Unable to open RTMP URL", err);
+    return NULL;
+  }
+
+  ffmpeg_rtmp_handle_t *fh = calloc(1, sizeof(ffmpeg_rtmp_handle_t));
+  fh->h.fh_proto = fap;
+  fh->avio = avio;
+
+  fh->size = avio_size(avio);
+  if(fh->size < 0)
+    fh->size = -1;
+
+  return &fh->h;
+}
+
+
+static void
+ffmpeg_rtmp_close(fa_handle_t *handle)
+{
+  ffmpeg_rtmp_handle_t *fh = (ffmpeg_rtmp_handle_t *)handle;
+  avio_closep(&fh->avio);
+  free(fh);
+}
+
+
+static int
+ffmpeg_rtmp_read(fa_handle_t *handle, void *buf, size_t size)
+{
+  ffmpeg_rtmp_handle_t *fh = (ffmpeg_rtmp_handle_t *)handle;
+  int r = avio_read(fh->avio, buf, size);
+  return r == AVERROR_EOF ? 0 : r;
+}
+
+
+static int64_t
+ffmpeg_rtmp_seek(fa_handle_t *handle, int64_t pos, int whence, int lazy)
+{
+  (void)lazy;
+
+  ffmpeg_rtmp_handle_t *fh = (ffmpeg_rtmp_handle_t *)handle;
+
+  if(whence == SEEK_END && fh->size < 0)
+    return -1;
+
+  int64_t r = avio_seek(fh->avio, pos, whence);
+  return r < 0 ? -1 : r;
+}
+
+
+static int64_t
+ffmpeg_rtmp_fsize(fa_handle_t *handle)
+{
+  ffmpeg_rtmp_handle_t *fh = (ffmpeg_rtmp_handle_t *)handle;
+  return fh->size;
+}
+
+
+static int
+ffmpeg_rtmp_stat(fa_protocol_t *fap, const char *url, struct fa_stat *fs,
+                 int flags, char *errbuf, size_t errlen)
+{
+  (void)fap;
+  (void)url;
+  (void)flags;
+  (void)errbuf;
+  (void)errlen;
+
+  memset(fs, 0, sizeof(struct fa_stat));
+  fs->fs_size = -1;
+  fs->fs_type = CONTENT_FILE;
+  return 0;
+}
+
+
+static void
+ffmpeg_rtmp_get_last_component(fa_protocol_t *fap, const char *url,
+                               char *dst, size_t dstlen)
+{
+  (void)fap;
+
+  int e, b;
+
+  if(dstlen == 0)
+    return;
+
+  for(e = 0; url[e] != 0 && url[e] != '?'; e++);
+  if(e > 0 && url[e - 1] == '/')
+    e--;
+
+  if(e == 0) {
+    *dst = 0;
+    return;
+  }
+
+  for(b = e; b > 0; b--)
+    if(url[b - 1] == '/')
+      break;
+
+  if(dstlen > e - b + 1)
+    dstlen = e - b + 1;
+
+  memcpy(dst, url + b, dstlen);
+  dst[dstlen - 1] = 0;
+}
+
+
+static fa_protocol_t fa_protocol_ffmpeg_rtmp = {
+  .fap_init  = ffmpeg_rtmp_init,
+  .fap_flags = FAP_INCLUDE_PROTO_IN_URL,
+  .fap_name  = "ffmpeg-rtmp",
+  .fap_match_proto = ffmpeg_rtmp_match_proto,
+  .fap_open  = ffmpeg_rtmp_open,
+  .fap_close = ffmpeg_rtmp_close,
+  .fap_read  = ffmpeg_rtmp_read,
+  .fap_seek  = ffmpeg_rtmp_seek,
+  .fap_fsize = ffmpeg_rtmp_fsize,
+  .fap_stat  = ffmpeg_rtmp_stat,
+  .fap_get_last_component = ffmpeg_rtmp_get_last_component,
+};
+
+FAP_REGISTER(ffmpeg_rtmp);
+
+#endif // !ENABLE_LIBRTMP

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -571,6 +571,8 @@ EOF
 
     if enabled libav; then
 	echo >>${CONFIG_MAK} "LDFLAGS_cfg += -lavresample -lswscale -lavformat -lavcodec -lswresample -lavutil"
+	libav_extra_libs=$(sed -n 's/^EXTRALIBS-\(avformat\|avcodec\|avresample\|swresample\|swscale\|avutil\)=//p' "${LIBAV_BUILD_DIR}/ffbuild/config.mak" | tr '\n' ' ')
+	echo >>${CONFIG_MAK} "LDFLAGS_cfg += ${libav_extra_libs}"
     fi
 
     if enabled libcec; then

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -47,10 +47,12 @@ appstreamcli validate --no-net \
 flatpak build build.flatpak-builder /app/bin/showtime --help
 
 flatpak build build.flatpak-builder ldd /app/bin/showtime | \
-  grep -Ei 'gtk|gdk|webkit|rtmp|dvd|vaapi|vdpau|libva|nvidia' || true
+  grep -Ei 'gtk|gdk|webkit|librtmp|dvd|vaapi|vdpau|libva|nvidia|gmp|gnutls' || true
 ```
 
-The dependency grep should be empty for this MVP profile.
+The dependency grep should not show GTK/WebKit, DVD, VAAPI, VDPAU, Nvidia,
+or external `librtmp` dependencies. `libgmp` and `libgnutls` are expected
+because they enable FFmpeg's native RTMP-family protocol support.
 
 The full smoke checklist for Linux, Flatpak, runtime, and Steam Deck checks is:
 
@@ -79,6 +81,20 @@ The manifest disables the hidden GLW recorder:
 
 That keeps the release-oriented Flatpak from writing large debug
 `capture.mkv` files. The `Alt+F12` recorder hotkey is a no-op in this build.
+
+The manifest enables bundled FFmpeg protocol helpers:
+
+```text
+--enable-version3
+--enable-gmp
+--enable-gnutls
+```
+
+`gmp` enables FFmpeg's RTMPE crypt helper, while `gnutls` enables FFmpeg TLS
+and HTTPS protocols. `--enable-version3` is required by FFmpeg when `gmp` is
+enabled. Together these flags allow native FFmpeg support for `rtmpe://`,
+`rtmps://`, `rtmpte://`, and `rtmpts://` without enabling the old external
+`librtmp` backend.
 
 The package persists Movian's legacy state and cache:
 

--- a/support/flatpak/dev.uzver.Movian.yml
+++ b/support/flatpak/dev.uzver.Movian.yml
@@ -37,6 +37,9 @@ modules:
           --disable-ffnvcodec
           --disable-nvdec
           --disable-v4l2-m2m
+          --enable-version3
+          --enable-gmp
+          --enable-gnutls
     build-commands:
       - rm -rf build.flatpak
       - >-


### PR DESCRIPTION
## Summary

- enable bundled FFmpeg RTMPE/RTMPS protocol support for the Flatpak build with `gmp` and `gnutls`
- include FFmpeg-generated static `EXTRALIBS-*` in Movian's libav link step so optional FFmpeg external libraries link cleanly
- add an FFmpeg-backed fileaccess protocol for `rtmp`, `rtmpt`, `rtmpe`, `rtmps`, `rtmpte`, and `rtmpts` when the old `librtmp` backend is disabled

Refs #31.

## Notes

The old `librtmp` backend is untouched and still owns RTMP URLs in builds where `CONFIG_LIBRTMP` is enabled. The new bridge registers only in `--disable-librtmp` builds.

`--enable-gcrypt --enable-gnutls` was considered, but FFmpeg 4.4.7's gcrypt-backed RTMP DH code failed to compile cleanly in the Freedesktop SDK. `gmp + gnutls + --enable-version3` builds and enables the same RTMP-family protocol coverage.

## Verification

- `git diff --check HEAD~2..HEAD`
- SDK debug configure/build with `--disable-librtmp` and FFmpeg `--enable-version3 --enable-gmp --enable-gnutls`
- `./build.debug-ffrtmp-sdk-gmp/movian --help` inside Freedesktop SDK
- verified FFmpeg config symbols: `CONFIG_GMP`, `CONFIG_GNUTLS`, `CONFIG_FFRTMPCRYPT_PROTOCOL`, `CONFIG_TLS_PROTOCOL`, `CONFIG_HTTPS_PROTOCOL`, `CONFIG_RTMPE_PROTOCOL`, `CONFIG_RTMPS_PROTOCOL`, `CONFIG_RTMPTE_PROTOCOL`, `CONFIG_RTMPTS_PROTOCOL`
- `support/flatpak/build-local.sh`
- `flatpak build build.flatpak-builder /app/bin/showtime --help`
- `desktop-file-validate support/flatpak/dev.uzver.Movian.desktop support/flatpak/dev.uzver.Movian.GameMode.desktop`
- `appstreamcli validate --no-net build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml`
- negative RTMP smoke against `rtmp://127.0.0.1:1/live/test` reached FFmpeg RTMP connection handling instead of unsupported-protocol handling