### PR TITLE
Mark list_x example scrollbars optional

### DIFF
--- a/plugin_examples/README
+++ b/plugin_examples/README
@@ -49,5 +49,6 @@ specific media playback state. For those, use the manual command and inspect the
 Movian log instead of expecting a fully automated smoke.
 
 The `listx_cloner` example demonstrates multiple horizontal `list_x` rows,
-per-row scrollbars, keyboard focus, pointer hover, and touch scrolling. Add
-`--pointer-is-touch` when testing touch gestures with a mouse on Linux or WSL.
+optional per-row scrollbars, keyboard focus, pointer hover, and touch
+scrolling. Add `--pointer-is-touch` when testing touch gestures with a mouse
+on Linux or WSL.

--- a/plugin_examples/listx_cloner/listx_cloner.view
+++ b/plugin_examples/listx_cloner/listx_cloner.view
@@ -68,6 +68,7 @@ widget(list_y, {
       });
     });
 
-    SectionScrollBar();
+    // Optional pointer scrollbar for desktop and WSL; uncomment per section.
+    // SectionScrollBar();
   });
 });


### PR DESCRIPTION
## Summary

- keep the per-section `slider_x` implementation available in the example
- leave scrollbars disabled by default
- document how desktop and WSL users can opt into them
- clarify in the examples index that per-row scrollbars are optional

## Validation

- `git diff --check`
- `node --check plugin_examples/listx_cloner/listx_cloner.js`
- `jq empty plugin_examples/listx_cloner/plugin.json`
- `make BUILD=debug -j$(nproc)`
- `./build.debug/movian --help`
- isolated Xvfb runtime smoke for touch, kinetic scrolling, vertical wheel, D-pad, and outside release
- temporary `/tmp` fixture with scrollbars enabled proved independent row bindings

No ZIP or runtime artifacts are included.