### PR TITLE
Fix FFmpeg RTMP fallback playback and add smoke tests

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,9 @@ The `movian6` branch includes:
 - bundled FFmpeg 4.4.7 media backend with existing `libav` option names kept
   for compatibility;
 - local SteamOS/Steam Deck Flatpak packaging;
-- a documented plugin debug workflow.
+- a documented plugin debug workflow;
+- documented public-branch patterns for build, packaging, media, and smoke
+  work.
 
 ## Linux Debug Build
 
@@ -111,6 +113,8 @@ More details:
   served from `/api/image` as `image/webp`.
 - Existing command-line names such as `--libav-log` are preserved while the
   bundled backend uses FFmpeg 4.4.7.
+- Flatpak builds use FFmpeg's RTMP-family protocols through SDK `gmp` and
+  `gnutls`, while the old external `librtmp` backend remains disabled there.
 - Steam launches avoid the X11 fullscreen path that can bounce back to the
   Steam loading screen.
 - The hidden GLW recorder is treated as a developer/debug aid. Linux debug
@@ -157,6 +161,7 @@ More details:
 
 - `docs/README.md`
 - `docs/Guides/BUNDLED_MODULE_UPDATE_PLAN.md`
+- `docs/Guides/PUBLIC_WORK_PATTERNS.md`
 - `docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md`
 - `docs/Guides/FLATPAK_STEAMOS_GUIDE.md`
 - `docs/Guides/PLUGIN_DEBUG_WORKFLOW.md`
@@ -172,7 +177,7 @@ Out of scope for the current stack:
 - Flathub-ready pinned source archives and hashes.
 - VAAPI or other hardware decode paths.
 - Native `/dev/input/event*` controller input in the Flatpak sandbox.
-- DVD and RTMP support in the Flatpak profile.
+- DVD support in the Flatpak profile.
 - Broad filesystem access beyond common read-only XDG media folders.
 
 ## Upstream

--- a/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+++ b/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
@@ -175,6 +175,30 @@ Expected result:
 - if the change is Flatpak-specific, repeat the same input through the Flatpak
   package when practical.
 
+### Local RTMP Smoke
+
+Use this when RTMP handling or the FFmpeg-backed RTMP fallback changes. The
+script starts a local synthetic RTMP stream with `ffmpeg`, opens it through the
+HTTP API, and keeps the Movian/server logs as artifacts:
+
+```sh
+./support/configure-linux-debug.sh --build=debug-ffrtmp-smoke --disable-librtmp
+make BUILD=debug-ffrtmp-smoke -j$(nproc)
+
+MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian \
+  support/rtmp-smoke/run-rtmp-smoke.sh
+```
+
+Expected result:
+
+- the log contains `Probed as flv`;
+- playback starts for the local `rtmp://127.0.0.1:.../live/test` URL;
+- the detected streams include H.264 video and AAC audio;
+- the current media URL property points at the local RTMP URL.
+
+Use the normal Flatpak build checks as well when RTMP behavior changed in the
+Flatpak profile.
+
 ## Steam Deck Manual Smoke
 
 Use this when the branch affects Flatpak launch behavior, fullscreen, Steam

--- a/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+++ b/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
@@ -217,6 +217,36 @@ system libraries at configure time.
 Use the normal Flatpak build checks as well when RTMP behavior changed in the
 Flatpak profile.
 
+### Local RTMPS Smoke
+
+Use this after Flatpak RTMP-family changes, or when validating TLS-backed RTMP
+playback. The helper starts MediaMTX in Docker with a temporary self-signed
+certificate, publishes a synthetic RTMP stream with `ffmpeg`, then opens it from
+Movian through `rtmps://`.
+
+```sh
+support/flatpak/build-local.sh
+
+support/rtmp-smoke/run-rtmps-mediamtx-smoke.sh
+```
+
+If `MOVIAN_BIN` is unset, the helper uses a temporary wrapper around:
+
+```sh
+flatpak build build.flatpak-builder /app/bin/showtime
+```
+
+Expected result:
+
+- MediaMTX starts from `bluenviron/mediamtx:1`;
+- playback starts for `rtmps://127.0.0.1:19397/live/test`;
+- the detected streams include H.264 video and AAC audio;
+- the current media URL property points at the RTMPS URL.
+
+Artifacts are stored under `/tmp/movian-rtmps-smoke` by default. Keep
+`summary.txt`, `mediamtx.log`, `ffmpeg-publisher.log`, and the nested Movian
+artifacts when the smoke is used as PR evidence.
+
 ## Steam Deck Manual Smoke
 
 Use this when the branch affects Flatpak launch behavior, fullscreen, Steam

--- a/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+++ b/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
@@ -196,6 +196,24 @@ Expected result:
 - the detected streams include H.264 video and AAC audio;
 - the current media URL property points at the local RTMP URL.
 
+For a manual external RTMP-family smoke, pass a live URL through the environment
+instead of committing it into the repository:
+
+```sh
+RTMP_URL='rtmp://example.invalid/live/stream' \
+MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian \
+  support/rtmp-smoke/run-rtmp-smoke.sh
+```
+
+Optional external URLs are useful PR evidence, but they should not be treated as
+stable CI inputs. Keep the exact URL and artifacts in the PR or issue notes when
+the source is temporary.
+
+For `rtmpe`, `rtmps`, `rtmpte`, or `rtmpts`, use the Flatpak profile or another
+build whose bundled FFmpeg config enables `gmp` and `gnutls`. The ordinary host
+debug profile may only cover plain `rtmp` and `rtmpt`, depending on available
+system libraries at configure time.
+
 Use the normal Flatpak build checks as well when RTMP behavior changed in the
 Flatpak profile.
 

--- a/docs/Guides/PUBLIC_WORK_PATTERNS.md
+++ b/docs/Guides/PUBLIC_WORK_PATTERNS.md
@@ -1,0 +1,202 @@
+# Public Work Patterns
+
+Use these patterns when preparing small public branches for the `movian6`
+line. They are based on changes that have already built, run, and reviewed
+cleanly in this checkout.
+
+## Branch Shape
+
+- Start each change from current `movian6`.
+- Keep one behavior or one documentation/tooling improvement per branch.
+- Split commits by purpose: runtime fix, packaging change, smoke helper, docs.
+- Do not rename old public concepts just because the implementation changed.
+  Compatibility names such as `libav` options and `showtime` binary paths are
+  part of the existing surface.
+- Do not push until push is explicitly requested.
+- After a merge, fast-forward local `movian6`, delete merged `public/*`
+  branches, and update the local session handoff before starting the next task.
+
+## Session Handoff
+
+- Keep a short ignored local session note with the current branch, last merged
+  PR, active issue, commands already run, and the next safe step.
+- Update the note after every merge and before risky branch switches.
+- Treat the note as operator state, not project documentation. Do not commit it
+  unless it has been deliberately rewritten as a public guide.
+- When a session resumes after a tool or editor restart, check the note first,
+  then confirm with `git status --short --branch` before editing.
+
+## Post-Merge Hygiene
+
+- After merging a PR, fast-forward local `movian6` before starting new work.
+- Remove merged local and remote topic branches once the merge is visible.
+- Run the smallest relevant post-merge smoke:
+  - debug build and `--help` for Linux build changes;
+  - Flatpak local build and metadata validation for packaging changes;
+  - targeted HTTP/API smoke for runtime behavior changes.
+- Record the result in the session note or issue before opening the next branch.
+
+## Public-Safe Implementation
+
+- Prefer clean-room patches on top of upstream `movian6`.
+- Use reference material only to understand desired behavior, then implement the
+  smallest independent public patch.
+- Avoid local machine paths, personal source tree names, and internal project
+  names in public docs, commits, issues, and pull requests.
+- For compatibility fixes, keep existing APIs working and add aliases or
+  wrappers instead of replacing old spellings in the same branch.
+- When a long-standing typo is script-visible, keep the old spelling and add the
+  corrected spelling as an alias in a separate compatibility patch.
+
+## Configure And Build Profiles
+
+- Keep the default Linux debug path boring:
+
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
+
+- Use separate build names for risky checks:
+
+```sh
+./support/configure-linux-debug.sh --build=debug-feature-smoke --disable-librtmp
+make BUILD=debug-feature-smoke -j$(nproc)
+```
+
+- Do not overload `build.debug` when a branch needs an alternate feature matrix.
+  A named build directory makes logs and comparisons much easier.
+- Keep WSL behavior runtime-detected when possible. Avoid adding configure
+  switches for environment quirks unless the build genuinely needs them.
+- Let Flatpak be a release-oriented profile. Debug-only developer tools should
+  stay enabled in Linux debug builds and disabled in release/Flatpak unless the
+  branch intentionally changes that policy.
+
+## Feature Gating
+
+- Preserve the old implementation when it is enabled and add new fallback code
+  only behind the inverse feature gate. For example, the FFmpeg RTMP fallback is
+  compiled only when `ENABLE_LIBRTMP` is false.
+- Disabled runtime actions should be safe no-ops, not crashes. The GLW recorder
+  hotkey is the model: debug builds can keep the tool, while release/Flatpak
+  builds consume the hotkey without recording.
+- Keep fallback protocols explicit. Register exactly the schemes the fallback
+  owns and let the old backend win when it is compiled in.
+
+## Backend And Fileaccess
+
+- Check resolver semantics before reusing helpers. Fileaccess protocol matching
+  treats `0` as a match, while backend `canhandle()` returns a positive score.
+- If a protocol is playable media, a fileaccess implementation may not be
+  enough. Add a small backend wrapper when the generic file backend would make
+  the wrong assumptions.
+- Live streams should normally be treated as non-seekable:
+  - keep size unknown;
+  - return unsupported for seek;
+  - skip filesystem and subtitle scans;
+  - avoid probing size with APIs that may consume stream data.
+- Verify that the playback path reaches media decode, not just network connect.
+  Useful log anchors are `Probed as`, `Starting playback`, stream summaries,
+  and `global/media/current/url`.
+
+## FFmpeg And Static Linking
+
+- Prefer upstream release tags for bundled FFmpeg updates. The current baseline
+  uses FFmpeg `n4.4.7`.
+- Keep existing user-facing option names where renaming would create churn.
+- Put API compatibility shims in a small compatibility header instead of
+  scattering version checks through unrelated code.
+- When enabling optional FFmpeg libraries in a static build, import FFmpeg's
+  generated `EXTRALIBS-*` values from `ffbuild/config.mak`. Otherwise optional
+  dependencies may configure successfully and fail only at final link.
+- For Flatpak RTMP-family protocol support, the successful SDK flags are:
+
+```text
+--enable-version3
+--enable-gmp
+--enable-gnutls
+```
+
+`gmp` enables FFmpeg's RTMP encrypted helper, and `gnutls` enables TLS-backed
+protocols such as `rtmps`.
+
+## Flatpak Packaging
+
+- Keep the local Flatpak manifest focused on sideload testing, not Flathub
+  publishing.
+- Prefer SDK-provided libraries over bundling more source when the SDK already
+  carries the dependency.
+- Generate AppStream release version from `git describe` so Discover,
+  `flatpak info`, logs, and About agree.
+- Install the app icon from a repository image asset and remove old conflicting
+  desktop/icon names from the image.
+- Validate both metadata and runtime linkage:
+
+```sh
+support/flatpak/build-local.sh
+flatpak build build.flatpak-builder /app/bin/showtime --help
+desktop-file-validate support/flatpak/dev.uzver.Movian.desktop \
+  support/flatpak/dev.uzver.Movian.GameMode.desktop
+appstreamcli validate --no-net \
+  build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml
+flatpak build build.flatpak-builder ldd /app/bin/showtime |
+  rg -i 'gnutls|gmp|librtmp|gtk|gdk|webkit|dvd|vaapi|vdpau|libva|nvidia|cuda' || true
+```
+
+For the current Flatpak RTMP profile, `libgmp` and `libgnutls` are expected;
+external `librtmp`, GTK/WebKit, DVD, VAAPI, VDPAU, and GPU-vendor libraries are
+not expected.
+
+## Smoke Tests
+
+- A good smoke test proves the smallest behavior that can regress.
+- Prefer synthetic local inputs over public network resources:
+  - generated PNG/WebP files for image paths;
+  - generated HLS or RTMP streams for media paths;
+  - isolated plugin fixtures for route and prop behavior.
+- Start Movian with isolated state:
+
+```sh
+--disable-upgrades \
+--persistent /tmp/movian-feature-smoke/persistent \
+--cache /tmp/movian-feature-smoke/cache
+```
+
+- Use the HTTP API for repeatable runtime checks:
+  - `/api/open` for navigation and media open;
+  - `/api/prop/...` for state assertions;
+  - `/api/screenshot/raw` for capture;
+  - `/api/image` for image payload checks.
+- Assert state, not just logs. Logs tell the story, props prove the current
+  model changed.
+- Store artifacts under `/tmp/movian-*-smoke` and keep:
+  - command or summary;
+  - Movian log;
+  - generated input/server log;
+  - prop state or screenshot when relevant.
+- If a UI or runtime wait exceeds two minutes, stop the run and keep artifacts
+  instead of letting it drift.
+
+## Pull Request Evidence
+
+Every public pull request should include:
+
+- branch name and commit list;
+- concise behavior summary;
+- exact configure/build commands;
+- runtime smoke command and artifact path;
+- Flatpak validation when packaging or release behavior changes;
+- dependency grep output when library surface changes;
+- issue link when the branch closes or advances an issue.
+
+Keep PR descriptions factual. Avoid local-only source paths and internal names.
+
+## Issues As Backlog
+
+- Use issues for work that should survive session loss.
+- Close issues only when the branch fully resolves them.
+- If a branch solves part of an issue, reference it in the PR and leave the
+  issue open with the remaining smoke or design work.
+- Split follow-ups when the next step has a different risk profile. Example:
+  release recorder policy and compressed recorder profiles are different tasks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,9 @@ The current branch includes:
   option names and internal build variables for compatibility;
 - local SteamOS/Steam Deck Flatpak packaging and small Linux runtime fixes used
   by that package;
-- a plugin debug workflow for route smoke tests against `build.debug/movian`.
+- a plugin debug workflow for route smoke tests against `build.debug/movian`;
+- repeatable public-branch patterns for build, packaging, media, and smoke
+  work.
 
 ## Linux Build
 
@@ -67,6 +69,11 @@ behavior:
 
 - `Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md`
 
+For branch structure, compatibility, feature gating, Flatpak validation, and
+runtime smoke patterns, use:
+
+- `Guides/PUBLIC_WORK_PATTERNS.md`
+
 ## Bundled Modules
 
 Use the bundled module update plan before changing submodule pointers or
@@ -89,6 +96,9 @@ The public stack currently includes these user-visible changes:
   `image/webp` for WebP payloads.
 - The bundled media backend is FFmpeg 4.4.7. Existing command-line and helper
   names such as `--libav-log` remain unchanged.
+- Flatpak builds use FFmpeg's RTMP-family protocols with SDK `gmp` and
+  `gnutls`, while leaving the old external `librtmp` backend disabled in that
+  profile.
 - Steam launches avoid the X11 fullscreen `override_redirect` path when
   `SteamGameId` or `SteamAppId` is set. `XK_Menu` maps to Movian's menu action
   for Steam Input keyboard layouts.
@@ -122,5 +132,5 @@ These are intentionally left for later branches:
 - Flathub-ready pinned source archives and hashes.
 - VAAPI or other hardware decode paths.
 - Native `/dev/input/event*` controller input in the Flatpak sandbox.
-- DVD and RTMP support in the Flatpak profile.
+- DVD support in the Flatpak profile.
 - Broader filesystem permissions such as removable media paths.

--- a/src/fileaccess/fa_ffmpeg_rtmp.c
+++ b/src/fileaccess/fa_ffmpeg_rtmp.c
@@ -30,8 +30,10 @@
 #include <libavformat/avformat.h>
 
 #include "main.h"
+#include "backend/backend.h"
 #include "fileaccess.h"
 #include "fa_proto.h"
+#include "fa_video.h"
 
 typedef struct ffmpeg_rtmp_handle {
   fa_handle_t h;
@@ -59,6 +61,20 @@ ffmpeg_rtmp_match_proto(const char *prefix)
       return 0;
 
   return 1;
+}
+
+
+static int
+ffmpeg_rtmp_canhandle(const char *url)
+{
+  for(int i = 0; ffmpeg_rtmp_protocols[i] != NULL; i++) {
+    const char *proto = ffmpeg_rtmp_protocols[i];
+    size_t len = strlen(proto);
+    if(!strncmp(url, proto, len) && !strncmp(url + len, "://", 3))
+      return 10;
+  }
+
+  return 0;
 }
 
 
@@ -100,10 +116,7 @@ ffmpeg_rtmp_open(fa_protocol_t *fap, const char *url, char *errbuf,
   ffmpeg_rtmp_handle_t *fh = calloc(1, sizeof(ffmpeg_rtmp_handle_t));
   fh->h.fh_proto = fap;
   fh->avio = avio;
-
-  fh->size = avio_size(avio);
-  if(fh->size < 0)
-    fh->size = -1;
+  fh->size = -1;
 
   return &fh->h;
 }
@@ -130,15 +143,12 @@ ffmpeg_rtmp_read(fa_handle_t *handle, void *buf, size_t size)
 static int64_t
 ffmpeg_rtmp_seek(fa_handle_t *handle, int64_t pos, int whence, int lazy)
 {
+  (void)handle;
+  (void)pos;
+  (void)whence;
   (void)lazy;
 
-  ffmpeg_rtmp_handle_t *fh = (ffmpeg_rtmp_handle_t *)handle;
-
-  if(whence == SEEK_END && fh->size < 0)
-    return -1;
-
-  int64_t r = avio_seek(fh->avio, pos, whence);
-  return r < 0 ? -1 : r;
+  return -1;
 }
 
 
@@ -199,6 +209,26 @@ ffmpeg_rtmp_get_last_component(fa_protocol_t *fap, const char *url,
 }
 
 
+static int
+ffmpeg_rtmp_backend_open(prop_t *page, const char *url, int sync)
+{
+  return backend_open_video(page, url, sync);
+}
+
+
+static event_t *
+ffmpeg_rtmp_backend_playvideo(const char *url, media_pipe_t *mp,
+                              char *errbuf, size_t errlen,
+                              video_queue_t *vq, struct vsource_list *vsl,
+                              const video_args_t *va0)
+{
+  video_args_t va = *va0;
+
+  va.flags |= BACKEND_VIDEO_NO_FS_SCAN | BACKEND_VIDEO_NO_SUBTITLE_SCAN;
+  return be_file_playvideo(url, mp, errbuf, errlen, vq, vsl, &va);
+}
+
+
 static fa_protocol_t fa_protocol_ffmpeg_rtmp = {
   .fap_init  = ffmpeg_rtmp_init,
   .fap_flags = FAP_INCLUDE_PROTO_IN_URL,
@@ -214,5 +244,14 @@ static fa_protocol_t fa_protocol_ffmpeg_rtmp = {
 };
 
 FAP_REGISTER(ffmpeg_rtmp);
+
+
+static backend_t be_ffmpeg_rtmp = {
+  .be_canhandle = ffmpeg_rtmp_canhandle,
+  .be_open = ffmpeg_rtmp_backend_open,
+  .be_play_video = ffmpeg_rtmp_backend_playvideo,
+};
+
+BE_REGISTER(ffmpeg_rtmp);
 
 #endif // !ENABLE_LIBRTMP

--- a/support/rtmp-smoke/run-rtmp-smoke.sh
+++ b/support/rtmp-smoke/run-rtmp-smoke.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MOVIAN_BIN=${MOVIAN_BIN:-./build.debug/movian}
+ARTIFACTS=${ARTIFACTS:-/tmp/movian-rtmp-smoke}
+PORT=${PORT:-19368}
+STREAM_SECONDS=${STREAM_SECONDS:-60}
+WAIT_SECONDS=${WAIT_SECONDS:-40}
+ALLOW_EXISTING_MOVIAN=${ALLOW_EXISTING_MOVIAN:-0}
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian \
+    support/rtmp-smoke/run-rtmp-smoke.sh
+
+Environment:
+  MOVIAN_BIN              Movian binary to test (default: ./build.debug/movian)
+  ARTIFACTS               Artifact directory (default: /tmp/movian-rtmp-smoke)
+  PORT                    Local RTMP port (default: 19368)
+  STREAM_SECONDS          Synthetic stream duration (default: 60)
+  WAIT_SECONDS            Startup/playback timeout (default: 40)
+  ALLOW_EXISTING_MOVIAN=1 Allow another Movian process to already be running
+
+The target Movian build should be configured without the old librtmp backend
+when validating the FFmpeg-backed RTMP fallback path.
+USAGE
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  if [ -n "${LOG:-}" ] && [ -f "$LOG" ]; then
+    tail -n 200 "$LOG" >"$ARTIFACTS/movian-tail.txt" || true
+    echo "Saved log tail: $ARTIFACTS/movian-tail.txt" >&2
+  fi
+  exit 1
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+[ -x "$MOVIAN_BIN" ] || fail "Movian binary is not executable: $MOVIAN_BIN"
+command -v ffmpeg >/dev/null 2>&1 || fail "ffmpeg is required"
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+case "$PORT" in
+  ''|*[!0-9]*) fail "PORT must be a positive integer, got: $PORT" ;;
+esac
+
+case "$STREAM_SECONDS" in
+  ''|*[!0-9]*) fail "STREAM_SECONDS must be a positive integer, got: $STREAM_SECONDS" ;;
+esac
+
+case "$WAIT_SECONDS" in
+  ''|*[!0-9]*) fail "WAIT_SECONDS must be a positive integer, got: $WAIT_SECONDS" ;;
+esac
+
+if [ "$ALLOW_EXISTING_MOVIAN" != "1" ]; then
+  existing=$(pgrep -a -f '/movian( |$)|build\.(debug|release|debug-gdb|asan|debug-ffrtmp-smoke)/movian' || true)
+  [ -z "$existing" ] || fail "Movian already appears to be running. Set ALLOW_EXISTING_MOVIAN=1 to continue.
+$existing"
+fi
+
+rm -rf "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
+
+LOG="$ARTIFACTS/movian.log"
+SERVER_LOG="$ARTIFACTS/ffmpeg-server.log"
+URL="rtmp://127.0.0.1:${PORT}/live/test"
+
+ffmpeg -hide_banner -loglevel info -nostdin -re \
+  -f lavfi -i testsrc2=size=320x180:rate=15 \
+  -f lavfi -i sine=frequency=880:sample_rate=44100 \
+  -t "$STREAM_SECONDS" \
+  -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p -g 15 \
+  -c:a aac -b:a 96k \
+  -f flv -listen 1 "$URL" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+"$MOVIAN_BIN" \
+  -d \
+  --libav-log \
+  --disable-upgrades \
+  --persistent "$ARTIFACTS/persistent" \
+  --cache "$ARTIFACTS/cache" \
+  >"$LOG" 2>&1 &
+MOVIAN_PID=$!
+
+cleanup() {
+  kill "$MOVIAN_PID" "$SERVER_PID" 2>/dev/null || true
+  wait "$MOVIAN_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_log() {
+  pattern=$1
+  label=$2
+  ticks=$((WAIT_SECONDS * 4))
+
+  for _ in $(seq 1 "$ticks"); do
+    if grep -Eq "$pattern" "$LOG"; then
+      return 0
+    fi
+    kill -0 "$MOVIAN_PID" 2>/dev/null || fail "Movian exited while waiting for $label"
+    kill -0 "$SERVER_PID" 2>/dev/null || fail "ffmpeg RTMP server exited while waiting for $label"
+    sleep 0.25
+  done
+
+  fail "Timed out waiting for $label: $pattern"
+}
+
+wait_log_fixed() {
+  pattern=$1
+  label=$2
+  ticks=$((WAIT_SECONDS * 4))
+
+  for _ in $(seq 1 "$ticks"); do
+    if grep -Fq "$pattern" "$LOG"; then
+      return 0
+    fi
+    kill -0 "$MOVIAN_PID" 2>/dev/null || fail "Movian exited while waiting for $label"
+    kill -0 "$SERVER_PID" 2>/dev/null || fail "ffmpeg RTMP server exited while waiting for $label"
+    sleep 0.25
+  done
+
+  fail "Timed out waiting for $label: $pattern"
+}
+
+wait_log "http-server: Listening on port [0-9]+" "HTTP server"
+wait_log_fixed "UI size scale changed" "GLW startup"
+
+HTTP_PORT=$(sed -n 's/.*http-server: Listening on port \([0-9][0-9]*\).*/\1/p' "$LOG" | tail -1)
+[ -n "$HTTP_PORT" ] || fail "Could not parse Movian HTTP port"
+BASE="http://127.0.0.1:$HTTP_PORT"
+
+printf '%s\n' "$URL" >"$ARTIFACTS/rtmp-url.txt"
+printf '%s\n' "$BASE" >"$ARTIFACTS/base-url.txt"
+
+sleep 1
+curl -fsS -L --get --data-urlencode "url=$URL" "$BASE/api/open" >"$ARTIFACTS/open.html"
+
+wait_log_fixed "Starting playback of $URL (flv)" "RTMP playback start"
+wait_log_fixed "Stream #0: Video: h264" "H.264 video stream"
+wait_log_fixed "Stream #1: Audio: aac" "AAC audio stream"
+
+{
+  echo "currentpage.source:"
+  curl -fsS "$BASE/api/prop/global/navigators/current/currentpage/source" || true
+  echo
+  echo "currentpage.model.type:"
+  curl -fsS "$BASE/api/prop/global/navigators/current/currentpage/model/type" || true
+  echo
+  echo "media.current.url:"
+  curl -fsS "$BASE/api/prop/global/media/current/url" || true
+  echo
+} >"$ARTIFACTS/props.txt"
+
+grep -Fq "is a $URL" "$ARTIFACTS/props.txt" ||
+  fail "Current media URL did not switch to $URL"
+
+{
+  echo "RTMP smoke passed"
+  echo "URL: $URL"
+  echo "Movian log: $LOG"
+  echo "ffmpeg server log: $SERVER_LOG"
+  echo "Props: $ARTIFACTS/props.txt"
+} | tee "$ARTIFACTS/summary.txt"

--- a/support/rtmp-smoke/run-rtmp-smoke.sh
+++ b/support/rtmp-smoke/run-rtmp-smoke.sh
@@ -7,6 +7,10 @@ PORT=${PORT:-19368}
 STREAM_SECONDS=${STREAM_SECONDS:-60}
 WAIT_SECONDS=${WAIT_SECONDS:-40}
 ALLOW_EXISTING_MOVIAN=${ALLOW_EXISTING_MOVIAN:-0}
+RTMP_URL=${RTMP_URL:-}
+EXPECT_CONTAINER=${EXPECT_CONTAINER:-flv}
+EXPECT_VIDEO=${EXPECT_VIDEO:-h264}
+EXPECT_AUDIO=${EXPECT_AUDIO:-aac}
 
 usage() {
   cat <<'USAGE'
@@ -21,6 +25,11 @@ Environment:
   STREAM_SECONDS          Synthetic stream duration (default: 60)
   WAIT_SECONDS            Startup/playback timeout (default: 40)
   ALLOW_EXISTING_MOVIAN=1 Allow another Movian process to already be running
+  RTMP_URL                Optional external RTMP-family URL. When set, the
+                          script skips the local ffmpeg RTMP server.
+  EXPECT_CONTAINER        Expected container in the playback log (default: flv)
+  EXPECT_VIDEO            Expected video codec in the playback log (default: h264)
+  EXPECT_AUDIO            Expected audio codec in the playback log (default: aac)
 
 The target Movian build should be configured without the old librtmp backend
 when validating the FFmpeg-backed RTMP fallback path.
@@ -42,8 +51,11 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
 fi
 
 [ -x "$MOVIAN_BIN" ] || fail "Movian binary is not executable: $MOVIAN_BIN"
-command -v ffmpeg >/dev/null 2>&1 || fail "ffmpeg is required"
 command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+if [ -z "$RTMP_URL" ]; then
+  command -v ffmpeg >/dev/null 2>&1 || fail "ffmpeg is required"
+fi
 
 case "$PORT" in
   ''|*[!0-9]*) fail "PORT must be a positive integer, got: $PORT" ;;
@@ -58,7 +70,11 @@ case "$WAIT_SECONDS" in
 esac
 
 if [ "$ALLOW_EXISTING_MOVIAN" != "1" ]; then
-  existing=$(pgrep -a -f '/movian( |$)|build\.(debug|release|debug-gdb|asan|debug-ffrtmp-smoke)/movian' || true)
+  existing=$(
+    pgrep -a -f '/movian( |$)|build\.(debug|release|debug-gdb|asan|debug-ffrtmp-smoke)/movian' |
+      awk -v self="$$" -v parent="$PPID" '$1 != self && $1 != parent { print }' ||
+      true
+  )
   [ -z "$existing" ] || fail "Movian already appears to be running. Set ALLOW_EXISTING_MOVIAN=1 to continue.
 $existing"
 fi
@@ -68,16 +84,26 @@ mkdir -p "$ARTIFACTS"
 
 LOG="$ARTIFACTS/movian.log"
 SERVER_LOG="$ARTIFACTS/ffmpeg-server.log"
-URL="rtmp://127.0.0.1:${PORT}/live/test"
+SERVER_PID=
 
-ffmpeg -hide_banner -loglevel info -nostdin -re \
-  -f lavfi -i testsrc2=size=320x180:rate=15 \
-  -f lavfi -i sine=frequency=880:sample_rate=44100 \
-  -t "$STREAM_SECONDS" \
-  -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p -g 15 \
-  -c:a aac -b:a 96k \
-  -f flv -listen 1 "$URL" >"$SERVER_LOG" 2>&1 &
-SERVER_PID=$!
+if [ -n "$RTMP_URL" ]; then
+  case "$RTMP_URL" in
+    rtmp://*|rtmpt://*|rtmpe://*|rtmps://*|rtmpte://*|rtmpts://*) ;;
+    *) fail "RTMP_URL must use an RTMP-family scheme, got: $RTMP_URL" ;;
+  esac
+  URL=$RTMP_URL
+else
+  URL="rtmp://127.0.0.1:${PORT}/live/test"
+
+  ffmpeg -hide_banner -loglevel info -nostdin -re \
+    -f lavfi -i testsrc2=size=320x180:rate=15 \
+    -f lavfi -i sine=frequency=880:sample_rate=44100 \
+    -t "$STREAM_SECONDS" \
+    -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p -g 15 \
+    -c:a aac -b:a 96k \
+    -f flv -listen 1 "$URL" >"$SERVER_LOG" 2>&1 &
+  SERVER_PID=$!
+fi
 
 "$MOVIAN_BIN" \
   -d \
@@ -89,11 +115,17 @@ SERVER_PID=$!
 MOVIAN_PID=$!
 
 cleanup() {
-  kill "$MOVIAN_PID" "$SERVER_PID" 2>/dev/null || true
+  kill "$MOVIAN_PID" ${SERVER_PID:+"$SERVER_PID"} 2>/dev/null || true
   wait "$MOVIAN_PID" 2>/dev/null || true
-  wait "$SERVER_PID" 2>/dev/null || true
+  if [ -n "$SERVER_PID" ]; then
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
+
+check_server_alive() {
+  [ -z "$SERVER_PID" ] || kill -0 "$SERVER_PID" 2>/dev/null
+}
 
 wait_log() {
   pattern=$1
@@ -105,7 +137,8 @@ wait_log() {
       return 0
     fi
     kill -0 "$MOVIAN_PID" 2>/dev/null || fail "Movian exited while waiting for $label"
-    kill -0 "$SERVER_PID" 2>/dev/null || fail "ffmpeg RTMP server exited while waiting for $label"
+    check_server_alive ||
+      fail "ffmpeg RTMP server exited while waiting for $label"
     sleep 0.25
   done
 
@@ -122,7 +155,8 @@ wait_log_fixed() {
       return 0
     fi
     kill -0 "$MOVIAN_PID" 2>/dev/null || fail "Movian exited while waiting for $label"
-    kill -0 "$SERVER_PID" 2>/dev/null || fail "ffmpeg RTMP server exited while waiting for $label"
+    check_server_alive ||
+      fail "ffmpeg RTMP server exited while waiting for $label"
     sleep 0.25
   done
 
@@ -142,9 +176,9 @@ printf '%s\n' "$BASE" >"$ARTIFACTS/base-url.txt"
 sleep 1
 curl -fsS -L --get --data-urlencode "url=$URL" "$BASE/api/open" >"$ARTIFACTS/open.html"
 
-wait_log_fixed "Starting playback of $URL (flv)" "RTMP playback start"
-wait_log_fixed "Stream #0: Video: h264" "H.264 video stream"
-wait_log_fixed "Stream #1: Audio: aac" "AAC audio stream"
+wait_log_fixed "Starting playback of $URL ($EXPECT_CONTAINER)" "RTMP playback start"
+wait_log "Stream #[0-9]+: Video: $EXPECT_VIDEO" "$EXPECT_VIDEO video stream"
+wait_log "Stream #[0-9]+: Audio: $EXPECT_AUDIO" "$EXPECT_AUDIO audio stream"
 
 {
   echo "currentpage.source:"
@@ -165,6 +199,8 @@ grep -Fq "is a $URL" "$ARTIFACTS/props.txt" ||
   echo "RTMP smoke passed"
   echo "URL: $URL"
   echo "Movian log: $LOG"
-  echo "ffmpeg server log: $SERVER_LOG"
+  if [ -n "$SERVER_PID" ]; then
+    echo "ffmpeg server log: $SERVER_LOG"
+  fi
   echo "Props: $ARTIFACTS/props.txt"
 } | tee "$ARTIFACTS/summary.txt"

--- a/support/rtmp-smoke/run-rtmps-mediamtx-smoke.sh
+++ b/support/rtmp-smoke/run-rtmps-mediamtx-smoke.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACTS=${ARTIFACTS:-/tmp/movian-rtmps-smoke}
+MEDIAMTX_IMAGE=${MEDIAMTX_IMAGE:-bluenviron/mediamtx:1}
+RTMP_PUBLISH_PORT=${RTMP_PUBLISH_PORT:-19395}
+RTMPS_PLAY_PORT=${RTMPS_PLAY_PORT:-19397}
+STREAM_SECONDS=${STREAM_SECONDS:-90}
+WAIT_SECONDS=${WAIT_SECONDS:-70}
+MOVIAN_BIN=${MOVIAN_BIN:-}
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  support/rtmp-smoke/run-rtmps-mediamtx-smoke.sh
+
+Environment:
+  MOVIAN_BIN              Movian binary or wrapper to test. If unset and
+                          build.flatpak-builder exists, a temporary Flatpak
+                          wrapper is generated automatically.
+  ARTIFACTS               Artifact directory (default: /tmp/movian-rtmps-smoke)
+  MEDIAMTX_IMAGE          Docker image (default: bluenviron/mediamtx:1)
+  RTMP_PUBLISH_PORT       Host RTMP publish port (default: 19395)
+  RTMPS_PLAY_PORT         Host RTMPS playback port (default: 19397)
+  STREAM_SECONDS          Synthetic publisher duration (default: 90)
+  WAIT_SECONDS            Movian playback timeout (default: 70)
+
+This smoke publishes a synthetic stream to MediaMTX over RTMP, then opens the
+same stream through RTMPS in Movian. It is intended for a Flatpak or equivalent
+build whose bundled FFmpeg enables gmp and gnutls.
+USAGE
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  if [ -n "${PUBLISHER_LOG:-}" ] && [ -f "$PUBLISHER_LOG" ]; then
+    tail -n 120 "$PUBLISHER_LOG" >"$ARTIFACTS/publisher-tail.txt" || true
+    echo "Saved publisher tail: $ARTIFACTS/publisher-tail.txt" >&2
+  fi
+  if [ -n "${MEDIAMTX_LOG:-}" ] && docker ps -a --format '{{.Names}}' |
+    grep -Fxq "${CONTAINER_NAME:-}"; then
+    docker logs "$CONTAINER_NAME" >"$MEDIAMTX_LOG" 2>&1 || true
+    echo "Saved MediaMTX log: $MEDIAMTX_LOG" >&2
+  fi
+  exit 1
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+command -v ffmpeg >/dev/null 2>&1 || fail "ffmpeg is required"
+command -v openssl >/dev/null 2>&1 || fail "openssl is required"
+
+case "$RTMP_PUBLISH_PORT" in
+  ''|*[!0-9]*) fail "RTMP_PUBLISH_PORT must be a positive integer, got: $RTMP_PUBLISH_PORT" ;;
+esac
+
+case "$RTMPS_PLAY_PORT" in
+  ''|*[!0-9]*) fail "RTMPS_PLAY_PORT must be a positive integer, got: $RTMPS_PLAY_PORT" ;;
+esac
+
+case "$STREAM_SECONDS" in
+  ''|*[!0-9]*) fail "STREAM_SECONDS must be a positive integer, got: $STREAM_SECONDS" ;;
+esac
+
+case "$WAIT_SECONDS" in
+  ''|*[!0-9]*) fail "WAIT_SECONDS must be a positive integer, got: $WAIT_SECONDS" ;;
+esac
+
+rm -rf "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
+
+CERT="$ARTIFACTS/server.crt"
+KEY="$ARTIFACTS/server.key"
+PUBLISHER_LOG="$ARTIFACTS/ffmpeg-publisher.log"
+MEDIAMTX_LOG="$ARTIFACTS/mediamtx.log"
+SMOKE_ARTIFACTS="$ARTIFACTS/movian"
+CONTAINER_NAME="movian-rtmps-mediamtx-$$"
+PUBLISH_URL="rtmp://127.0.0.1:${RTMP_PUBLISH_PORT}/live/test"
+PLAY_URL="rtmps://127.0.0.1:${RTMPS_PLAY_PORT}/live/test"
+PUBLISHER_PID=
+
+if [ -z "$MOVIAN_BIN" ]; then
+  if [ -d build.flatpak-builder ]; then
+    MOVIAN_BIN="$ARTIFACTS/run-flatpak-movian.sh"
+    {
+      printf '%s\n' '#!/usr/bin/env bash'
+      printf '%s\n' 'exec flatpak build build.flatpak-builder /app/bin/showtime "$@"'
+    } >"$MOVIAN_BIN"
+    chmod +x "$MOVIAN_BIN"
+  else
+    fail "MOVIAN_BIN is unset and build.flatpak-builder is missing"
+  fi
+fi
+
+[ -x "$MOVIAN_BIN" ] || fail "Movian binary or wrapper is not executable: $MOVIAN_BIN"
+
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [ -n "${PUBLISHER_PID:-}" ]; then
+    kill "$PUBLISHER_PID" 2>/dev/null || true
+    wait "$PUBLISHER_PID" 2>/dev/null || true
+  fi
+  if docker ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"; then
+    docker logs "$CONTAINER_NAME" >"$MEDIAMTX_LOG" 2>&1 || true
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "$KEY" \
+  -out "$CERT" \
+  -sha256 \
+  -days 1 \
+  -subj '/CN=localhost' >"$ARTIFACTS/openssl.log" 2>&1
+
+docker run -d --rm --name "$CONTAINER_NAME" \
+  -p "127.0.0.1:${RTMP_PUBLISH_PORT}:1935" \
+  -p "127.0.0.1:${RTMPS_PLAY_PORT}:1937" \
+  -v "$KEY:/server.key:ro" \
+  -v "$CERT:/server.crt:ro" \
+  -e MTX_RTMPENCRYPTION=optional \
+  -e MTX_RTMPSADDRESS=:1937 \
+  -e MTX_RTMPSERVERKEY=/server.key \
+  -e MTX_RTMPSERVERCERT=/server.crt \
+  "$MEDIAMTX_IMAGE" >"$ARTIFACTS/container-id.txt"
+
+sleep 2
+
+ffmpeg -hide_banner -loglevel info -nostdin -re \
+  -f lavfi -i testsrc2=size=320x180:rate=15 \
+  -f lavfi -i sine=frequency=700:sample_rate=44100 \
+  -t "$STREAM_SECONDS" \
+  -c:v libx264 -preset ultrafast -tune zerolatency -pix_fmt yuv420p -g 15 \
+  -c:a aac -b:a 96k \
+  -f flv "$PUBLISH_URL" >"$PUBLISHER_LOG" 2>&1 &
+PUBLISHER_PID=$!
+
+sleep 4
+kill -0 "$PUBLISHER_PID" 2>/dev/null ||
+  fail "ffmpeg RTMP publisher exited before the RTMPS playback check"
+
+ARTIFACTS="$SMOKE_ARTIFACTS" \
+WAIT_SECONDS="$WAIT_SECONDS" \
+RTMP_URL="$PLAY_URL" \
+MOVIAN_BIN="$MOVIAN_BIN" \
+  support/rtmp-smoke/run-rtmp-smoke.sh
+
+{
+  echo "RTMPS MediaMTX smoke passed"
+  echo "Publish URL: $PUBLISH_URL"
+  echo "Playback URL: $PLAY_URL"
+  echo "Movian artifacts: $SMOKE_ARTIFACTS"
+  echo "MediaMTX log: $MEDIAMTX_LOG"
+  echo "Publisher log: $PUBLISHER_LOG"
+} | tee "$ARTIFACTS/summary.txt"


### PR DESCRIPTION
## Summary

- Fix the FFmpeg-backed RTMP fallback so it can own RTMP-family media playback when the old `librtmp` backend is disabled.
- Add reproducible local RTMP and RTMPS smoke helpers.
- Document external RTMP smoke usage and public branch work patterns.

## Details

The previous fallback registered RTMP-family schemes as fileaccess protocols, but playable live streams also need backend scoring and media flags that avoid filesystem/subtitle scans and seek/size assumptions. This branch adds a small backend wrapper for the `!ENABLE_LIBRTMP` path while leaving the old `librtmp` backend untouched when it is enabled.

The new smoke helpers cover:

- synthetic local `rtmp://` playback via `ffmpeg -listen 1`;
- optional external RTMP-family URLs via `RTMP_URL=...`;
- synthetic local `rtmps://` playback through Docker MediaMTX and the Flatpak runtime.

This advances #31. The remaining legacy variants (`rtmpt`, `rtmpe`, `rtmpte`, `rtmpts`) are better tracked separately because they need legacy server research rather than the MediaMTX path.

## Validation

- `git diff --check movian6..HEAD`
- `./support/configure-linux-debug.sh --build=debug-ffrtmp-smoke --disable-librtmp`
- `make BUILD=debug-ffrtmp-smoke -j$(nproc)`
- `./build.debug-ffrtmp-smoke/movian --help`
- `MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian support/rtmp-smoke/run-rtmp-smoke.sh`
- external RTMP smoke with `RTMP_URL=rtmp://live.restream.io/pull/play_320121_94512612fd0e084bd284`
- `support/rtmp-smoke/run-rtmps-mediamtx-smoke.sh`
- `support/flatpak/build-local.sh`
- `flatpak build build.flatpak-builder /app/bin/showtime --help`
- `desktop-file-validate support/flatpak/dev.uzver.Movian.desktop support/flatpak/dev.uzver.Movian.GameMode.desktop`
- `appstreamcli validate --no-net build.flatpak-builder/files/share/metainfo/dev.uzver.Movian.metainfo.xml`
- Flatpak dependency grep showed expected `libgmp.so.10` and `libgnutls.so.30`, with no external `librtmp`, GTK/WebKit/DVD/VAAPI/VDPAU matches
- `sh -n support/rtmp-smoke/run-rtmp-smoke.sh support/rtmp-smoke/run-rtmps-mediamtx-smoke.sh`
- public-safe grep for internal names/paths in changed public files