### PR TITLE
Add resilient Codex project workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /build.*
+/.codex/
+/.codegraph/
+/.codex-session.md
 config.default
 *~
 ps3support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ Always run `git diff --check`. Scale additional tests to the changed behavior.
 
 ## Recovery
 
-Run `support/codex/context.sh check` at the start of a resumed session and
-`support/codex/context.sh refresh` after a merge. Local state belongs under
+When `.codex/context.sh` exists, run its `check` command at the start of a
+resumed session and `refresh` after a merge so local integrations are updated.
+Otherwise use `support/codex/context.sh` directly. Local state belongs under
 ignored `.codex/`; never commit generated handoff files, indexes, credentials,
 machine-specific paths, or test artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Movian Agent Instructions
+
+## Scope
+
+- Treat every tracked file and commit as public.
+- Use only public sources and independently implemented behavior.
+- Keep changes small, focused, and reviewable.
+- Work from `movian6` on a topic branch.
+- Keep separate logical changes in separate commits; do not squash by default.
+- Do not push, merge, or delete remote branches without an explicit request.
+
+## Code Navigation
+
+When `.codegraph/` exists, use CodeGraph before broad searches or exploratory
+file reads:
+
+- `codegraph explore "<question>"` for flows and related symbols;
+- `codegraph node <symbol-or-file>` for one symbol or file;
+- `codegraph query <name>` to locate a symbol.
+
+Use the equivalent MCP tools when available. Fall back to `rg` when the index
+does not cover the question or reports pending changes.
+
+## Build And Validation
+
+For Linux debug changes:
+
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc)
+./build.debug/movian --help
+```
+
+Always run `git diff --check`. Scale additional tests to the changed behavior.
+
+## Recovery
+
+Run `support/codex/context.sh check` at the start of a resumed session and
+`support/codex/context.sh refresh` after a merge. Local state belongs under
+ignored `.codex/`; never commit generated handoff files, indexes, credentials,
+machine-specific paths, or test artifacts.

--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -2,68 +2,52 @@
 
 set -euo pipefail
 
-usage() {
-  echo "Usage: $0 check|refresh|doctor" >&2
-  exit 2
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Not inside a Git repository" >&2
+  exit 1
 }
+STATE_DIR="${ROOT}/.codex"
+cd "${ROOT}"
 
-repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null
-}
-
-find_codegraph() {
+codegraph_cmd() {
   if command -v codegraph >/dev/null 2>&1; then
     command -v codegraph
     return
   fi
 
-  local candidate
-  candidate=$(find "${HOME}/.nvm/versions/node" \
+  [[ -d "${HOME}/.nvm/versions/node" ]] || return
+  find "${HOME}/.nvm/versions/node" \
     \( -path '*/bin/codegraph' -type l -o -path '*/bin/codegraph' -type f \) \
-    2>/dev/null | sort -V | tail -1)
-  if [[ -n "${candidate}" ]]; then
-    printf '%s\n' "${candidate}"
-  fi
+    2>/dev/null | sort -V | tail -1
 }
 
-git_value() {
-  git "$@" 2>/dev/null || printf '%s\n' "(none)"
-}
+print_state() {
+  local upstream origin
+  upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo none)
+  origin=$(git remote get-url origin 2>/dev/null || echo none)
 
-print_git_state() {
-  local branch head upstream origin
-  branch=$(git_value branch --show-current)
-  head=$(git_value rev-parse HEAD)
-  upstream=$(git_value rev-parse --abbrev-ref '@{upstream}')
-  origin=$(git_value remote get-url origin)
-
-  printf 'Repository: %s\n' "${ROOT}"
-  printf 'Branch:     %s\n' "${branch}"
-  printf 'HEAD:       %s\n' "${head}"
-  printf 'Upstream:   %s\n' "${upstream}"
-  printf 'Origin:     %s\n' "${origin}"
+  echo "Repository: ${ROOT}"
+  echo "Branch:     $(git branch --show-current)"
+  echo "HEAD:       $(git rev-parse HEAD)"
+  echo "Upstream:   ${upstream}"
+  echo "Origin:     ${origin}"
   git status --short --branch
 }
 
-check_state() {
-  print_git_state
+check() {
+  print_state
 
-  if [[ -f "${STATE_DIR}/STATE.md" ]]; then
-    local recorded current
-    recorded=$(sed -n 's/^- HEAD: `\([^`]*\)`/\1/p' \
-      "${STATE_DIR}/STATE.md" | head -1)
-    current=$(git rev-parse HEAD)
-    if [[ "${recorded}" == "${current}" ]]; then
-      echo "Local state: current"
-    else
-      echo "Local state: stale; run '$0 refresh'"
-    fi
+  local current recorded codegraph
+  current=$(git rev-parse HEAD)
+  recorded=$(sed -n 's/^- HEAD: //p' "${STATE_DIR}/STATE.md" 2>/dev/null |
+    head -1 || true)
+  if [[ "${recorded}" == "${current}" ]]; then
+    echo "Local state HEAD: current"
   else
-    echo "Local state: missing; run '$0 refresh'"
+    echo "Local state HEAD: stale or missing; run '$0 refresh'"
   fi
 
-  local codegraph
-  codegraph=$(find_codegraph || true)
+  codegraph=$(codegraph_cmd || true)
   if [[ -n "${codegraph}" && -d "${ROOT}/.codegraph" ]]; then
     "${codegraph}" status "${ROOT}"
   elif [[ -d "${ROOT}/.codegraph" ]]; then
@@ -73,120 +57,89 @@ check_state() {
   fi
 }
 
-refresh_state() {
+refresh() {
+  local generated branch head upstream origin merge status commits
   mkdir -p "${STATE_DIR}"
 
-  local generated branch head upstream origin merge status commits
   generated=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-  branch=$(git_value branch --show-current)
-  head=$(git_value rev-parse HEAD)
-  upstream=$(git_value rev-parse --abbrev-ref '@{upstream}')
-  origin=$(git_value remote get-url origin)
-  merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || true)
+  branch=$(git branch --show-current)
+  head=$(git rev-parse HEAD)
+  upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo none)
+  origin=$(git remote get-url origin 2>/dev/null || echo none)
+  merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || echo none)
   status=$(git status --short)
   commits=$(git log --oneline --decorate -8)
 
   {
     echo "# Repository State"
     echo
-    echo "- Generated: \`${generated}\`"
-    echo "- Branch: \`${branch}\`"
-    echo "- HEAD: \`${head}\`"
-    echo "- Upstream: \`${upstream}\`"
-    echo "- Origin: \`${origin}\`"
-    echo "- Latest merge: \`${merge:-none}\`"
+    echo "- Generated: ${generated}"
+    echo "- Branch: ${branch}"
+    echo "- HEAD: ${head}"
+    echo "- Upstream: ${upstream}"
+    echo "- Origin: ${origin}"
+    echo "- Latest merge: ${merge:-none}"
     echo
     echo "## Working Tree"
     echo
-    if [[ -n "${status}" ]]; then
-      printf '```text\n%s\n```\n' "${status}"
-    else
-      echo "Clean."
-    fi
+    printf '%s\n' "${status:-Clean.}"
     echo
     echo "## Recent Commits"
     echo
-    printf '```text\n%s\n```\n' "${commits}"
+    printf '%s\n' "${commits}"
   } >"${STATE_DIR}/STATE.md"
 
   {
     echo "# Session Handoff"
     echo
-    echo "Generated from Git on \`${generated}\`."
+    echo "Generated from Git on ${generated}."
     echo
     echo "## Resume"
     echo
-    echo "1. Read \`AGENTS.md\`."
-    echo "2. Run \`.codex/context.sh doctor\`."
-    echo "3. Read \`.codex/STATE.md\` and inspect \`git diff\`."
+    echo "1. Read AGENTS.md."
+    echo "2. Run .codex/context.sh doctor."
+    echo "3. Read .codex/STATE.md and inspect git diff."
     echo "4. Use CodeGraph before broad code exploration."
     echo
     echo "## Current Git Facts"
     echo
-    echo "- Branch: \`${branch}\`"
-    echo "- HEAD: \`${head}\`"
-    echo "- Latest merge: \`${merge:-none}\`"
-    echo
-    echo "Add task-specific decisions and remaining work below this generated section."
+    echo "- Branch: ${branch}"
+    echo "- HEAD: ${head}"
+    echo "- Latest merge: ${merge:-none}"
   } >"${STATE_DIR}/HANDOFF.md"
 
   echo "Updated ${STATE_DIR}/STATE.md and ${STATE_DIR}/HANDOFF.md"
 }
 
 doctor() {
-  local failed=0 codegraph
+  local failed=0 codegraph pattern
+  check
 
-  check_state
-
-  for path in \
-    "${ROOT}/AGENTS.md" \
-    "${ROOT}/support/configure-linux-debug.sh"; do
-    if [[ ! -f "${path}" ]]; then
-      echo "Missing required file: ${path}" >&2
-      failed=1
-    fi
-  done
+  [[ -f AGENTS.md ]] || { echo "Missing AGENTS.md" >&2; failed=1; }
+  [[ -x support/configure-linux-debug.sh ]] ||
+    { echo "Missing Linux build helper" >&2; failed=1; }
 
   for pattern in '/.codex/' '/.codegraph/' '/.codex-session.md'; do
-    if ! grep -Fxq "${pattern}" "${ROOT}/.gitignore"; then
-      echo "Missing ignore rule: ${pattern}" >&2
-      failed=1
-    fi
+    grep -Fxq "${pattern}" .gitignore ||
+      { echo "Missing ignore rule: ${pattern}" >&2; failed=1; }
   done
 
-  codegraph=$(find_codegraph || true)
-  if [[ -z "${codegraph}" ]]; then
-    echo "CodeGraph CLI not found" >&2
-    failed=1
-  elif [[ ! -d "${ROOT}/.codegraph" ]]; then
-    echo "CodeGraph index not initialized" >&2
-    failed=1
-  fi
+  codegraph=$(codegraph_cmd || true)
+  [[ -n "${codegraph}" ]] ||
+    { echo "CodeGraph CLI not found" >&2; failed=1; }
+  [[ -d .codegraph ]] ||
+    { echo "CodeGraph index not initialized" >&2; failed=1; }
 
-  if ((failed)); then
-    return 1
-  fi
+  ((failed == 0)) || return 1
   echo "Doctor: OK"
 }
 
-ROOT=$(repo_root) || {
-  echo "Not inside a Git repository" >&2
-  exit 1
-}
-STATE_DIR="${ROOT}/.codex"
-cd "${ROOT}"
-
 case "${1:-}" in
-  check)
-    check_state
-    ;;
-  refresh)
-    refresh_state
-    ;;
-  doctor)
-    doctor
-    ;;
+  check) check ;;
+  refresh) refresh ;;
+  doctor) doctor ;;
   *)
-    usage
+    echo "Usage: $0 check|refresh|doctor" >&2
+    exit 2
     ;;
 esac

--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -58,7 +58,7 @@ check() {
 }
 
 refresh() {
-  local generated branch head upstream origin merge status commits
+  local generated branch head upstream origin merge status commits recovery
   mkdir -p "${STATE_DIR}"
 
   generated=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -69,6 +69,11 @@ refresh() {
   merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || echo none)
   status=$(git status --short)
   commits=$(git log --oneline --decorate -8)
+  if [[ -x "${ROOT}/.codex/context.sh" ]]; then
+    recovery=".codex/context.sh"
+  else
+    recovery="support/codex/context.sh"
+  fi
 
   {
     echo "# Repository State"
@@ -97,7 +102,7 @@ refresh() {
     echo "## Resume"
     echo
     echo "1. Read AGENTS.md."
-    echo "2. Run .codex/context.sh doctor."
+    echo "2. Run ${recovery} doctor."
     echo "3. Read .codex/STATE.md and inspect git diff."
     echo "4. Use CodeGraph before broad code exploration."
     echo

--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 check|refresh|doctor" >&2
+  exit 2
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null
+}
+
+find_codegraph() {
+  if command -v codegraph >/dev/null 2>&1; then
+    command -v codegraph
+    return
+  fi
+
+  local candidate
+  candidate=$(find "${HOME}/.nvm/versions/node" \
+    \( -path '*/bin/codegraph' -type l -o -path '*/bin/codegraph' -type f \) \
+    2>/dev/null | sort -V | tail -1)
+  if [[ -n "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+  fi
+}
+
+git_value() {
+  git "$@" 2>/dev/null || printf '%s\n' "(none)"
+}
+
+print_git_state() {
+  local branch head upstream origin
+  branch=$(git_value branch --show-current)
+  head=$(git_value rev-parse HEAD)
+  upstream=$(git_value rev-parse --abbrev-ref '@{upstream}')
+  origin=$(git_value remote get-url origin)
+
+  printf 'Repository: %s\n' "${ROOT}"
+  printf 'Branch:     %s\n' "${branch}"
+  printf 'HEAD:       %s\n' "${head}"
+  printf 'Upstream:   %s\n' "${upstream}"
+  printf 'Origin:     %s\n' "${origin}"
+  git status --short --branch
+}
+
+check_state() {
+  print_git_state
+
+  if [[ -f "${STATE_DIR}/STATE.md" ]]; then
+    local recorded current
+    recorded=$(sed -n 's/^- HEAD: `\([^`]*\)`/\1/p' \
+      "${STATE_DIR}/STATE.md" | head -1)
+    current=$(git rev-parse HEAD)
+    if [[ "${recorded}" == "${current}" ]]; then
+      echo "Local state: current"
+    else
+      echo "Local state: stale; run '$0 refresh'"
+    fi
+  else
+    echo "Local state: missing; run '$0 refresh'"
+  fi
+
+  local codegraph
+  codegraph=$(find_codegraph || true)
+  if [[ -n "${codegraph}" && -d "${ROOT}/.codegraph" ]]; then
+    "${codegraph}" status "${ROOT}"
+  elif [[ -d "${ROOT}/.codegraph" ]]; then
+    echo "CodeGraph: index exists, CLI not found"
+  else
+    echo "CodeGraph: not initialized"
+  fi
+}
+
+refresh_state() {
+  mkdir -p "${STATE_DIR}"
+
+  local generated branch head upstream origin merge status commits
+  generated=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  branch=$(git_value branch --show-current)
+  head=$(git_value rev-parse HEAD)
+  upstream=$(git_value rev-parse --abbrev-ref '@{upstream}')
+  origin=$(git_value remote get-url origin)
+  merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || true)
+  status=$(git status --short)
+  commits=$(git log --oneline --decorate -8)
+
+  {
+    echo "# Repository State"
+    echo
+    echo "- Generated: \`${generated}\`"
+    echo "- Branch: \`${branch}\`"
+    echo "- HEAD: \`${head}\`"
+    echo "- Upstream: \`${upstream}\`"
+    echo "- Origin: \`${origin}\`"
+    echo "- Latest merge: \`${merge:-none}\`"
+    echo
+    echo "## Working Tree"
+    echo
+    if [[ -n "${status}" ]]; then
+      printf '```text\n%s\n```\n' "${status}"
+    else
+      echo "Clean."
+    fi
+    echo
+    echo "## Recent Commits"
+    echo
+    printf '```text\n%s\n```\n' "${commits}"
+  } >"${STATE_DIR}/STATE.md"
+
+  {
+    echo "# Session Handoff"
+    echo
+    echo "Generated from Git on \`${generated}\`."
+    echo
+    echo "## Resume"
+    echo
+    echo "1. Read \`AGENTS.md\`."
+    echo "2. Run \`.codex/context.sh doctor\`."
+    echo "3. Read \`.codex/STATE.md\` and inspect \`git diff\`."
+    echo "4. Use CodeGraph before broad code exploration."
+    echo
+    echo "## Current Git Facts"
+    echo
+    echo "- Branch: \`${branch}\`"
+    echo "- HEAD: \`${head}\`"
+    echo "- Latest merge: \`${merge:-none}\`"
+    echo
+    echo "Add task-specific decisions and remaining work below this generated section."
+  } >"${STATE_DIR}/HANDOFF.md"
+
+  echo "Updated ${STATE_DIR}/STATE.md and ${STATE_DIR}/HANDOFF.md"
+}
+
+doctor() {
+  local failed=0 codegraph
+
+  check_state
+
+  for path in \
+    "${ROOT}/AGENTS.md" \
+    "${ROOT}/support/configure-linux-debug.sh"; do
+    if [[ ! -f "${path}" ]]; then
+      echo "Missing required file: ${path}" >&2
+      failed=1
+    fi
+  done
+
+  for pattern in '/.codex/' '/.codegraph/' '/.codex-session.md'; do
+    if ! grep -Fxq "${pattern}" "${ROOT}/.gitignore"; then
+      echo "Missing ignore rule: ${pattern}" >&2
+      failed=1
+    fi
+  done
+
+  codegraph=$(find_codegraph || true)
+  if [[ -z "${codegraph}" ]]; then
+    echo "CodeGraph CLI not found" >&2
+    failed=1
+  elif [[ ! -d "${ROOT}/.codegraph" ]]; then
+    echo "CodeGraph index not initialized" >&2
+    failed=1
+  fi
+
+  if ((failed)); then
+    return 1
+  fi
+  echo "Doctor: OK"
+}
+
+ROOT=$(repo_root) || {
+  echo "Not inside a Git repository" >&2
+  exit 1
+}
+STATE_DIR="${ROOT}/.codex"
+cd "${ROOT}"
+
+case "${1:-}" in
+  check)
+    check_state
+    ;;
+  refresh)
+    refresh_state
+    ;;
+  doctor)
+    doctor
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -21,10 +21,16 @@ codegraph_cmd() {
     2>/dev/null | sort -V | tail -1
 }
 
+sanitize_remote_url() {
+  printf '%s\n' "$1" |
+    sed -E 's#^([[:alpha:]][[:alnum:]+.-]*://)[^/@]*@#\1#'
+}
+
 print_state() {
   local upstream origin
   upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo none)
   origin=$(git remote get-url origin 2>/dev/null || echo none)
+  origin=$(sanitize_remote_url "${origin}")
 
   echo "Repository: ${ROOT}"
   echo "Branch:     $(git branch --show-current)"
@@ -66,6 +72,7 @@ refresh() {
   head=$(git rev-parse HEAD)
   upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo none)
   origin=$(git remote get-url origin 2>/dev/null || echo none)
+  origin=$(sanitize_remote_url "${origin}")
   merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || echo none)
   status=$(git status --short)
   commits=$(git log --oneline --decorate -8)


### PR DESCRIPTION
## Summary

- add repository-level agent guidance for public-safe, reviewable work
- make local Codex state, CodeGraph indexes, and generated handoffs explicitly ignored
- add a portable `check|refresh|doctor` helper for recovering Git and CodeGraph context after a session interruption

## Why

Codex sessions and local tool state can be interrupted by application updates. The repository needs a small durable layer that restores authoritative Git facts without committing machine-specific configuration, generated state, credentials, or research notes.

## Developer impact

A resumed session can run:

```sh
support/codex/context.sh check
support/codex/context.sh refresh
support/codex/context.sh doctor
```

When an ignored project wrapper exists, `AGENTS.md` directs agents to use it so local integrations can extend the public helper.

## Validation

- `git diff --check`
- shell syntax checks for tracked and local helpers
- `check`, `refresh`, and `doctor` against the Movian checkout
- recovery helper smoke in a temporary repository without CodeGraph or an upstream remote
- CodeGraph index sync/status and direct MCP initialize handshake
- verified `.codex/`, `.codegraph/`, and `.codex-session.md` remain untracked
- public-safety scan for machine paths, credentials, and private terminology
- Linux debug configure/build and `./build.debug/movian --help` (`5.0.667.g5ce01`)

The branch preserves separate commits and is intended to merge without squash.