### PR TITLE
Preserve RTMP audio playback through FFmpeg fallback

### DIFF
--- a/src/fileaccess/fa_ffmpeg_rtmp.c
+++ b/src/fileaccess/fa_ffmpeg_rtmp.c
@@ -32,6 +32,7 @@
 #include "main.h"
 #include "backend/backend.h"
 #include "fileaccess.h"
+#include "fa_audio.h"
 #include "fa_proto.h"
 #include "fa_video.h"
 
@@ -249,6 +250,7 @@ FAP_REGISTER(ffmpeg_rtmp);
 static backend_t be_ffmpeg_rtmp = {
   .be_canhandle = ffmpeg_rtmp_canhandle,
   .be_open = ffmpeg_rtmp_backend_open,
+  .be_play_audio = be_file_playaudio,
   .be_play_video = ffmpeg_rtmp_backend_playvideo,
 };
 


### PR DESCRIPTION
## Summary

- Add audio playback delegation to the FFmpeg-backed RTMP fallback backend.
- Preserve the existing file/audio implementation for audio-only RTMP-family URLs when `librtmp` is disabled.

## Details

PR #33 added an RTMP-family backend wrapper so live RTMP video playback can avoid filesystem scans, subtitle scans, and seek/size assumptions. The wrapper has a higher backend score than the generic file backend, so playqueue/audio paths can now resolve to it too. Without a `be_play_audio` hook, those audio-only paths can fail with `No backend for URL` instead of using the existing FFmpeg file/audio playback path.

This follow-up keeps the video wrapper behavior unchanged and delegates audio playback to `be_file_playaudio`, matching the pre-wrapper behavior for audio-only streams.

Addresses the automated review feedback on #33.

## Validation

- `git diff --check movian6..HEAD`
- `make BUILD=debug-ffrtmp-smoke -j$(nproc)`
- `./build.debug-ffrtmp-smoke/movian --help`
- `ARTIFACTS=/tmp/movian-rtmp-smoke-audio-fallback-fix MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian support/rtmp-smoke/run-rtmp-smoke.sh`
- public-safe grep for internal names/paths in the changed file