### PR TITLE
Make Linux debug use FFmpeg RTMP path

### DIFF
--- a/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+++ b/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
@@ -182,10 +182,10 @@ script starts a local synthetic RTMP stream with `ffmpeg`, opens it through the
 HTTP API, and keeps the Movian/server logs as artifacts:
 
 ```sh
-./support/configure-linux-debug.sh --build=debug-ffrtmp-smoke --disable-librtmp
-make BUILD=debug-ffrtmp-smoke -j$(nproc)
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
 
-MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian \
+MOVIAN_BIN=./build.debug/movian \
   support/rtmp-smoke/run-rtmp-smoke.sh
 ```
 
@@ -201,7 +201,7 @@ instead of committing it into the repository:
 
 ```sh
 RTMP_URL='rtmp://example.invalid/live/stream' \
-MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian \
+MOVIAN_BIN=./build.debug/movian \
   support/rtmp-smoke/run-rtmp-smoke.sh
 ```
 
@@ -209,10 +209,17 @@ Optional external URLs are useful PR evidence, but they should not be treated as
 stable CI inputs. Keep the exact URL and artifacts in the PR or issue notes when
 the source is temporary.
 
+The standard Linux debug helper disables the old external `librtmp` backend, so
+plain `rtmp` and `rtmpt` exercise Movian's FFmpeg-backed path. Re-enable
+`librtmp` only for comparison builds:
+
+```sh
+./support/configure-linux-debug.sh --build=debug-librtmp-compare --enable-librtmp
+make BUILD=debug-librtmp-compare -j$(nproc)
+```
+
 For `rtmpe`, `rtmps`, `rtmpte`, or `rtmpts`, use the Flatpak profile or another
-build whose bundled FFmpeg config enables `gmp` and `gnutls`. The ordinary host
-debug profile may only cover plain `rtmp` and `rtmpt`, depending on available
-system libraries at configure time.
+build whose bundled FFmpeg config enables `gmp` and `gnutls`.
 
 Use the normal Flatpak build checks as well when RTMP behavior changed in the
 Flatpak profile.

--- a/docs/Guides/PLUGIN_DEBUG_WORKFLOW.md
+++ b/docs/Guides/PLUGIN_DEBUG_WORKFLOW.md
@@ -20,7 +20,7 @@ make BUILD=debug -j$(nproc)
 The helper configures the Linux debug build with:
 
 ```sh
-./configure.linux --build=debug --disable-vdpau --enable-polarssl
+./configure.linux --build=debug --disable-vdpau --enable-polarssl --disable-librtmp
 ```
 
 Append extra configure flags when needed:
@@ -183,6 +183,7 @@ LIBAV_COMMON_FLAGS="--disable-inline-asm" ./configure.linux \
   --disable-avahi \
   --disable-webkit \
   --enable-polarssl \
+  --disable-librtmp \
   --optlevel=g \
   --extra-cflags=-fno-omit-frame-pointer \
   --enable-bughunt

--- a/docs/Guides/PUBLIC_WORK_PATTERNS.md
+++ b/docs/Guides/PUBLIC_WORK_PATTERNS.md
@@ -61,7 +61,7 @@ make BUILD=debug -j$(nproc)
 - Use separate build names for risky checks:
 
 ```sh
-./support/configure-linux-debug.sh --build=debug-feature-smoke --disable-librtmp
+./support/configure-linux-debug.sh --build=debug-feature-smoke
 make BUILD=debug-feature-smoke -j$(nproc)
 ```
 
@@ -77,7 +77,9 @@ make BUILD=debug-feature-smoke -j$(nproc)
 
 - Preserve the old implementation when it is enabled and add new fallback code
   only behind the inverse feature gate. For example, the FFmpeg RTMP fallback is
-  compiled only when `ENABLE_LIBRTMP` is false.
+  compiled only when `ENABLE_LIBRTMP` is false; the standard Linux debug helper
+  now uses that path, while `--enable-librtmp` remains available for comparison
+  builds.
 - Disabled runtime actions should be safe no-ops, not crashes. The GLW recorder
   hotkey is the model: debug builds can keep the tool, while release/Flatpak
   builds consume the hotkey without recording.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,10 +35,12 @@ make BUILD=debug -j$(nproc)
 The helper runs:
 
 ```sh
-./configure.linux --build=debug --disable-vdpau --enable-polarssl
+./configure.linux --build=debug --disable-vdpau --enable-polarssl --disable-librtmp
 ```
 
-Extra configure flags can be appended to the helper command.
+Extra configure flags can be appended to the helper command. The old external
+`librtmp` backend can still be re-enabled explicitly for comparison builds with
+`--enable-librtmp`.
 
 ## Plugin Debug Workflow
 
@@ -96,6 +98,9 @@ The public stack currently includes these user-visible changes:
   `image/webp` for WebP payloads.
 - The bundled media backend is FFmpeg 4.4.7. Existing command-line and helper
   names such as `--libav-log` remain unchanged.
+- Linux debug builds created by `support/configure-linux-debug.sh` disable the
+  old external `librtmp` backend so ordinary RTMP playback uses the
+  FFmpeg-backed path.
 - Flatpak builds use FFmpeg's RTMP-family protocols with SDK `gmp` and
   `gnutls`, while leaving the old external `librtmp` backend disabled in that
   profile.

--- a/support/configure-linux-debug.sh
+++ b/support/configure-linux-debug.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 #
-# Configure a Linux debug build with defaults that work on newer Ubuntu
-# installs where VDPAU headers are often absent and OpenSSL is too new for
-# bundled librtmp.
+# Configure a Linux debug build with defaults that work on newer Ubuntu and
+# WSL installs. The old bundled librtmp backend is disabled by default so RTMP
+# playback uses the FFmpeg-backed path, matching the Flatpak direction for
+# ordinary RTMP smoke tests.
 
 set -eu
 
 TOPDIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$TOPDIR"
 
-exec ./configure.linux --build=debug --disable-vdpau --enable-polarssl "$@"
+exec ./configure.linux \
+  --build=debug \
+  --disable-vdpau \
+  --enable-polarssl \
+  --disable-librtmp \
+  "$@"

--- a/support/rtmp-smoke/run-rtmp-smoke.sh
+++ b/support/rtmp-smoke/run-rtmp-smoke.sh
@@ -15,7 +15,7 @@ EXPECT_AUDIO=${EXPECT_AUDIO:-aac}
 usage() {
   cat <<'USAGE'
 Usage:
-  MOVIAN_BIN=./build.debug-ffrtmp-smoke/movian \
+  MOVIAN_BIN=./build.debug/movian \
     support/rtmp-smoke/run-rtmp-smoke.sh
 
 Environment:
@@ -32,7 +32,8 @@ Environment:
   EXPECT_AUDIO            Expected audio codec in the playback log (default: aac)
 
 The target Movian build should be configured without the old librtmp backend
-when validating the FFmpeg-backed RTMP fallback path.
+when validating the FFmpeg-backed RTMP path. The standard Linux debug helper
+does this by default.
 USAGE
 }
 


### PR DESCRIPTION
## Summary

- Disable the old external `librtmp` backend in the standard Linux debug helper.
- Update RTMP smoke docs and helper usage so ordinary Linux debug smoke runs through `build.debug/movian`.
- Document `--enable-librtmp` as an explicit comparison build option.

## Validation

- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- Confirmed `build.debug/config.h` has `ENABLE_LIBRTMP 0` and FFmpeg has plain `rtmp`/`rtmpt` protocols enabled.
- `ARTIFACTS=/tmp/movian-rtmp-smoke-debug-ffmpeg MOVIAN_BIN=./build.debug/movian support/rtmp-smoke/run-rtmp-smoke.sh`
- `ARTIFACTS=/tmp/movian-rtmp-smoke-debug-day-tv071 WAIT_SECONDS=60 RTMP_URL=rtmp://f13h.mine.nu:1935/sat/tv071 MOVIAN_BIN=./build.debug/movian support/rtmp-smoke/run-rtmp-smoke.sh`