### PR TITLE
Add read-only SMB2 and SMB3 backend for Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 	path = ext/libyuv
 	url = https://chromium.googlesource.com/libyuv/libyuv
 	branch = main
+[submodule "ext/libsmb2"]
+	path = ext/libsmb2
+	url = https://github.com/sahlberg/libsmb2.git
+	ref = refs/tags/libsmb2-6.2

--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ SRCS-$(CONFIG_SPOTLIGHT)       += src/fileaccess/fa_spotlight.c
 SRCS-$(CONFIG_LIBNTFS)         += src/fileaccess/fa_ntfs.c
 SRCS-$(CONFIG_NATIVESMB)       += src/fileaccess/smb/fa_nativesmb.c \
 				  src/fileaccess/smb/nmb.c
+SRCS-$(CONFIG_LIBSMB2)         += src/fileaccess/smb2/fa_libsmb2.c
 SRCS-$(CONFIG_RAR)             += src/fileaccess/fa_rar.c
 
 BUNDLES += res/fileaccess

--- a/configure.linux
+++ b/configure.linux
@@ -91,6 +91,7 @@ enable dvd
 enable libfreetype
 enable libfontconfig
 enable libpulse
+enable libsmb2
 enable lirc
 enable stdin
 enable avahi

--- a/docs/Guides/LINUX_SMB2_BACKEND.md
+++ b/docs/Guides/LINUX_SMB2_BACKEND.md
@@ -1,0 +1,63 @@
+# Linux SMB2 and SMB3 Backend
+
+Linux builds include a bundled, read-only SMB2/SMB3 backend based on
+`libsmb2-6.2`. It is available through the temporary `smb2://` scheme while
+the existing `smb://` backend remains unchanged for compatibility and A/B
+testing.
+
+## URLs
+
+Use the same server, share, and path layout as an SMB URL:
+
+```text
+smb2://server/share/path
+smb2://server:port/share/path
+smb2://user@server/share/path
+smb2://domain;user@server/share/path
+```
+
+Opening `smb2://server/` enumerates disk shares exposed by the server.
+Passwords are requested through Movian's authentication dialog and keyring;
+they are not part of the URL.
+
+## Supported Operations
+
+The initial backend supports:
+
+- host share enumeration;
+- directory browsing;
+- path metadata;
+- file open, read, seek, size, and close;
+- guest and authenticated sessions.
+
+It is intentionally read-only. Write, create, rename, delete, directory
+mutation, and extended-attribute operations are not implemented.
+
+Each open file or directory operation owns its own libsmb2 context. This keeps
+parallel resources independent and avoids sharing mutable connection state
+between file handles.
+
+## Build
+
+The standard Linux debug helper enables both backends:
+
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
+
+The resulting binary contains the pinned static libsmb2 library and does not
+require a system `libsmb2.so`. The local Flatpak profile uses the same bundled
+backend.
+
+`CONFIG_LIBSMB2` is enabled by default on Linux. Other platform defaults are
+unchanged, so their existing `smb://` implementation remains in use.
+
+## Migration
+
+The separate `smb2://` scheme is a transition tool, not a replacement public
+standard. It allows the old and new implementations to be tested side by side.
+After the new backend has equivalent platform coverage, a later change can
+move standard `smb://` URLs to libsmb2, retain `smb2://` briefly as a
+compatibility alias, and then remove the alias.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ The current branch includes:
   content type;
 - bundled FFmpeg 4.4.7 as the media backend, while keeping existing `libav`
   option names and internal build variables for compatibility;
+- a bundled read-only SMB2/SMB3 backend for Linux and Flatpak, exposed through
+  temporary `smb2://` URLs alongside the existing `smb://` backend;
 - local SteamOS/Steam Deck Flatpak packaging and small Linux runtime fixes used
   by that package;
 - a plugin debug workflow for route smoke tests against `build.debug/movian`;
@@ -117,6 +119,10 @@ The public stack currently includes these user-visible changes:
   names such as `--libav-log` remain unchanged.
 - Linux debug and Flatpak builds disable the old external `librtmp` backend by
   default and use FFmpeg's RTMP-family protocols with `gmp` and `gnutls`.
+- Linux debug and Flatpak builds include pinned static libsmb2 support.
+  `smb2://` provides read-only SMB2/SMB3 browsing and playback while the
+  existing `smb://` backend remains available for compatibility. See
+  `Guides/LINUX_SMB2_BACKEND.md`.
 - Steam launches avoid the X11 fullscreen `override_redirect` path when
   `SteamGameId` or `SteamAppId` is set. `XK_Menu` maps to Movian's menu action
   for Steam Input keyboard layouts.

--- a/ext/libsmb2.mk
+++ b/ext/libsmb2.mk
@@ -1,0 +1,5 @@
+include ${BUILDDIR}/config.mak
+
+build:
+	cmake --build ${LIBSMB2_BUILD_DIR} --parallel
+	cmake --install ${LIBSMB2_BUILD_DIR}

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -1,0 +1,706 @@
+/*
+ *  Copyright (C) 2026 Movian contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <smb2/smb2.h>
+#include <smb2/libsmb2.h>
+#include <smb2/libsmb2-raw.h>
+#include <smb2/libsmb2-dcerpc-srvsvc.h>
+
+#include "main.h"
+#include "keyring.h"
+#include "fileaccess/fa_proto.h"
+
+#define SMB2_DEFAULT_TIMEOUT 15
+
+typedef struct {
+  char *server;
+  char *share;
+  char *path;
+  char *user;
+  char *domain;
+} movian_smb2_target_t;
+
+typedef struct {
+  char *user;
+  char *password;
+  char *domain;
+} movian_smb2_credentials_t;
+
+typedef struct {
+  fa_handle_t h;
+  struct smb2_context *smb2;
+  struct smb2fh *fh;
+  int64_t size;
+  hts_mutex_t mutex;
+} movian_smb2_file_t;
+
+typedef struct {
+  int done;
+  int status;
+  struct srvsvc_NetrShareEnum_rep *reply;
+} movian_smb2_enum_state_t;
+
+
+static void
+movian_smb2_target_fini(movian_smb2_target_t *target)
+{
+  free(target->server);
+  free(target->share);
+  free(target->path);
+  free(target->user);
+  free(target->domain);
+}
+
+
+static int
+movian_smb2_target_parse(const char *url, movian_smb2_target_t *target,
+                         char *errbuf, size_t errlen)
+{
+  if(strncmp(url, "smb2://", 7)) {
+    snprintf(errbuf, errlen, "Invalid SMB2 URL");
+    return -1;
+  }
+
+  struct smb2_context *smb2 = smb2_init_context();
+  if(smb2 == NULL) {
+    snprintf(errbuf, errlen, "Unable to initialize SMB2");
+    return -1;
+  }
+
+  size_t parser_url_len = strlen(url);
+  char *parser_url = malloc(parser_url_len);
+  if(parser_url == NULL) {
+    snprintf(errbuf, errlen, "Out of memory while parsing SMB2 URL");
+    smb2_destroy_context(smb2);
+    return -1;
+  }
+  snprintf(parser_url, parser_url_len, "smb://%s", url + 7);
+
+  struct smb2_url *parsed = smb2_parse_url(smb2, parser_url);
+  free(parser_url);
+  if(parsed == NULL || parsed->server == NULL || parsed->server[0] == '\0') {
+    snprintf(errbuf, errlen, "Invalid SMB2 URL: %s", smb2_get_error(smb2));
+    if(parsed != NULL)
+      smb2_destroy_url(parsed);
+    smb2_destroy_context(smb2);
+    return -1;
+  }
+
+  target->server = strdup(parsed->server);
+  target->share = parsed->share != NULL ? strdup(parsed->share) : NULL;
+  target->path = parsed->path != NULL ? strdup(parsed->path) : strdup("");
+  target->user = parsed->user != NULL ? strdup(parsed->user) : NULL;
+  target->domain = parsed->domain != NULL ? strdup(parsed->domain) : NULL;
+
+  smb2_destroy_url(parsed);
+  smb2_destroy_context(smb2);
+
+  if(target->server == NULL || target->path == NULL) {
+    snprintf(errbuf, errlen, "Out of memory while parsing SMB2 URL");
+    movian_smb2_target_fini(target);
+    memset(target, 0, sizeof(*target));
+    return -1;
+  }
+  return 0;
+}
+
+
+static void
+movian_smb2_credentials_fini(movian_smb2_credentials_t *credentials)
+{
+  free(credentials->user);
+  free(credentials->password);
+  free(credentials->domain);
+}
+
+
+static char *
+movian_smb2_keyring_id(const movian_smb2_target_t *target)
+{
+  size_t len = strlen(target->server) + 32;
+
+  if(target->user != NULL)
+    len += strlen(target->user);
+  if(target->domain != NULL)
+    len += strlen(target->domain);
+
+  char *id = malloc(len);
+  if(id == NULL)
+    return NULL;
+
+  if(target->user != NULL) {
+    snprintf(id, len, "smb2:connection:%s%s%s@%s",
+             target->domain != NULL ? target->domain : "",
+             target->domain != NULL ? ";" : "",
+             target->user, target->server);
+  } else {
+    snprintf(id, len, "smb2:connection:%s", target->server);
+  }
+  return id;
+}
+
+
+static void
+movian_smb2_default_credentials(const movian_smb2_target_t *target,
+                                movian_smb2_credentials_t *credentials)
+{
+  credentials->user = strdup(target->user != NULL ? target->user : "guest");
+  credentials->password = NULL;
+  credentials->domain =
+    target->domain != NULL ? strdup(target->domain) : NULL;
+}
+
+
+static int
+movian_smb2_apply_target_identity(const movian_smb2_target_t *target,
+                                  movian_smb2_credentials_t *credentials,
+                                  char *errbuf, size_t errlen)
+{
+  if(target->user != NULL) {
+    char *user = strdup(target->user);
+    if(user == NULL) {
+      snprintf(errbuf, errlen, "Out of memory while preparing SMB2 login");
+      return -1;
+    }
+    free(credentials->user);
+    credentials->user = user;
+  }
+
+  if(target->domain != NULL) {
+    char *domain = strdup(target->domain);
+    if(domain == NULL) {
+      snprintf(errbuf, errlen, "Out of memory while preparing SMB2 login");
+      return -1;
+    }
+    free(credentials->domain);
+    credentials->domain = domain;
+  }
+  return 0;
+}
+
+
+static int
+movian_smb2_is_auth_error(int status, const char *reason)
+{
+  return status == -EACCES || status == -EPERM ||
+    (status == -ECONNREFUSED && reason != NULL &&
+     strstr(reason, "STATUS_LOGON_FAILURE") != NULL);
+}
+
+
+static struct smb2_context *
+movian_smb2_connect_once(const movian_smb2_target_t *target,
+                         const char *share,
+                         const movian_smb2_credentials_t *credentials,
+                         int timeout, int *status,
+                         char *errbuf, size_t errlen)
+{
+  const char *user =
+    credentials->user != NULL && credentials->user[0] != '\0' ?
+    credentials->user : "guest";
+  struct smb2_context *smb2 = smb2_init_context();
+  if(smb2 == NULL) {
+    *status = -ENOMEM;
+    snprintf(errbuf, errlen, "Unable to initialize SMB2");
+    return NULL;
+  }
+
+  smb2_set_timeout(smb2, timeout);
+  smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
+  smb2_set_user(smb2, user);
+  smb2_set_password(smb2, credentials->password);
+  if(credentials->domain != NULL)
+    smb2_set_domain(smb2, credentials->domain);
+
+  *status = smb2_connect_share(smb2, target->server, share, user);
+  if(*status == 0)
+    return smb2;
+
+  snprintf(errbuf, errlen, "%s", smb2_get_error(smb2));
+  smb2_destroy_context(smb2);
+  return NULL;
+}
+
+
+static struct smb2_context *
+movian_smb2_connect(const movian_smb2_target_t *target, const char *share,
+                    int flags, int timeout, char *errbuf, size_t errlen)
+{
+  movian_smb2_credentials_t credentials = {};
+  char *keyring_id = movian_smb2_keyring_id(target);
+  int status;
+
+  if(keyring_id == NULL) {
+    snprintf(errbuf, errlen, "Out of memory while preparing SMB2 login");
+    return NULL;
+  }
+
+  int keyring_status =
+    keyring_lookup(keyring_id, &credentials.user, &credentials.password,
+                   &credentials.domain, NULL, NULL, NULL, 0);
+  if(keyring_status != KEYRING_OK) {
+    movian_smb2_default_credentials(target, &credentials);
+  } else if(movian_smb2_apply_target_identity(target, &credentials,
+                                               errbuf, errlen)) {
+    movian_smb2_credentials_fini(&credentials);
+    free(keyring_id);
+    return NULL;
+  }
+
+  char reason[256] = {};
+  struct smb2_context *smb2 =
+    movian_smb2_connect_once(target, share, &credentials, timeout, &status,
+                            reason, sizeof(reason));
+  if(smb2 != NULL) {
+    movian_smb2_credentials_fini(&credentials);
+    free(keyring_id);
+    return smb2;
+  }
+
+  if(flags & (FA_NON_INTERACTIVE | FA_DISABLE_AUTH) ||
+     !movian_smb2_is_auth_error(status, reason)) {
+    snprintf(errbuf, errlen, "Unable to connect to SMB2 share: %s", reason);
+    movian_smb2_credentials_fini(&credentials);
+    free(keyring_id);
+    return NULL;
+  }
+
+  movian_smb2_credentials_fini(&credentials);
+  memset(&credentials, 0, sizeof(credentials));
+  if(movian_smb2_apply_target_identity(target, &credentials,
+                                       errbuf, errlen)) {
+    free(keyring_id);
+    return NULL;
+  }
+
+  size_t source_len = strlen(target->server) + 16;
+  char *source = malloc(source_len);
+  if(source == NULL) {
+    snprintf(errbuf, errlen, "Out of memory while preparing SMB2 login");
+    free(keyring_id);
+    return NULL;
+  }
+  snprintf(source, source_len, "SMB2 server '%s'", target->server);
+
+  keyring_status =
+    keyring_lookup(keyring_id,
+                   target->user != NULL ? NULL : &credentials.user,
+                   &credentials.password,
+                   target->domain != NULL ? NULL : &credentials.domain,
+                   NULL, source, reason,
+                   KEYRING_QUERY_USER | KEYRING_SHOW_REMEMBER_ME |
+                   KEYRING_REMEMBER_ME_SET);
+  free(source);
+
+  if(keyring_status != KEYRING_OK) {
+    snprintf(errbuf, errlen, "Authentication rejected by user");
+    movian_smb2_credentials_fini(&credentials);
+    free(keyring_id);
+    return NULL;
+  }
+
+  smb2 = movian_smb2_connect_once(target, share, &credentials, timeout,
+                                  &status, reason, sizeof(reason));
+  if(smb2 == NULL)
+    snprintf(errbuf, errlen, "Unable to connect to SMB2 share: %s", reason);
+
+  movian_smb2_credentials_fini(&credentials);
+  free(keyring_id);
+  return smb2;
+}
+
+
+static void
+movian_smb2_disconnect(struct smb2_context *smb2)
+{
+  if(smb2 == NULL)
+    return;
+  smb2_disconnect_share(smb2);
+  smb2_destroy_context(smb2);
+}
+
+
+static char *
+movian_smb2_child_url(const char *parent, const char *name)
+{
+  size_t parent_len = strlen(parent);
+  while(parent_len > 0 && parent[parent_len - 1] == '/')
+    parent_len--;
+
+  size_t len = parent_len + strlen(name) + 2;
+  char *url = malloc(len);
+  if(url != NULL)
+    snprintf(url, len, "%.*s/%s", (int)parent_len, parent, name);
+  return url;
+}
+
+
+static void
+movian_smb2_enum_callback(struct smb2_context *smb2, int status,
+                          void *command_data, void *opaque)
+{
+  movian_smb2_enum_state_t *state = opaque;
+  state->status = status;
+  state->reply = command_data;
+  state->done = 1;
+}
+
+
+static int
+movian_smb2_wait_for_enum(struct smb2_context *smb2,
+                          movian_smb2_enum_state_t *state)
+{
+  int64_t deadline =
+    arch_get_ts() + (SMB2_DEFAULT_TIMEOUT + 5) * 1000000LL;
+
+  while(!state->done) {
+    int64_t remaining = deadline - arch_get_ts();
+    if(remaining <= 0)
+      return -1;
+
+    struct pollfd pfd = {
+      .fd = smb2_get_fd(smb2),
+      .events = smb2_which_events(smb2),
+    };
+
+    int timeout = (remaining + 999) / 1000;
+    if(timeout > 1000)
+      timeout = 1000;
+
+    int status = poll(&pfd, 1, timeout);
+    if(status < 0) {
+      if(errno == EINTR)
+        continue;
+      return -1;
+    }
+    if(smb2_service(smb2, status == 0 ? 0 : pfd.revents) < 0)
+      return -1;
+  }
+  return 0;
+}
+
+
+static int
+movian_smb2_scan_host(fa_dir_t *fd, const char *url,
+                      const movian_smb2_target_t *target, int flags,
+                      char *errbuf, size_t errlen)
+{
+  struct smb2_context *smb2 =
+    movian_smb2_connect(target, "IPC$", flags, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, errlen);
+  if(smb2 == NULL)
+    return -1;
+
+  movian_smb2_enum_state_t state = {};
+  if(smb2_share_enum_async(smb2, SHARE_INFO_1,
+                           movian_smb2_enum_callback, &state) < 0 ||
+     movian_smb2_wait_for_enum(smb2, &state) < 0 ||
+     state.status != 0 || state.reply == NULL) {
+    snprintf(errbuf, errlen, "Unable to enumerate SMB2 shares: %s",
+             smb2_get_error(smb2));
+    if(state.reply != NULL)
+      smb2_free_data(smb2, state.reply);
+    movian_smb2_disconnect(smb2);
+    return -1;
+  }
+
+  struct srvsvc_SHARE_INFO_1_CONTAINER *shares =
+    &state.reply->ses.ShareInfo.Level1;
+  if(shares->Buffer != NULL) {
+    for(uint32_t i = 0; i < shares->EntriesRead; i++) {
+      struct srvsvc_SHARE_INFO_1 *share =
+        &shares->Buffer->share_info_1[i];
+      const char *name = share->netname.utf8;
+
+      if(share->type != SHARE_TYPE_DISKTREE || name == NULL)
+        continue;
+
+      char *child = movian_smb2_child_url(url, name);
+      if(child == NULL)
+        continue;
+
+      fa_dir_entry_t *fde = fa_dir_add(fd, child, name, CONTENT_SHARE);
+      if(fde != NULL) {
+        fde->fde_stat.fs_type = CONTENT_SHARE;
+        fde->fde_statdone = 1;
+      }
+      free(child);
+    }
+  }
+
+  smb2_free_data(smb2, state.reply);
+  movian_smb2_disconnect(smb2);
+  return 0;
+}
+
+
+static int
+movian_smb2_scan_directory(fa_dir_t *fd, const char *url,
+                           const movian_smb2_target_t *target, int flags,
+                           char *errbuf, size_t errlen)
+{
+  struct smb2_context *smb2 =
+    movian_smb2_connect(target, target->share, flags, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, errlen);
+  if(smb2 == NULL)
+    return -1;
+
+  struct smb2dir *dir = smb2_opendir(smb2, target->path);
+  if(dir == NULL) {
+    snprintf(errbuf, errlen, "Unable to open SMB2 directory: %s",
+             smb2_get_error(smb2));
+    movian_smb2_disconnect(smb2);
+    return -1;
+  }
+
+  struct smb2dirent *entry;
+  while((entry = smb2_readdir(smb2, dir)) != NULL) {
+    if(!strcmp(entry->name, ".") || !strcmp(entry->name, ".."))
+      continue;
+
+    int type = entry->st.smb2_type == SMB2_TYPE_DIRECTORY ?
+      CONTENT_DIR : CONTENT_FILE;
+    char *child = movian_smb2_child_url(url, entry->name);
+    if(child == NULL)
+      continue;
+
+    fa_dir_entry_t *fde = fa_dir_add(fd, child, entry->name, type);
+    if(fde != NULL) {
+      fde->fde_stat.fs_type = type;
+      fde->fde_stat.fs_size = entry->st.smb2_size;
+      fde->fde_stat.fs_mtime = entry->st.smb2_mtime;
+      fde->fde_statdone = 1;
+    }
+    free(child);
+  }
+
+  smb2_closedir(smb2, dir);
+  movian_smb2_disconnect(smb2);
+  return 0;
+}
+
+
+static int
+movian_smb2_scan(fa_protocol_t *fap, fa_dir_t *fd, const char *url,
+                 char *errbuf, size_t errlen, int flags)
+{
+  movian_smb2_target_t target = {};
+  if(movian_smb2_target_parse(url, &target, errbuf, errlen))
+    return -1;
+
+  int status = target.share == NULL || target.share[0] == '\0' ?
+    movian_smb2_scan_host(fd, url, &target, flags, errbuf, errlen) :
+    movian_smb2_scan_directory(fd, url, &target, flags, errbuf, errlen);
+
+  movian_smb2_target_fini(&target);
+  return status;
+}
+
+
+static fa_handle_t *
+movian_smb2_open(fa_protocol_t *fap, const char *url,
+                 char *errbuf, size_t errlen, int flags,
+                 fa_open_extra_t *foe)
+{
+  movian_smb2_target_t target = {};
+  if(movian_smb2_target_parse(url, &target, errbuf, errlen))
+    return NULL;
+
+  if(target.share == NULL || target.share[0] == '\0' ||
+     target.path[0] == '\0') {
+    snprintf(errbuf, errlen, "SMB2 URL does not identify a file");
+    movian_smb2_target_fini(&target);
+    return NULL;
+  }
+
+  int timeout = foe != NULL && foe->foe_open_timeout > 0 ?
+    (foe->foe_open_timeout + 999) / 1000 : SMB2_DEFAULT_TIMEOUT;
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&target, target.share, flags, timeout,
+                        errbuf, errlen);
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&target);
+    return NULL;
+  }
+
+  struct smb2fh *fh = smb2_open(smb2, target.path, O_RDONLY);
+  if(fh == NULL) {
+    snprintf(errbuf, errlen, "Unable to open SMB2 file: %s",
+             smb2_get_error(smb2));
+    movian_smb2_disconnect(smb2);
+    movian_smb2_target_fini(&target);
+    return NULL;
+  }
+
+  struct smb2_stat_64 statbuf;
+  if(smb2_fstat(smb2, fh, &statbuf) < 0 ||
+     statbuf.smb2_type == SMB2_TYPE_DIRECTORY) {
+    snprintf(errbuf, errlen, "Unable to stat SMB2 file: %s",
+             smb2_get_error(smb2));
+    smb2_close(smb2, fh);
+    movian_smb2_disconnect(smb2);
+    movian_smb2_target_fini(&target);
+    return NULL;
+  }
+
+  movian_smb2_file_t *file = calloc(1, sizeof(*file));
+  if(file == NULL) {
+    snprintf(errbuf, errlen, "Out of memory while opening SMB2 file");
+    smb2_close(smb2, fh);
+    movian_smb2_disconnect(smb2);
+    movian_smb2_target_fini(&target);
+    return NULL;
+  }
+
+  file->h.fh_proto = fap;
+  file->smb2 = smb2;
+  file->fh = fh;
+  file->size = statbuf.smb2_size;
+  hts_mutex_init(&file->mutex);
+
+  movian_smb2_target_fini(&target);
+  return &file->h;
+}
+
+
+static void
+movian_smb2_close(fa_handle_t *fh)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+
+  hts_mutex_lock(&file->mutex);
+  smb2_close(file->smb2, file->fh);
+  movian_smb2_disconnect(file->smb2);
+  hts_mutex_unlock(&file->mutex);
+  hts_mutex_destroy(&file->mutex);
+  free(file);
+}
+
+
+static int
+movian_smb2_read(fa_handle_t *fh, void *buf, size_t size)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+  uint32_t count = size > INT_MAX ? INT_MAX : size;
+
+  hts_mutex_lock(&file->mutex);
+  int status = smb2_read(file->smb2, file->fh, buf, count);
+  hts_mutex_unlock(&file->mutex);
+  return status;
+}
+
+
+static int64_t
+movian_smb2_seek(fa_handle_t *fh, int64_t pos, int whence, int lazy)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+
+  hts_mutex_lock(&file->mutex);
+  int64_t status = smb2_lseek(file->smb2, file->fh, pos, whence, NULL);
+  hts_mutex_unlock(&file->mutex);
+  return status;
+}
+
+
+static int64_t
+movian_smb2_fsize(fa_handle_t *fh)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+  return file->size;
+}
+
+
+static void
+movian_smb2_set_read_timeout(fa_handle_t *fh, int ms)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+  int seconds = ms > 0 ? (ms + 999) / 1000 : 0;
+
+  hts_mutex_lock(&file->mutex);
+  smb2_set_timeout(file->smb2, seconds);
+  hts_mutex_unlock(&file->mutex);
+}
+
+
+static int
+movian_smb2_stat(fa_protocol_t *fap, const char *url, struct fa_stat *fs,
+                 int flags, char *errbuf, size_t errlen)
+{
+  movian_smb2_target_t target = {};
+  if(movian_smb2_target_parse(url, &target, errbuf, errlen))
+    return FAP_ERROR;
+
+  memset(fs, 0, sizeof(*fs));
+  if(target.share == NULL || target.share[0] == '\0') {
+    fs->fs_type = CONTENT_DIR;
+    movian_smb2_target_fini(&target);
+    return FAP_OK;
+  }
+
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&target, target.share, flags, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, errlen);
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&target);
+    return FAP_ERROR;
+  }
+
+  int status = FAP_OK;
+  if(target.path[0] == '\0') {
+    fs->fs_type = CONTENT_DIR;
+  } else {
+    struct smb2_stat_64 statbuf;
+    if(smb2_stat(smb2, target.path, &statbuf) < 0) {
+      snprintf(errbuf, errlen, "Unable to stat SMB2 path: %s",
+               smb2_get_error(smb2));
+      status = FAP_ERROR;
+    } else {
+      fs->fs_type = statbuf.smb2_type == SMB2_TYPE_DIRECTORY ?
+        CONTENT_DIR : CONTENT_FILE;
+      fs->fs_size = statbuf.smb2_size;
+      fs->fs_mtime = statbuf.smb2_mtime;
+    }
+  }
+
+  movian_smb2_disconnect(smb2);
+  movian_smb2_target_fini(&target);
+  return status;
+}
+
+
+static int
+movian_smb2_no_parking(fa_handle_t *fh)
+{
+  return 1;
+}
+
+
+static fa_protocol_t fa_protocol_smb2 = {
+  .fap_flags = FAP_INCLUDE_PROTO_IN_URL | FAP_ALLOW_CACHE,
+  .fap_name = "smb2",
+  .fap_scan = movian_smb2_scan,
+  .fap_open = movian_smb2_open,
+  .fap_close = movian_smb2_close,
+  .fap_read = movian_smb2_read,
+  .fap_seek = movian_smb2_seek,
+  .fap_fsize = movian_smb2_fsize,
+  .fap_stat = movian_smb2_stat,
+  .fap_set_read_timeout = movian_smb2_set_read_timeout,
+  .fap_no_parking = movian_smb2_no_parking,
+};
+
+FAP_REGISTER(smb2);

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -426,7 +426,7 @@ movian_smb2_scan_host(fa_dir_t *fd, const char *url,
         &shares->Buffer->share_info_1[i];
       const char *name = share->netname.utf8;
 
-      if(share->type != SHARE_TYPE_DISKTREE || name == NULL)
+      if((share->type & 3) != SHARE_TYPE_DISKTREE || name == NULL)
         continue;
 
       char *child = movian_smb2_child_url(url, name);

--- a/support/check-submodules.sh
+++ b/support/check-submodules.sh
@@ -18,7 +18,8 @@ case "${1:-}" in
     cat <<EOF
 Usage: support/check-submodules.sh [--fail-on-outdated]
 
-Compare submodule gitlinks in HEAD with their configured upstream branches.
+Compare submodule gitlinks in HEAD with their configured upstream branches or
+exact refs.
 By default this is an informational check and exits 0 even when a submodule is
 outdated. Use --fail-on-outdated to make outdated or unresolved entries fail.
 EOF
@@ -46,10 +47,10 @@ short_sha() {
 status_code=0
 entries=$(git config --file .gitmodules --get-regexp '^submodule\..*\.path$')
 
-printf '%-28s %-14s %-12s %-12s %s\n' \
-  "Submodule" "Branch" "Pinned" "Upstream" "Status"
-printf '%-28s %-14s %-12s %-12s %s\n' \
-  "---------" "------" "------" "--------" "------"
+printf '%-28s %-24s %-12s %-12s %s\n' \
+  "Submodule" "Tracking" "Pinned" "Upstream" "Status"
+printf '%-28s %-24s %-12s %-12s %s\n' \
+  "---------" "--------" "------" "--------" "------"
 
 while read -r key path; do
   name=${key#submodule.}
@@ -57,16 +58,28 @@ while read -r key path; do
 
   url=$(git config --file .gitmodules --get "submodule.$name.url")
   branch=$(git config --file .gitmodules --get "submodule.$name.branch" || true)
+  exact_ref=$(git config --file .gitmodules --get "submodule.$name.ref" || true)
 
-  if [ -z "$branch" ]; then
+  if [ -n "$exact_ref" ]; then
+    tracking=${exact_ref#refs/}
+    upstream=$(git ls-remote "$url" "${exact_ref}^{}" |
+      awk 'NR == 1 { print $1 }')
+    if [ -z "$upstream" ]; then
+      upstream=$(git ls-remote "$url" "$exact_ref" |
+        awk 'NR == 1 { print $1 }')
+    fi
+  elif [ -z "$branch" ]; then
+    tracking=HEAD
     branch=HEAD
     ref=HEAD
+    upstream=$(git ls-remote "$url" "$ref" | awk 'NR == 1 { print $1 }')
   else
+    tracking=$branch
     ref=refs/heads/$branch
+    upstream=$(git ls-remote "$url" "$ref" | awk 'NR == 1 { print $1 }')
   fi
 
   pinned=$(git ls-tree HEAD "$path" | awk '$1 == "160000" { print $3 }')
-  upstream=$(git ls-remote "$url" "$ref" | awk 'NR == 1 { print $1 }')
 
   if [ -z "$pinned" ]; then
     status=missing-gitlink
@@ -89,8 +102,8 @@ while read -r key path; do
     status_code=1
   fi
 
-  printf '%-28s %-14s %-12s %-12s %s\n' \
-    "$path" "$branch" "$pinned_short" "$upstream_short" "$status"
+  printf '%-28s %-24s %-12s %-12s %s\n' \
+    "$path" "$tracking" "$pinned_short" "$upstream_short" "$status"
 done <<EOF
 $entries
 EOF

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -69,6 +69,7 @@ CONFIG_LIST="
  libogc
  libpthread
  libpulse
+ libsmb2
  librtmp
  libx11
  libxext
@@ -463,6 +464,44 @@ ext_setup() {
     rtmpdump_setup
     gumbo_setup
     vmir_setup
+    libsmb2_setup
+}
+
+
+libsmb2_setup() {
+    if disabled libsmb2; then
+        return
+    fi
+
+    which >/dev/null 2>&1 cmake || die
+    update_ext_submodule libsmb2
+
+    LIBSMB2_BUILD_DIR=${BUILDDIR}/libsmb2/build
+    mkdir -p "${LIBSMB2_BUILD_DIR}"
+
+    LIBSMB2_CC="${CC}"
+    LIBSMB2_CMAKE_LAUNCHER=
+    if enabled ccache; then
+        LIBSMB2_CC="${CC#ccache }"
+        LIBSMB2_CMAKE_LAUNCHER="-DCMAKE_C_COMPILER_LAUNCHER=ccache"
+    fi
+
+    cmake \
+        -S "${TOPDIR}/ext/libsmb2" \
+        -B "${LIBSMB2_BUILD_DIR}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER="${LIBSMB2_CC}" \
+        ${LIBSMB2_CMAKE_LAUNCHER} \
+        -DCMAKE_INSTALL_PREFIX="${EXT_INSTALL_DIR}" \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DENABLE_EXAMPLES=OFF \
+        -DENABLE_LIBKRB5=OFF \
+        -DENABLE_GSSAPI=OFF || die
+
+    echo >>${CONFIG_MAK} "LIBSMB2_BUILD_DIR=${LIBSMB2_BUILD_DIR}"
+    echo >>${CONFIG_MAK} "LDFLAGS_cfg += -lsmb2"
+    add_stamp libsmb2
 }
 
 

--- a/support/mklicense.mk
+++ b/support/mklicense.mk
@@ -10,6 +10,9 @@ LICENSEDEPS = \
 ifeq ($(CONFIG_LIBNTFS), yes)
 LICENSEDEPS += ext/libntfs_ext/LICENSE_LIBNTFS
 endif
+ifeq ($(CONFIG_LIBSMB2), yes)
+LICENSEDEPS += ext/libsmb2/COPYING
+endif
 
 ${BUILDDIR}/LICENSE: ${LICENSEDEPS}
 	echo >$@ "=================================================="
@@ -44,6 +47,11 @@ ifeq ($(CONFIG_LIBNTFS), yes)
 	echo >>$@ "libntfs\n============================"
 	cat >>$@ ext/libntfs_ext/LICENSE_LIBNTFS
 endif
+ifeq ($(CONFIG_LIBSMB2), yes)
+	echo >>$@ "\f\n============================"
+	echo >>$@ "libsmb2\n============================"
+	cat >>$@ ext/libsmb2/COPYING
+endif
 ifeq ($(CONFIG_BSPATCH), yes)
 	echo >>$@ "\f\n============================"
 	echo >>$@ "bspatch\n============================"
@@ -58,5 +66,4 @@ ${BUILDDIR}/LICENSE.ps: ${BUILDDIR}/LICENSE support/mklicense.mk
 
 ${BUILDDIR}/LICENSE.pdf: ${BUILDDIR}/LICENSE.ps support/mklicense.mk
 	ps2pdfwr -sPAPERSIZE=a4 -dOptimize=true -dEmbedAllFonts=true $< $@
-
 


### PR DESCRIPTION
## Summary

- add a pinned static `libsmb2-6.2` module to Linux and Flatpak builds
- add a read-only `smb2://` backend for share discovery, browse, stat, open, read, seek, size, and close
- keep the existing `smb://` backend unchanged for compatibility and side-by-side testing
- document the temporary scheme and migration path

## Design

Each open file or directory owns an independent libsmb2 context. Authentication uses Movian's existing keyring flow, with credentials separated by host, port, user, and domain. The initial backend intentionally excludes all write and mutation operations.

Only Linux enables libsmb2 by default. Other platform defaults remain unchanged.

## Validation

- clean Linux debug configure and build
- `./build.debug/movian --help`
- static linkage check: no external `libsmb2.so`
- guest and authenticated Samba shares
- wrong-password interactive and non-interactive paths
- host/share/directory browse
- image and ZIP access
- H.264/AAC playback, seek, stop, and reopen
- parallel resources and disconnect/reconnect
- legacy `smb://` comparison against an SMB1-compatible server
- full Flatpak build and AppStream validation
- Flatpak runtime browse through `smb2://`
- `git diff --check`

## Security note

No credentials, test server addresses, or local environment paths are included in this branch.