### PR TITLE
Fix generated Codex recovery commands

### DIFF
--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -26,12 +26,16 @@ sanitize_remote_url() {
     sed -E 's#^([[:alpha:]][[:alnum:]+.-]*://)[^/@]*@#\1#'
 }
 
-recovery_script() {
+recovery_command() {
+  local action=$1 script
+
   if [[ -x "${ROOT}/.codex/context.sh" ]]; then
-    echo ".codex/context.sh"
+    script="${ROOT}/.codex/context.sh"
   else
-    echo "support/codex/context.sh"
+    script="${ROOT}/support/codex/context.sh"
   fi
+
+  printf '%q %q\n' "${script}" "${action}"
 }
 
 print_state() {
@@ -58,8 +62,8 @@ check() {
   if [[ "${recorded}" == "${current}" ]]; then
     echo "Local state HEAD: current"
   else
-    recovery=$(recovery_script)
-    echo "Local state HEAD: stale or missing; run '${recovery} refresh'"
+    recovery=$(recovery_command refresh)
+    echo "Local state HEAD: stale or missing; run ${recovery}"
   fi
 
   codegraph=$(codegraph_cmd || true)
@@ -85,7 +89,7 @@ refresh() {
   merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || echo none)
   status=$(git status --short)
   commits=$(git log --oneline --decorate -8)
-  recovery=$(recovery_script)
+  recovery=$(recovery_command check)
 
   {
     echo "# Repository State"
@@ -114,7 +118,7 @@ refresh() {
     echo "## Resume"
     echo
     echo "1. Read AGENTS.md."
-    echo "2. Run ${recovery} check."
+    echo "2. Run \`${recovery}\`."
     echo "3. Read .codex/STATE.md and inspect git diff."
     echo "4. Use CodeGraph before broad code exploration."
     echo

--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -118,7 +118,9 @@ refresh() {
     echo "## Resume"
     echo
     echo "1. Read AGENTS.md."
-    echo "2. Run \`${recovery}\`."
+    echo "2. Run:"
+    echo
+    echo "       ${recovery}"
     echo "3. Read .codex/STATE.md and inspect git diff."
     echo "4. Use CodeGraph before broad code exploration."
     echo

--- a/support/codex/context.sh
+++ b/support/codex/context.sh
@@ -26,6 +26,14 @@ sanitize_remote_url() {
     sed -E 's#^([[:alpha:]][[:alnum:]+.-]*://)[^/@]*@#\1#'
 }
 
+recovery_script() {
+  if [[ -x "${ROOT}/.codex/context.sh" ]]; then
+    echo ".codex/context.sh"
+  else
+    echo "support/codex/context.sh"
+  fi
+}
+
 print_state() {
   local upstream origin
   upstream=$(git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null || echo none)
@@ -43,14 +51,15 @@ print_state() {
 check() {
   print_state
 
-  local current recorded codegraph
+  local current recorded codegraph recovery
   current=$(git rev-parse HEAD)
   recorded=$(sed -n 's/^- HEAD: //p' "${STATE_DIR}/STATE.md" 2>/dev/null |
     head -1 || true)
   if [[ "${recorded}" == "${current}" ]]; then
     echo "Local state HEAD: current"
   else
-    echo "Local state HEAD: stale or missing; run '$0 refresh'"
+    recovery=$(recovery_script)
+    echo "Local state HEAD: stale or missing; run '${recovery} refresh'"
   fi
 
   codegraph=$(codegraph_cmd || true)
@@ -76,11 +85,7 @@ refresh() {
   merge=$(git log --merges -1 --format='%H %s' 2>/dev/null || echo none)
   status=$(git status --short)
   commits=$(git log --oneline --decorate -8)
-  if [[ -x "${ROOT}/.codex/context.sh" ]]; then
-    recovery=".codex/context.sh"
-  else
-    recovery="support/codex/context.sh"
-  fi
+  recovery=$(recovery_script)
 
   {
     echo "# Repository State"
@@ -109,7 +114,7 @@ refresh() {
     echo "## Resume"
     echo
     echo "1. Read AGENTS.md."
-    echo "2. Run ${recovery} doctor."
+    echo "2. Run ${recovery} check."
     echo "3. Read .codex/STATE.md and inspect git diff."
     echo "4. Use CodeGraph before broad code exploration."
     echo


### PR DESCRIPTION
## Summary

- generate an absolute shell-escaped recovery command that works from the caller's directory
- use the non-strict `check` command in generated handoffs
- render generated commands in an indented Markdown code block
- preserve the optional local `.codex/context.sh` wrapper when present

## Root cause

The recovery helper reused `$0` after changing its own working directory, but that internal `cd` does not change the caller shell's directory. A replacement repository-relative path was therefore still invalid when copied from a nested directory. Generated handoffs also called strict `doctor`, even though a clean checkout without CodeGraph is a supported fallback configuration. Finally, inline Markdown code cannot safely contain every shell-escaped path, such as one with a literal backtick.

## Validation

- `bash -n support/codex/context.sh`
- `git diff --check`
- clean temporary Git checkout without CodeGraph
- invocation from `sub/dir` using `../../support/codex/context.sh check`
- execution of the printed recovery command from that same `sub/dir`
- fixture repository path containing both a space and literal backtick
- execution of the command extracted from the generated handoff
- generated handoff with and without `.codex/context.sh`
- `./build.debug/movian --help`

Follow-up to the post-merge review of #41.