### PR TITLE
Linux: discover SMB servers through Avahi

### DIFF
--- a/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
+++ b/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
@@ -24,7 +24,6 @@ deferred subsystems:
 --disable-webkit
 --disable-dvd
 --disable-vdpau
---disable-avahi
 --disable-libxss
 --disable-libxxf86vm
 --disable-librtmp
@@ -65,10 +64,13 @@ sockets=x11;wayland;pulseaudio;
 devices=dri;
 filesystems=xdg-download:ro;xdg-pictures:ro;xdg-videos:ro;xdg-music:ro;
 persistent=.hts;.cache/movian;
+system-talk-name=org.freedesktop.Avahi;
 ```
 
 The persisted directories preserve Movian's legacy settings, plugin state, and
 image cache inside the Flatpak app home.
+The Avahi system-bus permission allows Local network discovery while service
+traffic continues to use the shared network namespace.
 
 ## Host Setup
 
@@ -208,7 +210,7 @@ and writes environment and launch diagnostics to:
 - The manifest uses local `type: dir` sources; Flathub needs pinned source
   archives and hashes.
 - Hardware acceleration is disabled for this first package profile.
-- DVD, RTMP, GU/WebKit, Avahi, VDPAU, libXss, and libXxf86vm are disabled.
+- DVD, RTMP, GU/WebKit, VDPAU, libXss, and libXxf86vm are disabled.
 - The sandbox exposes common XDG media folders read-only, not every removable
   media path.
 - Native `/dev/input/event*` controller access is not requested; use Steam

--- a/docs/Guides/LINUX_SMB2_BACKEND.md
+++ b/docs/Guides/LINUX_SMB2_BACKEND.md
@@ -20,6 +20,11 @@ Opening `smb2://server/` enumerates disk shares exposed by the server.
 Passwords are requested through Movian's authentication dialog and keyring;
 they are not part of the URL.
 
+Linux builds discover `_smb._tcp` services through Avahi. Discovered servers
+appear under Local network and preserve the advertised port in their
+`smb2://server:port/` URL. Flatpak builds use the host Avahi daemon through
+its system D-Bus service.
+
 ## Supported Operations
 
 The initial backend supports:

--- a/src/sd/avahi.c
+++ b/src/sd/avahi.c
@@ -107,6 +107,10 @@ resolve_callback(AvahiServiceResolver *r,
       sd_add_service_htsp(si, name, a, port);
       break;
 
+    case SERVICE_SMB:
+      sd_add_service_smb(si, name, a, port);
+      break;
+
     case SERVICE_WEBDAV:
       apath = avahi_string_list_find(txt, "path");
       if(apath == NULL ||
@@ -403,6 +407,7 @@ avahi_thread(void *aux)
 
   service_type_add("_webdav._tcp", SERVICE_WEBDAV, c);
   service_type_add("_htsp._tcp", SERVICE_HTSP, c);
+  service_type_add("_smb._tcp", SERVICE_SMB, c);
 
 #if ENABLE_AIRPLAY
   name = strdup(APPNAMEUSER);

--- a/src/sd/sd.c
+++ b/src/sd/sd.c
@@ -151,6 +151,27 @@ sd_add_service_htsp(service_instance_t *si, const char *name,
 
 
 /**
+ * SMB service creator
+ */
+void
+sd_add_service_smb(service_instance_t *si, const char *name,
+                   const char *host, int port)
+{
+  char url[URL_MAX];
+  char buf[256];
+#ifdef CONFIG_LIBSMB2
+  const char *scheme = "smb2";
+#else
+  const char *scheme = "smb";
+#endif
+
+  snprintf(url, sizeof(url), "%s://%s:%d/", scheme, host, port);
+  snprintf(buf, sizeof(buf), "SMB server on %s:%d", host, port);
+  sd_add_service(si, name, url, "server", 0, buf);
+}
+
+
+/**
  * Webdav service creator
  */
 void

--- a/src/sd/sd.h
+++ b/src/sd/sd.h
@@ -27,6 +27,7 @@ LIST_HEAD(service_instance_list, service_instance);
 
 typedef enum {
   SERVICE_HTSP,
+  SERVICE_SMB,
   SERVICE_WEBDAV,
 } service_class_t;
 
@@ -59,6 +60,9 @@ void si_destroy(service_instance_t *si);
 
 void sd_add_service_htsp(service_instance_t *si, const char *name,
                          const char *host, int port);
+
+void sd_add_service_smb(service_instance_t *si, const char *name,
+                        const char *host, int port);
 
 void sd_add_service_webdav(service_instance_t *si, const char *name, 
                            const char *host, int port, const char *path,

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -103,6 +103,15 @@ The package persists Movian's legacy state and cache:
 --persist=.cache/movian
 ```
 
+Avahi service discovery uses the host daemon over the system D-Bus:
+
+```text
+--system-talk-name=org.freedesktop.Avahi
+```
+
+This allows `_smb._tcp` servers to appear under Local network without
+granting broader system bus access.
+
 AppStream metadata is generated from `dev.uzver.Movian.metainfo.xml.in`
 during the build. The version comes from:
 

--- a/support/flatpak/dev.uzver.Movian.yml
+++ b/support/flatpak/dev.uzver.Movian.yml
@@ -11,6 +11,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
+  - --system-talk-name=org.freedesktop.Avahi
   - --filesystem=xdg-videos:ro
   - --filesystem=xdg-music:ro
   - --filesystem=xdg-pictures:ro
@@ -51,7 +52,6 @@ modules:
         --disable-webkit
         --disable-dvd
         --disable-vdpau
-        --disable-avahi
         --disable-libxss
         --disable-libxxf86vm
         --disable-librtmp


### PR DESCRIPTION
## Summary

- browse `_smb._tcp` services through the existing Avahi service-discovery backend
- expose discovered Linux servers with the transitional `smb2://host:port/` URL
- allow the Flatpak to talk to the host Avahi daemon over its narrow system D-Bus permission
- document Linux and Flatpak discovery behavior

## Why

The bundled Linux SMB2/SMB3 backend could browse explicitly entered servers, but local SMB services were not shown under Local network. Avahi support was also disabled in the Flatpak profile.

## Validation

- `git diff --check`
- Linux debug configure/build and `./build.debug/movian --help`
- temporary `_smb._tcp` publication discovered in `discovered:`
- host and share browse through `smb2://host:port/`
- SMB image read verified by matching SHA-256
- full Flatpak rebuild and AppStream validation
- Flatpak Avahi D-Bus access and discovery smoke
- confirmed the Flatpak binary has no external `libsmb2` linkage

The branch contains three separate commits for discovery, Flatpak packaging, and documentation.