### PR TITLE
Enable FFmpeg RTMP-family playback in Linux debug

### DIFF
--- a/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
+++ b/docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
@@ -20,6 +20,10 @@ Expected result:
 
 - `git diff --check` prints nothing.
 - configure completes with the current bundled FFmpeg/libav submodule.
+- `build.debug/libav/build/config.h` shows `CONFIG_GMP 1`,
+  `CONFIG_GNUTLS 1`, `CONFIG_FFRTMPCRYPT_PROTOCOL 1`, `CONFIG_TLS_PROTOCOL 1`,
+  and the `rtmp`, `rtmpt`, `rtmpe`, `rtmps`, `rtmpte`, and `rtmpts` protocol
+  symbols enabled.
 - `make` produces `build.debug/movian`.
 - `--help` prints the Movian version and option list.
 
@@ -209,8 +213,10 @@ Optional external URLs are useful PR evidence, but they should not be treated as
 stable CI inputs. Keep the exact URL and artifacts in the PR or issue notes when
 the source is temporary.
 
-The standard Linux debug helper disables the old external `librtmp` backend, so
-plain `rtmp` and `rtmpt` exercise Movian's FFmpeg-backed path. Re-enable
+The standard Linux debug helper disables the old external `librtmp` backend and
+enables FFmpeg's `gmp`/`gnutls` RTMP-family support, so `rtmp`, `rtmpt`,
+`rtmpe`, `rtmps`, `rtmpte`, and `rtmpts` all route through Movian's
+FFmpeg-backed path when the local server supports the scheme. Re-enable
 `librtmp` only for comparison builds:
 
 ```sh
@@ -218,11 +224,17 @@ plain `rtmp` and `rtmpt` exercise Movian's FFmpeg-backed path. Re-enable
 make BUILD=debug-librtmp-compare -j$(nproc)
 ```
 
-For `rtmpe`, `rtmps`, `rtmpte`, or `rtmpts`, use the Flatpak profile or another
-build whose bundled FFmpeg config enables `gmp` and `gnutls`.
-
 Use the normal Flatpak build checks as well when RTMP behavior changed in the
 Flatpak profile.
+
+For encrypted or tunneled RTMP-family variants, prove playback with a server
+that really supports the target scheme. MediaMTX is a good local baseline for
+`rtmp` and `rtmps`, but it does not cover the full legacy family. Red5 2.x can
+serve as a positive local `rtmpe` source when a live app is available: publish a
+synthetic `testsrc2` + `sine` stream with `ffmpeg`, open the `rtmpe://` URL in
+Movian, and keep both the direct FFmpeg probe and Movian screenshot/log. Red5
+1.0.x and MonaServer2 were useful comparison candidates, but were not reliable
+positive `rtmpe` sources in local smoke.
 
 ### Local RTMPS Smoke
 

--- a/docs/Guides/PUBLIC_WORK_PATTERNS.md
+++ b/docs/Guides/PUBLIC_WORK_PATTERNS.md
@@ -98,9 +98,15 @@ make BUILD=debug-feature-smoke -j$(nproc)
   - return unsupported for seek;
   - skip filesystem and subtitle scans;
   - avoid probing size with APIs that may consume stream data.
+- For protocols natively owned by FFmpeg, prefer a direct
+  `avformat_open_input()` playback path when the protocol has its own
+  handshake, encryption, tunnel, or buffering semantics. A generic fileaccess
+  wrapper can prove network connect while still starving the demuxer of video
+  packets.
 - Verify that the playback path reaches media decode, not just network connect.
-  Useful log anchors are `Probed as`, `Starting playback`, stream summaries,
-  and `global/media/current/url`.
+  Useful log anchors are `Opened directly as`, `Probed as`,
+  `Starting playback`, stream summaries, codec creation, screenshots, and
+  `global/media/current/url`.
 
 ## FFmpeg And Static Linking
 
@@ -112,7 +118,8 @@ make BUILD=debug-feature-smoke -j$(nproc)
 - When enabling optional FFmpeg libraries in a static build, import FFmpeg's
   generated `EXTRALIBS-*` values from `ffbuild/config.mak`. Otherwise optional
   dependencies may configure successfully and fail only at final link.
-- For Flatpak RTMP-family protocol support, the successful SDK flags are:
+- For Flatpak RTMP-family protocol support, and Linux debug builds where the
+  old external `librtmp` backend is disabled, use:
 
 ```text
 --enable-version3

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,23 @@ The helper runs:
 ./configure.linux --build=debug --disable-vdpau --enable-polarssl --disable-librtmp
 ```
 
+Before running the helper on a fresh Ubuntu/WSL install, make sure FFmpeg's
+RTMP-family TLS/crypto dependencies are available:
+
+```sh
+sudo apt install libgmp-dev libgnutls28-dev
+```
+
+The helper exports the same FFmpeg RTMP-family feature flags used by the
+Flatpak profile:
+
+```text
+--enable-version3 --enable-gmp --enable-gnutls
+```
+
+It also uses the Flatpak-compatible portable FFmpeg switches that disable
+assembly and hardware acceleration autodetect for this debug profile.
+
 Extra configure flags can be appended to the helper command. The old external
 `librtmp` backend can still be re-enabled explicitly for comparison builds with
 `--enable-librtmp`.
@@ -98,12 +115,8 @@ The public stack currently includes these user-visible changes:
   `image/webp` for WebP payloads.
 - The bundled media backend is FFmpeg 4.4.7. Existing command-line and helper
   names such as `--libav-log` remain unchanged.
-- Linux debug builds created by `support/configure-linux-debug.sh` disable the
-  old external `librtmp` backend so ordinary RTMP playback uses the
-  FFmpeg-backed path.
-- Flatpak builds use FFmpeg's RTMP-family protocols with SDK `gmp` and
-  `gnutls`, while leaving the old external `librtmp` backend disabled in that
-  profile.
+- Linux debug and Flatpak builds disable the old external `librtmp` backend by
+  default and use FFmpeg's RTMP-family protocols with `gmp` and `gnutls`.
 - Steam launches avoid the X11 fullscreen `override_redirect` path when
   `SteamGameId` or `SteamAppId` is set. `XK_Menu` maps to Movian's menu action
   for Steam Input keyboard layouts.

--- a/src/fileaccess/fa_ffmpeg_rtmp.c
+++ b/src/fileaccess/fa_ffmpeg_rtmp.c
@@ -225,8 +225,9 @@ ffmpeg_rtmp_backend_playvideo(const char *url, media_pipe_t *mp,
 {
   video_args_t va = *va0;
 
+  (void)vsl;
   va.flags |= BACKEND_VIDEO_NO_FS_SCAN | BACKEND_VIDEO_NO_SUBTITLE_SCAN;
-  return be_file_playvideo(url, mp, errbuf, errlen, vq, vsl, &va);
+  return be_file_playvideo_ffmpeg_url(url, mp, errbuf, errlen, vq, &va);
 }
 
 

--- a/src/fileaccess/fa_video.c
+++ b/src/fileaccess/fa_video.c
@@ -216,8 +216,9 @@ video_player_loop(AVFormatContext *fctx, media_codec_t **cwvec,
 
       mp->mp_eof = 0;
 
-      fa_deadline(fh, mp->mp_buffer_delay != INT32_MAX ?
-		  mp->mp_buffer_delay / 3 : 0);
+      if(fh != NULL)
+	fa_deadline(fh, mp->mp_buffer_delay != INT32_MAX ?
+		    mp->mp_buffer_delay / 3 : 0);
 
       r = av_read_frame(fctx, &pkt);
 
@@ -650,32 +651,15 @@ be_file_playvideo(const char *url, media_pipe_t *mp,
 /**
  *
  */
-event_t *
-be_file_playvideo_fh(const char *url, media_pipe_t *mp,
-                     char *errbuf, size_t errlen,
-                     video_queue_t *vq, fa_handle_t *fh,
-		     const video_args_t *va0)
+static event_t *
+be_file_playvideo_fctx(const char *url, media_pipe_t *mp,
+                       char *errbuf, size_t errlen,
+                       video_queue_t *vq, fa_handle_t *fh,
+                       AVFormatContext *fctx, const video_args_t *va0,
+                       int direct)
 {
   sub_scanner_t *ss = NULL;
   video_args_t va = *va0;
-
-  if(!(va.flags & BACKEND_VIDEO_NO_SUBTITLE_SCAN)) {
-    compute_hash(fh, &va);
-    if(!va.hash_valid)
-      TRACE(TRACE_DEBUG, "Video",
-            "Unable to compute opensub hash, stream probably not seekable");
-  }
-
-  int strategy = fa_libav_get_strategy_for_file(fh);
-  AVIOContext *avio = fa_libav_reopen(fh, 0);
-  va.filesize = avio_size(avio);
-
-  AVFormatContext *fctx;
-  if((fctx = fa_libav_open_format(avio, url, errbuf, errlen,
-				  va.mimetype, strategy)) == NULL) {
-    fa_libav_close(avio);
-    return NULL;
-  }
 
   usage_event("Play video", 1, USAGE_SEG("format", fctx->iformat->name));
 
@@ -748,7 +732,8 @@ be_file_playvideo_fh(const char *url, media_pipe_t *mp,
   memset(cwvec, 0, sizeof(void *) * fctx->nb_streams);
 
   int cwvec_size = fctx->nb_streams;
-  media_format_t *fw = media_format_create(fctx);
+  media_format_t *fw = direct ? media_format_create_direct(fctx) :
+    media_format_create(fctx);
 
 
   // Scan all streams and select defaults
@@ -915,6 +900,119 @@ be_file_playvideo_fh(const char *url, media_pipe_t *mp,
     metadata_destroy(md);
 #endif
 
+  return e;
+}
+
+
+/**
+ *
+ */
+event_t *
+be_file_playvideo_fh(const char *url, media_pipe_t *mp,
+                     char *errbuf, size_t errlen,
+                     video_queue_t *vq, fa_handle_t *fh,
+		     const video_args_t *va0)
+{
+  video_args_t va = *va0;
+
+  if(!(va.flags & BACKEND_VIDEO_NO_SUBTITLE_SCAN)) {
+    compute_hash(fh, &va);
+    if(!va.hash_valid)
+      TRACE(TRACE_DEBUG, "Video",
+            "Unable to compute opensub hash, stream probably not seekable");
+  }
+
+  int strategy = fa_libav_get_strategy_for_file(fh);
+  AVIOContext *avio = fa_libav_reopen(fh, 0);
+  va.filesize = avio_size(avio);
+
+  AVFormatContext *fctx;
+  if((fctx = fa_libav_open_format(avio, url, errbuf, errlen,
+				  va.mimetype, strategy)) == NULL) {
+    fa_libav_close(avio);
+    return NULL;
+  }
+
+  return be_file_playvideo_fctx(url, mp, errbuf, errlen, vq, fh, fctx, &va, 0);
+}
+
+
+/**
+ *
+ */
+event_t *
+be_file_playvideo_ffmpeg_url(const char *url, media_pipe_t *mp,
+                             char *errbuf, size_t errlen,
+                             video_queue_t *vq, const video_args_t *va0)
+{
+  rstr_t *title = NULL;
+  video_args_t va = *va0;
+  AVFormatContext *fctx = NULL;
+  int err;
+
+  mp_set_url(mp, va0->canonical_url, va0->parent_url, va0->parent_title);
+
+  prop_set(mp->mp_prop_root, "loading", PROP_SET_INT, 1);
+
+  if(!(va.flags & BACKEND_VIDEO_NO_AUDIO))
+    mp_become_primary(mp);
+
+  prop_set(mp->mp_prop_root, "type", PROP_SET_STRING, "video");
+
+  if(va.flags & BACKEND_VIDEO_SET_TITLE) {
+    char tmp[1024];
+
+    fa_url_get_last_component(tmp, sizeof(tmp), va.canonical_url);
+    char *x = strrchr(tmp, '.');
+    if(x)
+      *x = 0;
+
+    title = rstr_from_bytes(tmp, NULL, 0);
+    va.title = rstr_get(title);
+
+    prop_set(mp->mp_prop_metadata, "title", PROP_SET_RSTRING, title);
+  }
+
+  fctx = avformat_alloc_context();
+  if(fctx == NULL) {
+    snprintf(errbuf, errlen, "Unable to allocate input context");
+    rstr_release(title);
+    return NULL;
+  }
+
+  fctx->fps_probe_size = 2;
+  fctx->max_analyze_duration = 1;
+
+  err = avformat_open_input(&fctx, url, NULL, NULL);
+  if(err < 0) {
+    char msg[256];
+    fa_libav_error_to_txt(err, msg, sizeof(msg));
+    snprintf(errbuf, errlen, "Unable to open RTMP URL: %s", msg);
+    avformat_close_input(&fctx);
+    rstr_release(title);
+    return NULL;
+  }
+
+  fctx->fps_probe_size = 2;
+  fctx->max_analyze_duration = 1;
+
+  err = avformat_find_stream_info(fctx, NULL);
+  if(err < 0) {
+    char msg[256];
+    fa_libav_error_to_txt(err, msg, sizeof(msg));
+    snprintf(errbuf, errlen, "Unable to handle RTMP URL: %s", msg);
+    avformat_close_input(&fctx);
+    rstr_release(title);
+    return NULL;
+  }
+
+  TRACE(TRACE_DEBUG, "probe", "%s: Opened directly as %s",
+        url, fctx->iformat->name);
+
+  va.filesize = -1;
+  event_t *e = be_file_playvideo_fctx(url, mp, errbuf, errlen, vq, NULL,
+                                      fctx, &va, 1);
+  rstr_release(title);
   return e;
 }
 

--- a/src/fileaccess/fa_video.h
+++ b/src/fileaccess/fa_video.h
@@ -39,4 +39,9 @@ event_t *be_file_playvideo_fh(const char *url, media_pipe_t *mp,
                               struct fa_handle *fh,
 			      const struct video_args *va);
 
+event_t *be_file_playvideo_ffmpeg_url(const char *url, media_pipe_t *mp,
+                                      char *errbuf, size_t errlen,
+                                      struct video_queue *vq,
+                                      const struct video_args *va);
+
 #endif /* FA_VIDEO_H */

--- a/src/libav.c
+++ b/src/libav.c
@@ -466,6 +466,21 @@ media_format_create(AVFormatContext *fctx)
   media_format_t *fw = malloc(sizeof(media_format_t));
   atomic_set(&fw->refcount, 1);
   fw->fctx = fctx;
+  fw->direct = 0;
+  return fw;
+}
+
+
+/**
+ *
+ */
+media_format_t *
+media_format_create_direct(AVFormatContext *fctx)
+{
+  media_format_t *fw = malloc(sizeof(media_format_t));
+  atomic_set(&fw->refcount, 1);
+  fw->fctx = fctx;
+  fw->direct = 1;
   return fw;
 }
 
@@ -478,7 +493,10 @@ media_format_deref(media_format_t *fw)
 {
   if(atomic_dec(&fw->refcount))
     return;
-  fa_libav_close_format(fw->fctx, 0);
+  if(fw->direct)
+    avformat_close_input(&fw->fctx);
+  else
+    fa_libav_close_format(fw->fctx, 0);
   free(fw);
 }
 
@@ -561,4 +579,3 @@ mp_set_mq_meta(media_queue_t *mq, const AVCodec *codec,
   metadata_from_libav(buf, sizeof(buf), codec, avctx);
   prop_set_string(mq->mq_prop_codec, buf);
 }
-

--- a/src/media/media_codec.h
+++ b/src/media/media_codec.h
@@ -114,11 +114,14 @@ void media_register_codec(codec_def_t *cd);
 typedef struct media_format {
   atomic_t refcount;
   struct AVFormatContext *fctx;
+  int direct;
 } media_format_t;
 
 #if ENABLE_LIBAV
 
 media_format_t *media_format_create(struct AVFormatContext *fctx);
+
+media_format_t *media_format_create_direct(struct AVFormatContext *fctx);
 
 void media_format_deref(media_format_t *fw);
 

--- a/support/configure-linux-debug.sh
+++ b/support/configure-linux-debug.sh
@@ -2,13 +2,28 @@
 #
 # Configure a Linux debug build with defaults that work on newer Ubuntu and
 # WSL installs. The old bundled librtmp backend is disabled by default so RTMP
-# playback uses the FFmpeg-backed path, matching the Flatpak direction for
-# ordinary RTMP smoke tests.
+# playback uses FFmpeg's RTMP-family protocols, matching the Flatpak profile.
 
 set -eu
 
 TOPDIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$TOPDIR"
+
+: "${LIBAV_COMMON_FLAGS:=--disable-x86asm --disable-inline-asm --disable-hwaccels --disable-vaapi --disable-vdpau --disable-cuda --disable-cuda-llvm --disable-cuvid --disable-ffnvcodec --disable-nvdec --disable-v4l2-m2m --enable-version3 --enable-gmp --enable-gnutls}"
+export LIBAV_COMMON_FLAGS
+
+if ! printf '%s\n' '#include <gmp.h>' 'int main(void) { return 0; }' |
+    cc -x c - -lgmp -o /tmp/movian-gmp-check.$$ >/dev/null 2>&1; then
+  rm -f /tmp/movian-gmp-check.$$
+  echo "Missing libgmp development headers. Install libgmp-dev." >&2
+  exit 1
+fi
+rm -f /tmp/movian-gmp-check.$$
+
+if ! pkg-config --exists gnutls; then
+  echo "Missing GnuTLS development metadata. Install libgnutls28-dev." >&2
+  exit 1
+fi
 
 exec ./configure.linux \
   --build=debug \


### PR DESCRIPTION
## Summary

- enable the Linux debug helper to build bundled FFmpeg with RTMP-family TLS/crypto support (`gmp`, `gnutls`, `ffrtmpcrypt`, `tls`)
- route FFmpeg-backed `rtmp*://` video playback through direct `avformat_open_input()` demuxing instead of wrapping the protocol as generic fileaccess
- document the successful local RTMP-family smoke patterns and server caveats

## Why

The old external `librtmp` backend is disabled in the current Linux debug/Flatpak direction. Plain `rtmp://` worked through the FFmpeg fallback, but encrypted/tunneled variants could connect while still failing to deliver usable video through the generic fileaccess wrapper. Direct FFmpeg demuxing keeps the protocol handshake, encryption, and buffering semantics inside FFmpeg.

## Validation

- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- direct FFmpeg probe: `rtmpe://127.0.0.1:19389/live/manualtest2038` reported H.264 video + AAC audio
- Movian smoke: `rtmp://127.0.0.1:19391/live/manualtest` rendered test video, screenshot saved at `/tmp/movian-rtmp-direct-smoke/screenshot.png`
- Movian smoke: `rtmpe://127.0.0.1:19389/live/manualtest2038` rendered test video, screenshot saved at `/tmp/movian-rtmpe-direct-smoke/screenshot.png`
- direct probes also passed for local `rtmpt`, `rtmps`, and `rtmpts`

## Post-merge Red5 follow-up

Issue #31 now records the fuller Red5 validation pass. Local Red5/Red5 TLS testing confirmed positive RTMP-family evidence for `rtmp`, `rtmpt`, `rtmpe`, `rtmps`, and `rtmpts`; the direct-FFmpeg Movian path fixed the earlier RTMPE audio-only/rendering issue.

`rtmpte` still does not have a reliable positive Red5 endpoint/tool combination in the saved local matrix (`Protocol not found` / `Input/output error` depending on probe path). That is documented as a server/proof limitation, not a Movian unsupported-protocol regression.