### PR TITLE
Add horizontal touch scrolling for list_x

### DIFF
--- a/docs/Guides/PLUGIN_DEVELOPMENT_NOTES.md
+++ b/docs/Guides/PLUGIN_DEVELOPMENT_NOTES.md
@@ -73,6 +73,62 @@ var links = doc.root.getElementsByTagName('a');
 This keeps compatibility local to the plugin while leaving the built-in module
 as the source of truth for parser behavior.
 
+## Horizontal Rows With `list_x`
+
+Plugins can build pages with any number of independently scrollable rows. Add
+each row as a passive page item whose `data` contains that row's cards:
+
+```js
+page.appendPassiveItem('list', upcomingCards, {
+  title: 'Movies - Upcoming'
+});
+page.appendPassiveItem('list', nowPlayingCards, {
+  title: 'Movies - Now Playing'
+});
+page.appendPassiveItem('list', topRatedCards, {
+  title: 'Movies - Top Rated'
+});
+```
+
+The outer cloner creates the sections. Each section then clones its own
+`$self.data` into a separate `list_x`:
+
+```view
+widget(list_y, {
+  cloner($self.model.nodes, container_y, {
+    widget(label, {
+      caption: $self.metadata.title;
+    });
+
+    widget(list_x, {
+      id: "section-row";
+      focusable: 1;
+      chaseFocus: 0;
+      navWrap: false;
+
+      cloner($self.data, loader, {
+        source: "skin://items/rect/default.view";
+      });
+    });
+
+    widget(slider_x, {
+      bind("section-row");
+      focusable: canScroll();
+      alpha: iir(canScroll(), 16);
+    });
+  });
+});
+```
+
+Keep the optional scrollbar inside the same cloned section as its row. The
+local `"section-row"` ID then binds to that section's `list_x`, so every row
+keeps an independent scroll position.
+
+Keyboard and D-pad navigation continue to use left/right focus movement. Touch
+or simulated touch can drag the row horizontally, while a vertical swipe over
+a card continues to scroll the outer `list_y`. On Linux/WSL this can be tested
+with `--pointer-is-touch`.
+
 ## Developer Guide Roadmap
 
 A fuller plugin guide should eventually cover:

--- a/docs/Guides/PLUGIN_DEVELOPMENT_NOTES.md
+++ b/docs/Guides/PLUGIN_DEVELOPMENT_NOTES.md
@@ -129,6 +129,9 @@ or simulated touch can drag the row horizontally, while a vertical swipe over
 a card continues to scroll the outer `list_y`. On Linux/WSL this can be tested
 with `--pointer-is-touch`.
 
+A complete runnable implementation is available in
+`plugin_examples/listx_cloner`.
+
 ## Developer Guide Roadmap
 
 A fuller plugin guide should eventually cover:

--- a/plugin_examples/README
+++ b/plugin_examples/README
@@ -41,8 +41,13 @@ Useful routes:
 - `plugin_examples/music` -> `example:music:`
 - `plugin_examples/subscriptions` -> `example:subscriptions:`
 - `plugin_examples/async_page_load` -> `asyncPageLoad:test:demo`
+- `plugin_examples/listx_cloner` -> `example:listx-cloner:`
 - `plugin_examples/webpopupplugin` -> `devplug:webtest`
 
 Some examples demonstrate APIs that need user interaction, network services, or
 specific media playback state. For those, use the manual command and inspect the
 Movian log instead of expecting a fully automated smoke.
+
+The `listx_cloner` example demonstrates multiple horizontal `list_x` rows,
+per-row scrollbars, keyboard focus, pointer hover, and touch scrolling. Add
+`--pointer-is-touch` when testing touch gestures with a mouse on Linux or WSL.

--- a/plugin_examples/listx_cloner/listx_cloner.js
+++ b/plugin_examples/listx_cloner/listx_cloner.js
@@ -1,0 +1,43 @@
+var page = require('movian/page');
+var service = require('movian/service');
+
+var PREFIX = 'example:listx-cloner:';
+
+service.create('list_x Cloner Example', PREFIX, 'other', true);
+
+function makeCards(prefix, count) {
+  var cards = [];
+
+  for (var i = 1; i <= count; i++) {
+    cards.push({
+      title: prefix + (i < 10 ? '0' : '') + i,
+      url: PREFIX + 'item:' + prefix + i
+    });
+  }
+
+  return cards;
+}
+
+new page.Route(PREFIX, function(page) {
+  page.metadata.title = 'list_x Cloner Example';
+  page.metadata.glwview = Plugin.path + 'listx_cloner.view';
+  page.type = 'raw';
+
+  page.appendPassiveItem('list', makeCards('U', 20), {
+    title: 'Movies - Upcoming'
+  });
+  page.appendPassiveItem('list', makeCards('N', 18), {
+    title: 'Movies - Now Playing'
+  });
+  page.appendPassiveItem('list', makeCards('T', 16), {
+    title: 'Movies - Top Rated'
+  });
+  page.appendPassiveItem('list', makeCards('D', 14), {
+    title: 'Movies - Documentaries'
+  });
+  page.appendPassiveItem('list', makeCards('C', 12), {
+    title: 'Movies - Classics'
+  });
+
+  page.loading = false;
+});

--- a/plugin_examples/listx_cloner/listx_cloner.view
+++ b/plugin_examples/listx_cloner/listx_cloner.view
@@ -1,0 +1,73 @@
+#define Card() {
+  widget(container_z, {
+    focusable: true;
+    width: 8em;
+    height: 4.5em;
+    margin: [0, 0, 0.7em, 0];
+
+    widget(quad, {
+      color: 0.08;
+      alpha: 0.9;
+    });
+
+    widget(quad, {
+      alpha: 0.3 * iir(isNavFocused() + isHovered(), 4);
+      color: "#3366cc";
+    });
+
+    widget(label, {
+      padding: [0.4em, 0.2em, 0.4em, 0.2em];
+      caption: $self.title;
+      align: center;
+      color: 0.95;
+    });
+  });
+}
+
+#define SectionScrollBar() {
+  widget(container_y, {
+    height: 0.8em;
+    padding: [2em, 0, 2em, 0];
+
+    widget(slider_x, {
+      bind("section-row");
+      height: 0.5em;
+      focusable: canScroll();
+      alpha: iir(canScroll(), 16);
+      alwaysGrabKnob: true;
+
+      widget(quad, {
+        alpha: 0.8 + isHovered();
+      });
+    });
+  });
+}
+
+widget(list_y, {
+  padding: [2em, 0.6em, 2em, 0.6em];
+  spacing: 0.7em;
+  navWrap: false;
+
+  cloner($self.model.nodes, container_y, {
+    spacing: 0.25em;
+
+    widget(label, {
+      caption: $self.metadata.title;
+      sizeScale: 1.2;
+    });
+
+    widget(list_x, {
+      id: "section-row";
+      height: 5em;
+      focusable: 1;
+      chaseFocus: 0;
+      navWrap: false;
+
+      cloner($self.data, container_z, {
+        Card();
+      });
+    });
+
+    SectionScrollBar();
+  });
+});

--- a/plugin_examples/listx_cloner/plugin.json
+++ b/plugin_examples/listx_cloner/plugin.json
@@ -1,0 +1,10 @@
+{
+  "type": "ecmascript",
+  "id": "example_listx_cloner",
+  "title": "list_x Cloner Example",
+  "version": "1.0.0",
+  "category": "other",
+  "synopsis": "Multiple independently scrollable horizontal rows",
+  "file": "listx_cloner.js",
+  "apiversion": 2
+}

--- a/src/ui/glw/glw.c
+++ b/src/ui/glw/glw.c
@@ -2263,6 +2263,24 @@ glw_pointer_event(glw_root_t *gr, glw_pointer_event_t *gpe)
     return;
   }
 
+  if((gpe->type == GLW_POINTER_TOUCH_END ||
+      gpe->type == GLW_POINTER_TOUCH_CANCEL) &&
+     (w = gr->gr_pointer_grab_scroll) != NULL) {
+    if(w->glw_matrix != NULL) {
+      glw_widget_unproject(w->glw_matrix, &x, &y, p, dir);
+      gpe0 = *gpe;
+      gpe0.local_x = x;
+      gpe0.local_y = y;
+
+      const glw_class_t *gc = w->glw_class;
+      if(gc->gc_pointer_event_filter != NULL)
+        gc->gc_pointer_event_filter(w, &gpe0);
+      glw_send_pointer_event(w, &gpe0);
+    }
+    if(gr->gr_pointer_grab_scroll == w)
+      gr->gr_pointer_grab_scroll = NULL;
+  }
+
   if(gpe->type == GLW_POINTER_GONE) {
     // Mouse pointer left our screen
     glw_root_set_hover(gr, NULL);

--- a/src/ui/glw/glw_list.c
+++ b/src/ui/glw/glw_list.c
@@ -189,16 +189,7 @@ glw_list_layout_x(glw_t *w, const glw_rctx_t *rc)
       l->gsc.scroll_to_me = w->glw_focused;
   }
 
-  l->gsc.target_pos = GLW_MAX(0, GLW_MIN(l->gsc.target_pos,
-                                         l->gsc.total_size - l->gsc.page_size));
-
-  if(fabsf(l->gsc.target_pos - l->gsc.filtered_pos) > rc->rc_width * 2) {
-    l->gsc.filtered_pos = l->gsc.target_pos;
-  } else {
-    glw_lp(&l->gsc.filtered_pos, w->glw_root, l->gsc.target_pos, 0.25);
-  }
-
-  l->gsc.rounded_pos = l->gsc.filtered_pos;
+  glw_scroll_layout(&l->gsc, w, rc->rc_width);
 
   TAILQ_FOREACH(c, &w->glw_childs, glw_parent_link) {
     if(c->glw_flags & GLW_HIDDEN)

--- a/src/ui/glw/glw_list.c
+++ b/src/ui/glw/glw_list.c
@@ -21,6 +21,12 @@
 #include "glw_scroll.h"
 #include "glw_navigation.h"
 
+enum {
+  GLW_LIST_TOUCH_AXIS_UNDECIDED,
+  GLW_LIST_TOUCH_AXIS_HORIZONTAL,
+  GLW_LIST_TOUCH_AXIS_VERTICAL,
+};
+
 typedef struct glw_list {
   glw_t w;
 
@@ -31,6 +37,11 @@ typedef struct glw_list {
   int16_t padding[4];
 
   glw_scroll_control_t gsc;
+
+  glw_t *touch_parent_scroll;
+  float touch_start_screen_x;
+  float touch_start_screen_y;
+  char touch_axis;
 
 } glw_list_t;
 
@@ -646,6 +657,78 @@ handle_pointer_event_filter(struct glw *w, const glw_pointer_event_t *gpe)
 }
 
 
+static int
+deliver_pointer_event(glw_t *w, const glw_pointer_event_t *gpe)
+{
+  if(w == NULL || w->glw_matrix == NULL)
+    return 0;
+
+  Vec3 p, dir;
+  glw_vec3_copy(p, glw_vec3_make(gpe->screen_x, gpe->screen_y, -2.41));
+  glw_vec3_sub(dir, p, glw_vec3_make(gpe->screen_x * 42.38,
+                                    gpe->screen_y * 42.38,
+                                    -100));
+
+  glw_pointer_event_t gpe0 = *gpe;
+  if(!glw_widget_unproject(w->glw_matrix, &gpe0.local_x, &gpe0.local_y,
+                           p, dir))
+    return 0;
+  return glw_send_pointer_event(w, &gpe0);
+}
+
+
+static int
+handle_pointer_event_filter_x(struct glw *w,
+                              const glw_pointer_event_t *gpe)
+{
+  glw_list_t *l = (glw_list_t *)w;
+
+  if(gpe->type == GLW_POINTER_TOUCH_START) {
+    l->touch_parent_scroll = w->glw_root->gr_pointer_grab_scroll;
+    l->touch_start_screen_x = gpe->screen_x;
+    l->touch_start_screen_y = gpe->screen_y;
+    l->touch_axis = GLW_LIST_TOUCH_AXIS_UNDECIDED;
+  } else if(gpe->type == GLW_POINTER_TOUCH_END) {
+    l->touch_parent_scroll = NULL;
+    l->touch_axis = GLW_LIST_TOUCH_AXIS_UNDECIDED;
+  }
+
+  return glw_scroll_handle_pointer_event_filter(&l->gsc, w, gpe);
+}
+
+
+static int
+handle_pointer_event_x(struct glw *w, const glw_pointer_event_t *gpe)
+{
+  glw_list_t *l = (glw_list_t *)w;
+
+  if(gpe->type == GLW_POINTER_FOCUS_MOTION &&
+     l->touch_axis == GLW_LIST_TOUCH_AXIS_UNDECIDED) {
+    glw_root_t *gr = w->glw_root;
+    const float dx = fabsf(gpe->screen_x - l->touch_start_screen_x) *
+      gr->gr_width;
+    const float dy = fabsf(gpe->screen_y - l->touch_start_screen_y) *
+      gr->gr_height;
+
+    if(GLW_MAX(dx, dy) < 8)
+      return 0;
+
+    if(l->touch_parent_scroll != NULL && dy > dx) {
+      l->touch_axis = GLW_LIST_TOUCH_AXIS_VERTICAL;
+      gr->gr_pointer_grab_scroll = l->touch_parent_scroll;
+      return deliver_pointer_event(l->touch_parent_scroll, gpe);
+    }
+    l->touch_axis = GLW_LIST_TOUCH_AXIS_HORIZONTAL;
+  }
+
+  if(gpe->type == GLW_POINTER_TOUCH_CANCEL) {
+    l->touch_parent_scroll = NULL;
+    l->touch_axis = GLW_LIST_TOUCH_AXIS_UNDECIDED;
+  }
+
+  return glw_scroll_handle_pointer_event_x(&l->gsc, w, gpe);
+}
+
 
 static glw_class_t glw_list_y = {
   .gc_name = "list_y",
@@ -684,9 +767,12 @@ static glw_class_t glw_list_x = {
   .gc_signal_handler = glw_list_callback,
   .gc_suggest_focus = glw_list_suggest_focus,
   .gc_set_int16_4 = glw_list_set_int16_4,
+  .gc_pointer_event = handle_pointer_event_x,
+  .gc_pointer_event_filter = handle_pointer_event_filter_x,
   .gc_bubble_event = glw_navigate_horizontal,
   .gc_set_int_unresolved = glw_list_set_int_unresolved,
   .gc_set_float_unresolved = glw_list_set_float_unresolved,
+  .gc_find_visible_child = glw_list_find_visible_child,
 };
 
 GLW_REGISTER_CLASS(glw_list_x);

--- a/src/ui/glw/glw_list.c
+++ b/src/ui/glw/glw_list.c
@@ -230,8 +230,6 @@ glw_list_layout_x(glw_t *w, const glw_rctx_t *rc)
     xpos += l->spacing;
   }
 
-  xpos += l->gsc.scroll_threshold_post;
-
   if(l->gsc.total_size != xpos) {
     l->gsc.total_size = xpos;
     l->w.glw_flags |= GLW_UPDATE_METRICS;

--- a/src/ui/glw/glw_scroll.c
+++ b/src/ui/glw/glw_scroll.c
@@ -137,6 +137,77 @@ glw_scroll_handle_pointer_event(glw_scroll_control_t *gs,
 /**
  *
  */
+int
+glw_scroll_handle_pointer_event_x(glw_scroll_control_t *gs,
+                                  glw_t *w,
+                                  const glw_pointer_event_t *gpe)
+{
+  glw_root_t *gr = w->glw_root;
+  int64_t dt;
+  const int grabbed = gr->gr_pointer_grab_scroll == w;
+  float v;
+  switch(gpe->type) {
+
+  case GLW_POINTER_SCROLL:
+    gs->bottom_anchored = 0;
+    gs->target_pos -= gs->page_size * gpe->delta_x;
+    w->glw_flags |= GLW_UPDATE_METRICS;
+    glw_schedule_refresh(w->glw_root, 0);
+    return 1;
+
+  case GLW_POINTER_FINE_SCROLL:
+    gs->bottom_anchored = 0;
+    gs->target_pos -= gpe->delta_x;
+    w->glw_flags |= GLW_UPDATE_METRICS;
+    glw_schedule_refresh(w->glw_root, 0);
+    return 1;
+
+  case GLW_POINTER_TOUCH_CANCEL:
+    if(grabbed)
+      gr->gr_pointer_grab_scroll = NULL;
+    return 1;
+
+  case GLW_POINTER_FOCUS_MOTION:
+    if(!grabbed)
+      return 0;
+
+    gs->bottom_anchored = 0;
+    gs->target_pos = (gs->initial_touch_x - gpe->local_x) *
+        gs->page_size * 0.5 + gs->initial_pos;
+
+    const int max_value =
+      MAX(0, gs->total_size - gs->page_size + gs->scroll_threshold_post);
+    gs->target_pos = GLW_CLAMP(gs->target_pos, 0, max_value);
+
+    if(abs(gs->target_pos - gs->initial_pos) > 15) {
+      if(gr->gr_pointer_press != NULL) {
+        glw_path_modify(gr->gr_pointer_press, 0, GLW_IN_PRESSED_PATH, NULL);
+        gr->gr_pointer_press = NULL;
+      }
+    }
+
+    dt = gpe->ts - gs->last_touch_time;
+    if(dt > 100) {
+      v = 1000000.0 * (gs->last_touch_x - gpe->local_x) / dt;
+      gs->touch_velocity = v * 10;
+    }
+    gs->last_touch_time = gpe->ts;
+    gs->last_touch_x = gpe->local_x;
+    gs->last_touch_y = gpe->local_y;
+    w->glw_flags |= GLW_UPDATE_METRICS;
+    glw_schedule_refresh(w->glw_root, 0);
+    break;
+
+  default:
+    return 0;
+  }
+  return 0;
+}
+
+
+/**
+ *
+ */
 void
 glw_scroll_layout(glw_scroll_control_t *gsc, glw_t *w, int height)
 {

--- a/src/ui/glw/glw_scroll.c
+++ b/src/ui/glw/glw_scroll.c
@@ -149,6 +149,8 @@ glw_scroll_handle_pointer_event_x(glw_scroll_control_t *gs,
   switch(gpe->type) {
 
   case GLW_POINTER_SCROLL:
+    if(gpe->delta_x == 0)
+      return 0;
     gs->bottom_anchored = 0;
     gs->target_pos -= gs->page_size * gpe->delta_x;
     w->glw_flags |= GLW_UPDATE_METRICS;
@@ -156,6 +158,8 @@ glw_scroll_handle_pointer_event_x(glw_scroll_control_t *gs,
     return 1;
 
   case GLW_POINTER_FINE_SCROLL:
+    if(gpe->delta_x == 0)
+      return 0;
     gs->bottom_anchored = 0;
     gs->target_pos -= gpe->delta_x;
     w->glw_flags |= GLW_UPDATE_METRICS;
@@ -163,8 +167,9 @@ glw_scroll_handle_pointer_event_x(glw_scroll_control_t *gs,
     return 1;
 
   case GLW_POINTER_TOUCH_CANCEL:
-    if(grabbed)
-      gr->gr_pointer_grab_scroll = NULL;
+    if(!grabbed)
+      return 0;
+    gr->gr_pointer_grab_scroll = NULL;
     return 1;
 
   case GLW_POINTER_FOCUS_MOTION:

--- a/src/ui/glw/glw_scroll.c
+++ b/src/ui/glw/glw_scroll.c
@@ -49,12 +49,13 @@ glw_scroll_handle_pointer_event_filter(glw_scroll_control_t *gs,
     return 0;
 
   case GLW_POINTER_TOUCH_END:
+    if(!grabbed)
+      return 0;
     if(fabsf(gs->touch_velocity) > 10) {
       gs->kinetic_scroll = gs->touch_velocity;
       glw_schedule_refresh(w->glw_root, 0);
     }
-    if(grabbed)
-      gr->gr_pointer_grab_scroll = NULL;
+    gr->gr_pointer_grab_scroll = NULL;
     return 0;
   }
 

--- a/src/ui/glw/glw_scroll.h
+++ b/src/ui/glw/glw_scroll.h
@@ -65,6 +65,10 @@ int glw_scroll_handle_pointer_event(glw_scroll_control_t *gsc,
                                     glw_t *w,
                                     const glw_pointer_event_t *gpe);
 
+int glw_scroll_handle_pointer_event_x(glw_scroll_control_t *gsc,
+                                      glw_t *w,
+                                      const glw_pointer_event_t *gpe);
+
 int glw_scroll_handle_pointer_event_filter(glw_scroll_control_t *gsc,
                                            glw_t *w,
                                            const glw_pointer_event_t *gpe);


### PR DESCRIPTION
## Summary

- add horizontal pointer and touch scrolling to `list_x`
- preserve keyboard navigation and independent scrolling for multiple rows
- document the multi-section cloner pattern for plugin developers
- add a runnable `plugin_examples/listx_cloner` example with five rows and local scrollbars

## Why

`list_x` already supported keyboard navigation and scrollbar binding, but it was not connected to horizontal pointer/touch scrolling. This makes horizontal media rows practical on touch devices and testable on Linux/WSL with `--pointer-is-touch`.

## Validation

- `git diff --check`
- `./support/configure-linux-debug.sh`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- JavaScript and JSON syntax checks
- isolated runtime smoke with five independently scrollable cloner sections
- keyboard focus and D-pad navigation
- pointer hover and per-row scrollbar drag
- horizontal simulated-touch drag and vertical outer-list swipe
- temporary ZIP discovery using the manifest `title` (archive removed after validation)

No ZIP or test artifacts are included.