### PR TITLE
SMB2 writable operations and navigation parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,15 @@ file reads:
 Use the equivalent MCP tools when available. Fall back to `rg` when the index
 does not cover the question or reports pending changes.
 
+## WSL Workspace Guardrail
+
+When working from Windows tooling against this WSL checkout, open the workspace
+through the WSL UNC path (`\\wsl.localhost\<Distro>\...`) instead of a Windows
+mirror such as `C:\home\...`. Run compound shell commands inside one WSL bash
+invocation, for example `wsl -d Ubuntu --cd /path/to/repo -- bash -lc '...'`,
+so pipes, redirects, `$(...)`, `&&`, and tools such as `sed` execute in Linux
+rather than PowerShell.
+
 ## Build And Validation
 
 For Linux debug changes:

--- a/docs/Guides/PLUGIN_API_REFERENCE.md
+++ b/docs/Guides/PLUGIN_API_REFERENCE.md
@@ -528,6 +528,10 @@ Minimal synchronous filesystem helper:
 
 - `fs.writeFileSync(filename, data, opts)`
 - `fs.readFileSync(filename, opts)`
+- `fs.readdirSync(path)`
+- `fs.unlinkSync(filename)`
+- `fs.mkdirSync(path)`
+- `fs.rmdirSync(path)`
 
 ### `require('http')` / `require('https')`
 
@@ -663,9 +667,13 @@ Supported algorithms are `md5`, `sha1`, `sha256`, and `sha512`.
 - `read(handle, buffer, offset, length, position)`
 - `write(handle, buffer, offset, length, position)`
 - `fsize(handle)`
-- `ftrunctae(handle, size)` - spelling is as registered in C.
+- `ftruncate(handle, size)`
+- `ftrunctae(handle, size)` - legacy compatibility alias for the old misspelling.
 - `rename(from, to)`
 - `mkdirs(path, reserved)`
+- `unlink(path)`
+- `rmdir(path)`
+- `readdir(path)`
 - `dirname(path)`
 - `basename(path)`
 - `copyfile(from, to)`

--- a/docs/Guides/PLUGIN_DEBUG_WORKFLOW.md
+++ b/docs/Guides/PLUGIN_DEBUG_WORKFLOW.md
@@ -91,6 +91,23 @@ Optional environment variables:
 - `ALLOW_EXISTING_MOVIAN=1` - allow another Movian process to already be
   running.
 
+Harness rules that prevented false failures during SMB/SMB2 navigation work:
+
+- Wait until `/api/diag` responds, then allow a short UI settle before the
+  first `/api/open`. A request sent immediately after the HTTP port appears can
+  return success while the navigator remains on `page:home`.
+- Do not use `--no-ui` for HTTP prop navigation harnesses. Reserve it for
+  command-line URL smokes or GDB smokes where the URL is passed as an argv
+  route.
+- For browser-style protocol roots such as `smb://host` or `smb2://host`, open
+  `search:<url>` through `/api/open` and assert the final protocol URL from
+  `currentpage.url`.
+- Assert both the expected URL and `loading=0` before reading node content.
+  `loading=0` alone can still describe the previous page.
+- Kill only the test-owned Movian PID during cleanup. If graceful shutdown
+  stalls, escalate that PID to `SIGKILL` rather than using broad process
+  cleanup.
+
 The runner saves:
 
 - `movian.log`
@@ -122,6 +139,11 @@ is set. This keeps non-visual route checks usable in headless or GL-limited
 environments.
 
 ## HTTP And Prop Surface
+
+`/api/open` accepts the target in the `url` request argument. For normal plugin
+routes, open the route directly. For SMB/SMB2 browser navigation, open the
+search wrapper (`search:smb2://host/`) and then verify that the navigator lands
+on the canonical protocol URL.
 
 Useful endpoints during manual diagnosis:
 
@@ -167,7 +189,11 @@ example:
 [1, 2, 0, "navigators.current.currentpage.model.loading"]
 ```
 
-Do not use slash-separated paths for JSON STPP subscriptions.
+Do not use slash-separated paths for JSON STPP subscriptions. For popup fields,
+inspect `/api/prop/global/popups/*0` first; `*0` is an HTTP display alias, not a
+valid STPP dot-path segment. Subscribe to `popups`, recover the child propref,
+and write fields relative to that propref. If that does not update the visible
+dialog reliably, fall back to real X11 input.
 
 ## Escalation
 

--- a/docs/Guides/PLUGIN_FS_SECURITY_AUDIT.md
+++ b/docs/Guides/PLUGIN_FS_SECURITY_AUDIT.md
@@ -1,0 +1,377 @@
+# Plugin Filesystem Security Audit
+
+This note audits plugin-facing filesystem boundaries after SMB2 gained writable
+fileaccess operations.
+
+## Scope
+
+The audited path is JavaScript plugin code calling `native/fs` or the CommonJS
+`fs` wrapper, then reaching generic fileaccess protocols such as local `file://`,
+`smb://`, `smb2://`, and `ntfs://`.
+
+This does not cover OS process sandboxing. JavaScript plugins run inside the
+Movian process; the plugin sandbox here is an application-level URL/path ACL.
+
+## Current Enforcement Points
+
+- `src/ecmascript/es_fs.c:get_filename()` is the main plugin filesystem ACL.
+  It rejects filenames containing parent references and allows access only when
+  the requested URL begins with `ec->ec_storage` or `ec->ec_path`.
+- `ec->ec_storage` is created per plugin under
+  `gconf.persistent_path/plugins/<plugin-id>`.
+- `ec->ec_path` is the parent directory of the plugin entry file. Default
+  plugins can therefore access their persistent storage and their load
+  directory.
+- `entitlements.bypassFileACLRead` and `entitlements.bypassFileACLWrite` in
+  `plugin.json` bypass the read or write path ACL for that plugin.
+- `--bypass-ecmascript-acl` disables JavaScript filesystem ACL checks globally.
+- Command-line `--ecmascript` scripts are created with read and write bypass
+  flags; treat them as a development/admin surface, not as sandboxed plugins.
+
+## SMB And SMB2 Write Surface
+
+SMB1 currently exposes destructive operations (`unlink`, `rmdir`) but not
+`fap_write`, so `native/fs.open("smb://...", "w")` is rejected by
+`fa_open_ex()` as a filesystem without write support.
+
+SMB2 now exposes:
+
+- `fap_write`
+- `fap_ftruncate`
+- `fap_unlink`
+- `fap_rmdir`
+- `fap_rename`
+- `fap_makedir`
+- `fap_fsinfo`
+
+That means an SMB2 URL is writable whenever JavaScript filesystem ACL checks
+allow the URL to reach `fa_open_ex()` or the path operation wrappers.
+
+For normal installed plugins without bypass entitlements, `smb2://...` is not
+inside the default local storage path, so direct SMB2 writes are blocked. The
+exception is a plugin loaded from an SMB2 URL: in that case the plugin load
+directory can itself be an SMB2 URL, and writes under that directory match
+`ec->ec_path`.
+
+For plugins with `entitlements.bypassFileACLWrite`, SMB2 is writable anywhere
+the share credentials and server permissions allow. This is consistent with the
+current broad meaning of the entitlement, but it is a wider practical effect
+now that SMB2 implements writes.
+
+## Findings
+
+## Runtime Smoke Evidence
+
+A temporary development plugin with no `entitlements` block was tested against a
+reserved SMB2 URL (`smb2://192.0.2.10/...`) using an isolated profile. The URL
+uses a non-routable documentation address so a failed ACL cannot damage a real
+share; a passing ACL blocks before any SMB2 connection is attempted.
+
+The plugin route exercised these destructive/write paths:
+
+- `native/fs.open(url, "w")`
+- `native/fs.open(url, "a")`
+- `fs.writeFileSync(url, data)`
+- `native/fs.mkdirs(url)`
+- `fs.mkdirSync(url)`
+- `native/fs.unlink(url)`
+- `fs.unlinkSync(url)`
+- `native/fs.rmdir(url)`
+- `fs.rmdirSync(url)`
+- `native/fs.rename(smb2Old, smb2New)`
+- `native/fs.rename(scopedLocal, smb2New)`
+- `native/fs.open(url, "r")` followed by `native/fs.ftruncate(fd, 0)`
+
+All destructive/write SMB2 cases threw:
+
+```text
+Bad filename smb2://... -- Access not allowed
+```
+
+The stack for each denial reached `src/ecmascript/es_fs.c:get_filename()` before
+fileaccess opened the SMB2 URL. The log contained no SMB2 connection, session
+setup, or keyring prompt signals for these denied cases.
+
+The same smoke also ran `native/fs.copyfile(outsideReadUrl, storageName)`.
+That call completed without an ACL error, confirming the separate read-scope
+finding below.
+
+### P1: `copyfile(from, to)` bypasses read path scoping
+
+`native/fs.copyfile(from, to)` does not call `get_filename()` for `from`.
+Instead, it sanitizes `to`, constructs a destination under plugin storage, and
+calls `fa_copy(storage_copy_path, from)`.
+
+Impact: a plugin without read bypass can ask fileaccess to read an arbitrary
+source URL into its own storage, then read the copied file from storage. This is
+an existing read-scope issue independent of SMB2 write support.
+
+Compatibility research: the HDRezka development plugin uses this behavior for
+its updater. `utils/updater.js:getRemoteManifest()` calls:
+
+```js
+nativeFs.copyfile('zip://' + downloadURL + '/plugin.json',
+                  'remote_plugin.json')
+```
+
+The plugin manifest sets `downloadURL` to a remote package URL. A runtime probe
+with HDRezka loaded without any `entitlements` confirmed that Movian logs:
+
+```text
+Copying file from 'zip://http://.../plugin.json'
+  to '<plugin-storage>/copy/remote_plugin.json'
+```
+
+and the remote `plugin.json` lands in plugin storage. This is a legitimate
+remote-package import use case, so a simple `get_filename(ctx, 0, ec, 0)` on the
+source would break existing updater behavior.
+
+Recommended fix: do not turn `copyfile` into a pure scoped local copy without a
+replacement import API. Either replace it with two explicit APIs:
+
+- scoped local copy, enforcing read ACL on `from`;
+- remote download/import, limited to explicitly allowed protocols such as
+  `http://` and `https://`.
+
+Or keep `copyfile` as the import API but add source policy:
+
+- allow sources that pass normal read ACL;
+- allow `http://` and `https://`;
+- allow `zip://http://...` and `zip://https://...` for remote package metadata;
+- reject local and share-backed sources that do not pass read ACL, including
+  `file://`, bare local paths, `smb://`, `smb2://`, `ntfs://`, and nested forms
+  such as `zip://file://...` or `zip://smb2://...`.
+
+### Standard plugin archive install path
+
+Movian core already supports installing a plugin from a direct archive URL.
+The normal navigation path is:
+
+1. Open `search:<archive-url>`.
+2. The search backend strips the `search:` prefix and lets fileaccess probe the
+   URL.
+3. ZIP probing reads `zip://<archive-url>/plugin.json`.
+4. A ZIP with plugin metadata is classified as `CONTENT_PLUGIN`.
+5. `plugin_open_file()` reads the archive manifest and calls
+   `plugin_install(pl, url)`.
+6. `plugin_install()` downloads the archive with `fa_load()`, validates ZIP
+   magic, and stores it under `persistent/mrp/installed/<plugin-id>.zip`.
+
+The repository upgrade path is also already archive-URL based:
+
+1. `plugins_upgrade_check()` loads configured repositories.
+2. `plugin_load_repo()` reads each plugin entry and resolves `downloadURL`
+   relative to the repo URL.
+3. `plugin_autoupgrade()` calls `plugin_install(pl, NULL)`.
+4. `plugin_install()` uses the resolved package URL stored on the plugin.
+
+Runtime evidence: opening a public plugin archive through `search:<archive-url>`
+in an isolated profile produced the expected core install logs:
+
+```text
+Opening search:<archive-url>
+Downloading plugin <id>@local from <archive-url>
+Plugin <id>@local valid ZIP archive <n> bytes
+```
+
+The installed ZIP was written under the isolated profile and contained
+`plugin.json`.
+
+This means HDRezka-style update code does not need `copyfile()` for the actual
+install or upgrade action. Its current use of `copyfile(zip://.../plugin.json,
+...)` is only for a pre-install remote manifest/version check.
+
+### Self-update without a plugin repository
+
+The runtime tests found a no-core-change path for plugins that cannot publish
+to the shared Movian repository: ship a small `repo.json` inside the plugin ZIP
+and subscribe to it as `zip://<archive-url>/repo.json`. The embedded repository
+entry should use an absolute HTTP(S) `downloadURL` for the archive.
+
+This reuses the standard repository install and upgrade flow instead of adding
+a new manifest-read API or using `native/fs.copyfile()` to copy
+`zip://.../plugin.json` into plugin storage. The installed plugin identity is
+repository-scoped, so upgrades work when the plugin was installed through the
+same feed URL. A direct `search:<archive-url>` install remains `@local` and is
+not upgraded by that feed because the origins differ.
+
+The `search:<archive-url>` path is still a core install path, not a filesystem
+bypass:
+
+- it probes the archive through fileaccess;
+- it classifies valid plugin ZIPs as `CONTENT_PLUGIN`;
+- it reads `plugin.json` through `plugin_open_file()`;
+- it calls `plugin_install(pl, url)`;
+- it downloads and stores the ZIP under `persistent/mrp/installed/`.
+
+A fully silent plugin-initiated update would still need a separate core API such
+as `native/plugin.selfUpdate(url)`. That API should validate that the archive
+manifest id matches the calling plugin before install, and it should schedule
+the install after the current JavaScript callback returns so the running plugin
+context is not unloaded while native code is still executing inside it.
+
+### Repository update reuse research
+
+The built-in repository path is useful reference material, but it is not the
+target path for plugins that must self-update without publishing a repository.
+It is currently a core/UI feature rather than a JavaScript plugin API.
+
+Repository format:
+
+```json
+{
+  "version": 1,
+  "title": "Example Plugin Repository",
+  "plugins": [
+    {
+      "type": "ecmascript",
+      "id": "example_plugin",
+      "title": "Example Plugin",
+      "version": "1.2.3",
+      "category": "video",
+      "downloadURL": "example-plugin.zip"
+    }
+  ]
+}
+```
+
+The repository loader:
+
+1. loads the repository JSON through `fa_load()` with compression and auth
+   disabled;
+2. requires repository `version` to be `1`;
+3. walks the `plugins` list;
+4. skips unsupported plugin types and blacklisted versions;
+5. resolves each `downloadURL` relative to the repository URL;
+6. creates a plugin entry whose origin is an MD5-derived hash of the resolved
+   package URL;
+7. sets `availableVersion`, install/upgrade status, metadata, optional
+   `showtimeVersion`, and optional `control` autoplugin triggers.
+
+Runtime evidence with an isolated local HTTP repository:
+
+- repo v1 exposed one plugin item with `canInstall=1` and
+  `availableVersion=1.0.0`;
+- sending the normal plugin item action `install:` downloaded the ZIP from the
+  repository `downloadURL` and wrote
+  `persistent/mrp/installed/<id>@<origin>.zip`;
+- after restarting with the same persistent profile and repo v2, the same item
+  showed `installed=1`, `installedVersion=1.0.0`, `availableVersion=2.0.0`,
+  and `canUpgrade=1`;
+- sending the normal plugin item action `upgrade` downloaded the v2 ZIP through
+  the same `plugin_install(pl, NULL)` path.
+
+Important limitations for reuse:
+
+- Repository subscription is not exposed to plugin JavaScript. Repositories can
+  be added through the core settings popup, the `--plugin-repo` command-line
+  option, or the saved `pluginrepos` store, but `plugin_repo_create()` and
+  `plugins_upgrade_check()` are static core functions.
+- A direct plugin ZIP URL is not accepted as a repository feed today.
+  `repo_get()` reads the feed URL with `fa_load()` and deserializes the bytes as
+  JSON, so an archive URL fails with "Malformed JSON in repository".
+- A repository JSON stored inside an archive does work when the feed URL is
+  written explicitly as `zip://<archive-url>/repo.json`. Runtime smoke verified
+  that Movian loads this URL and creates the repo plugin item. Use an absolute
+  HTTP(S) `downloadURL` inside that embedded `repo.json`; relative URLs from a
+  `zip://.../repo.json` base are not a good compatibility contract.
+- The installed plugin identity includes the origin hash. A plugin installed
+  through direct archive open is `id@local`; the same plugin discovered through
+  a repository is `id@<hash-of-package-url>`. To get clean repo upgrades, the
+  plugin should be installed from the repository entry at least once, otherwise
+  the repo item and the existing local item can coexist as separate plugin
+  origins.
+- Manual install and manual upgrade through the repository UI path work.
+- The automatic upgrade path needs more work before relying on it:
+  `plugin_autoupgrade()` checks `pl->pl_auto_upgrade`, but current code only
+  stores the repository setting in `pr->pr_autoupgrade`; no assignment from the
+  repository setting to plugin entries was found in this pass.
+
+Reuse options:
+
+- Best fit without core changes: put `repo.json` in the plugin archive and ask
+  users to subscribe to `zip://<archive-url>/repo.json`; runtime tests confirmed
+  `plugin:start` and `plugin:repo` show installed and available versions through
+  the standard repository model.
+- Best fit for maintained plugins that can publish a feed: publish a small
+  repository JSON beside the archive and have users subscribe once. After that,
+  the core repository UI can show available versions and perform installs or
+  upgrades without plugin-side `copyfile()`.
+- If only one public archive URL is available, the archive can contain
+  `repo.json` and users can subscribe to
+  `zip://<archive-url>/repo.json`. For better UX, core could adapt
+  `repo_get()` so a direct archive URL automatically falls back to
+  `zip://<archive-url>/repo.json` before reporting malformed JSON.
+- If plugin-side repository subscription is desired, add a narrow core API such
+  as `native/plugin.addRepository(url)` / `native/plugin.checkUpgrades()` rather
+  than granting filesystem bypass or general arbitrary-source reads.
+
+### P2: path scope uses raw prefix matching
+
+`get_filename()` uses `mystrbegins(filename, ec->ec_storage)` and
+`mystrbegins(filename, ec->ec_path)`. `mystrbegins()` is a plain byte-prefix
+check.
+
+Impact: a scope such as `/path/plugin` also matches `/path/plugin-extra` unless
+the scope string is guaranteed to end with `/` and the requested URL is
+canonicalized consistently. For URL protocols, the same boundary issue applies
+to strings such as `smb2://server/share/plugin` and
+`smb2://server/share/plugin-extra`.
+
+Recommended fix: replace the raw prefix check with a helper that allows only:
+
+- exact scope match;
+- child paths where the next byte after the scope is `/`;
+- scopes normalized to a single trailing slash before comparison.
+
+### P2: ACL is checked before protocol-specific parsing/decoding
+
+`get_filename()` checks the raw JavaScript string. Later, fileaccess protocol
+handlers may normalize, redirect, or parse that string differently.
+
+Impact: encoded path traversal or protocol redirects could become security
+relevant if a protocol decodes `%2e%2e`, rewrites URLs, or treats equivalent
+paths differently after the JavaScript ACL check. No concrete bypass was proven
+in this pass, but the boundary should be tested before relying on string-level
+ACLs for network protocols.
+
+Recommended fix: introduce a protocol-aware ACL function that validates a
+canonical URL/path form and either disables redirects during ACL validation or
+revalidates after redirect.
+
+### P3: write bypass entitlement is all-protocol, not local-filesystem-only
+
+`entitlements.bypassFileACLWrite` currently bypasses the entire JavaScript write
+ACL. It is not limited to local plugin storage, local filesystem paths, or a
+specific protocol family.
+
+Impact: any plugin granted this entitlement can write through every writable
+fileaccess protocol available in the build, including SMB2.
+
+Recommended fix: document this as a high-trust entitlement, or replace it with
+more specific entitlements such as:
+
+- `fileACL.write.storage`
+- `fileACL.write.pluginPath`
+- `fileACL.write.local`
+- `fileACL.write.networkShares`
+
+## Recommended Policy
+
+For this SMB2 PR, do not add protocol-local checks inside SMB2 unless the
+product decision is that JavaScript should never write to network shares. SMB2
+does not know whether its caller is the UI, a trusted core path, or a plugin.
+The correct enforcement point is the JavaScript filesystem ACL layer.
+
+Before marking SMB2 write support as safe for plugins:
+
+1. Fix `copyfile(from, to)` read ACL behavior.
+2. Replace raw prefix path scoping with boundary-aware scope checks.
+3. Decide whether `bypassFileACLWrite` is intentionally all-protocol.
+4. Add JavaScript regression tests or a smoke plugin covering:
+   - default plugin cannot open `smb2://host/share/file` for write;
+   - default plugin cannot mkdir/unlink/rename an SMB2 URL;
+   - plugin with write bypass can write SMB2 only when that entitlement is
+     intentionally granted;
+   - `copyfile()` cannot import disallowed local or SMB2 URLs unless read ACL
+     allows them.

--- a/docs/Guides/SMB_SMB2_NAVIGATION_LIFECYCLE.md
+++ b/docs/Guides/SMB_SMB2_NAVIGATION_LIFECYCLE.md
@@ -1,0 +1,156 @@
+# SMB And SMB2 Navigation Lifecycle
+
+This note captures the observed navigation behavior for SMB1 and SMB2 host
+roots, and the points that should stay comparable when debugging auth or share
+listing regressions.
+
+## SMB1 Lifecycle
+
+SMB1 host navigation is centered on `cifs_resolve()` in
+`src/fileaccess/smb/fa_nativesmb.c`.
+
+- `smb_stat()` and `smb_scandir()` both resolve the URL through
+  `cifs_resolve()`.
+- Host-root resolution first attempts a guest/default connection with
+  `CC_F_AS_GUEST`.
+- `cifs_get_connection()` logs the TCP connect, protocol negotiation, session
+  setup, and disconnect lifecycle through `SMBTRACE`.
+- `smb_setup_andX()` logs the attempted setup identity as
+  `SETUP user:password-state:domain`, then logs the SMB status code.
+- If guest/default setup fails with an auth-style error, `cifs_resolve()`
+  retries without `CC_F_AS_GUEST`, which can trigger the keyring prompt.
+- Host-root `stat` reports `CONTENT_SHARE`, and host-root `scandir` enumerates
+  shares.
+
+The expected first-auth user experience is therefore a clean login prompt with
+domain `WORKGROUP`, not a raw server status string before the user has entered
+credentials.
+
+## SMB2 Lifecycle
+
+SMB2 navigation is implemented in `src/fileaccess/smb2/fa_libsmb2.c`.
+
+- URL parsing is handled by `movian_smb2_target_parse()`.
+- Auth and connection retry are centralized in `movian_smb2_connect_impl()`.
+- One connection attempt is performed by `movian_smb2_connect_once()`, which
+  wraps `libsmb2` `smb2_connect_share()`.
+- Host-root scans connect to `IPC$` and call `smb2_share_enum_async()`.
+- Directory scans connect to the target share and use `smb2_opendir()` /
+  `smb2_readdir()`.
+
+For parity with SMB1, SMB2 now traces the key lifecycle points under the `SMB2`
+debug component: keyring hit/miss, setup identity with password redacted,
+connect result, auth retry decision, prompt result, redirect, and share enum
+add/filter decisions.
+
+## Navigation Parity Notes
+
+- `smb://host` and `smb2://host` should both navigate to the host root. SMB2
+  redirects the no-trailing-slash host URL to `smb2://host/`.
+- `smb://host/` and `smb2://host/` should both show the normal disk shares
+  visible to the authenticated user.
+- SMB2 share enumeration intentionally adds only shares whose type is exactly
+  `SHARE_TYPE_DISKTREE`. Hidden/admin shares such as `ADMIN$`, `C$`, or `F$`
+  are filtered from normal root navigation.
+- A first interactive SMB2 auth prompt with no saved credentials should show
+  `Login required` and prefill domain `WORKGROUP`.
+- Background or startup probes on the `asyncio` thread must not open an
+  interactive auth popup.
+
+## Validated Decisions
+
+- Use `movian_smb2_connect_impl()` as the single SMB2 auth lifecycle point.
+  It is called by normal SMB2 connects and `stat`, so keyring behavior,
+  auth-retry decisions, and non-interactive suppression stay consistent.
+- Show `Login required` on the first interactive prompt when no saved
+  credentials were present. Preserve the raw SMB2 failure reason only after
+  saved or user-entered credentials fail.
+- Prefill the prompt domain with `WORKGROUP` when the URL does not specify a
+  domain. This matches the SMB1 first-auth experience and avoids an empty domain
+  field on Windows shares.
+- Suppress interactive credential prompts from the `asyncio` thread. Startup
+  and background probes may discover that auth is needed, but they must not
+  steal focus with an auth popup.
+- Treat `smb2://host` as a host-root URL and redirect it to `smb2://host/`.
+  This closes the no-trailing-slash mismatch with SMB1 navigation.
+- Report SMB2 host-root `stat` as `CONTENT_SHARE`, matching SMB1 host-root
+  behavior.
+- Filter SMB2 root shares by exact `SHARE_TYPE_DISKTREE`. This keeps normal
+  navigation aligned with SMB1-visible shares and hides admin/hidden shares.
+- Preseed `persistent/settings/dev` with `{ "smbdebug": 1 }` for runtime
+  lifecycle tests. `-d` enables verbose process logging, but SMB/SMB2 trace
+  lines still require the developer `smbdebug` setting.
+- Seed runtime credentials for automation through
+  `persistent/settings/keyring` using the real keyring JSON shape. This gives a
+  deterministic profile without relying on old `/tmp` state or manual popup
+  input.
+- Inspect active auth popups through `/api/prop/global/popups/*0`. The HTTP
+  `*0` segment is the exported view of the first unnamed popup child.
+- To fill popup fields through STPP, subscribe to the `popups` directory, read
+  the exported popup child propref from the child-add event, then send `SET`
+  relative to that propref, for example `[3, child_ref, "username", "user"]`.
+  This was verified to update `/api/prop/global/popups/*0/username` and
+  `/api/prop/global/popups/*0/domain`.
+- Wait for the expected page URL before asserting `loading=0` or node content.
+  Without the URL check, tests can sample the previous page and produce false
+  failures during fast route transitions.
+
+## Rejected Or Failed Approaches
+
+- Do not show raw `STATUS_INVALID_PARAMETER` or similar libsmb2/server errors
+  on the first prompt when no credentials have been entered. That message is
+  useful after a failed credential attempt, but it is misleading as the initial
+  login reason.
+- Do not allow startup/background SMB2 probes to invoke `KEYRING_QUERY_USER`.
+  A startup popup was observed from the `asyncio` thread for
+  `smb2:connection:<server>`; the correct behavior is to report auth
+  needed without displaying UI.
+- Do not copy old isolated profiles from `/tmp` as proof of saved credentials.
+  A copied profile may not contain `persistent/settings/keyring`, which caused
+  SMB1 to fall back to the login prompt during testing.
+- Do not use `/api/prop` `POST value=...` to set settings or auth fields. The
+  HTTP prop endpoint only handles `action` and `debug`; direct value writes
+  return `400`.
+- Do not rely on STPP wildcard paths such as `popups.*0.username` to fill the
+  auth popup. `*0` is an HTTP `/api/prop` display alias for an unnamed child,
+  not a real dot-path segment. STPP reported a value for that wildcard path,
+  but the actual HTTP popup prop still showed `username` as void.
+- Do not parse STPP directory child-add events with strict JSON only. A
+  `popups` subscription returned `[5,1,0,[1]` during testing, missing the final
+  bracket. A task-specific probe can still recover the child propref with a
+  tolerant parse, then use propref-relative `SET`.
+- Do not use STPP popup filling as the only fallback. If propref export or
+  field writes are flaky, drive the visible dialog with real X11 keypresses via
+  `movian-plugin-testing/scripts/x11_keypress.py`.
+- Do not treat `loading=0` alone as a route-ready signal after `/api/open`.
+  One failed run sampled the previous page before the user-directory navigation
+  had settled. Use current URL plus title/nodes/loading.
+- Do not change SMB2 directory-entry type mapping in this pass. The current
+  code maps `entry->st.smb2_type`; a later raw attribute test is needed before
+  claiming a Movian-side metadata bug.
+
+## Current Directory Metadata Finding
+
+The observed user-directory node type/count differences between SMB1 and SMB2
+are treated as a server/libsmb2 metadata difference in this pass. SMB2 maps
+directory entries from `entry->st.smb2_type`, which libsmb2 derives from SMB2
+file attributes. Do not change Movian-side type mapping unless a later raw
+attribute probe shows that Movian is discarding correct directory metadata.
+
+## Debug Checklist
+
+When investigating a new SMB navigation report, collect:
+
+- URL opened and whether it has a trailing slash.
+- Isolated profile/keyring state: no credentials, saved credentials, or
+  user-entered credentials.
+- `SMB` and `SMB2` debug lines around connect/setup/share enum.
+- Page title, loading state, popup type/reason/domain, and node list.
+- Screenshots for the SMB1 and SMB2 host roots.
+- For automated authenticated navigation, create a fresh isolated profile and
+  write only the needed keyring entries; remove that keyring file from reusable
+  artifacts after the run.
+- For popup automation, first inspect `/api/prop/global/popups/*0`. Prefer
+  seeded keyring for deterministic auth tests, use STPP propref-relative field
+  writes when the test must exercise the dialog, and fall back to real X11
+  keypress navigation when property writes do not match visible UI behavior.

--- a/docs/Guides/SMB_SMB2_NAVIGATION_LIFECYCLE.md
+++ b/docs/Guides/SMB_SMB2_NAVIGATION_LIFECYCLE.md
@@ -94,6 +94,17 @@ add/filter decisions.
 - Wait for the expected page URL before asserting `loading=0` or node content.
   Without the URL check, tests can sample the previous page and produce false
   failures during fast route transitions.
+- Drive automated browser-navigation parity tests through
+  `support/smb-smoke/run-http-nav-smoke.sh`. It opens `search:smb2://...` via
+  `/api/open`, waits for the canonical final SMB2 URL, and records the root
+  node list for comparison.
+- Use `support/smb-smoke/run-gdb-smoke.sh` for native safety checks around SMB2
+  navigation and writable operations. A timeout exit is expected because Movian
+  keeps running; the useful signal is `crash_signal=no` plus the JS smoke
+  reaching its final `done` line.
+- Keep SMB smoke credentials outside the repository in environment variables.
+  The support scripts seed an isolated keyring, sanitize logs, and remove seeded
+  keyring files from reusable artifacts.
 
 ## Rejected Or Failed Approaches
 
@@ -125,6 +136,15 @@ add/filter decisions.
 - Do not treat `loading=0` alone as a route-ready signal after `/api/open`.
   One failed run sampled the previous page before the user-directory navigation
   had settled. Use current URL plus title/nodes/loading.
+- Do not send the first `/api/open` immediately after the HTTP port appears.
+  Wait for `/api/diag`, then allow a short UI settle; otherwise the request can
+  return without any `navigator Opening ...` log line.
+- Do not use `--no-ui` for HTTP prop navigation parity tests. In this harness it
+  left `/api/open` on `page:home`. Use `--no-ui` only for command-line URL or
+  GDB smokes where the URL is passed directly to Movian.
+- Do not open raw `smb2://...` when testing the in-app browser path. The user
+  flow opens `search:smb2://...`, which then resolves to the canonical SMB2
+  page.
 - Do not change SMB2 directory-entry type mapping in this pass. The current
   code maps `entry->st.smb2_type`; a later raw attribute test is needed before
   claiming a Movian-side metadata bug.
@@ -154,3 +174,6 @@ When investigating a new SMB navigation report, collect:
   seeded keyring for deterministic auth tests, use STPP propref-relative field
   writes when the test must exercise the dialog, and fall back to real X11
   keypress navigation when property writes do not match visible UI behavior.
+- For repeatable runtime checks, prefer the opt-in scripts in `support/smb-smoke`
+  over ad hoc one-liners. Pass host/share/path/user/password/domain through the
+  `SMB_SMOKE_*` environment variables and keep artifacts under `/tmp`.

--- a/res/ecmascript/modules/fs.js
+++ b/res/ecmascript/modules/fs.js
@@ -22,3 +22,19 @@ exports.readFileSync = function(filename, opts) {
     Core.resourceDestroy(fd);
   }
 }
+
+exports.readdirSync = function(path) {
+  return require('native/fs').readdir(path);
+}
+
+exports.unlinkSync = function(filename) {
+  require('native/fs').unlink(filename);
+}
+
+exports.mkdirSync = function(path) {
+  require('native/fs').mkdirs(path);
+}
+
+exports.rmdirSync = function(path) {
+  require('native/fs').rmdir(path);
+}

--- a/src/ecmascript/es_fs.c
+++ b/src/ecmascript/es_fs.c
@@ -35,6 +35,8 @@ typedef struct es_fd_t {
   es_resource_t super;
   char *efd_path;
   fa_handle_t *efd_fh;
+  char efd_can_read;
+  char efd_can_write;
 } es_fd_t;
 
 /**
@@ -78,31 +80,42 @@ const es_resource_class_t es_resource_fd = {
 /**
  *
  */
+static int
+filename_is_allowed(duk_context *ctx, const char *filename,
+                    const es_context_t *ec, int for_write, int fail)
+{
+  if(strstr(filename, "../") || strstr(filename, "/.."))
+    duk_error(ctx, DUK_ERR_ERROR,
+              "Bad filename %s -- Contains parent references", filename);
+
+  if(gconf.bypass_ecmascript_acl)
+    return 1;
+
+  if(for_write && ec->ec_bypass_file_acl_write)
+    return 1;
+
+  if(!for_write && ec->ec_bypass_file_acl_read)
+    return 1;
+
+  if((ec->ec_storage != NULL && mystrbegins(filename, ec->ec_storage)) ||
+     (ec->ec_path    != NULL && mystrbegins(filename, ec->ec_path)))
+    return 1;
+
+  if(fail)
+    duk_error(ctx, DUK_ERR_ERROR, "Bad filename %s -- Access not allowed",
+              filename);
+
+  return 0;
+}
+
+
 static const char *
 get_filename(duk_context *ctx, int index, const es_context_t *ec,
              int for_write)
 {
   const char *filename = duk_to_string(ctx, index);
-
-  if(gconf.bypass_ecmascript_acl)
-    return filename;
-
-  if(for_write && ec->ec_bypass_file_acl_write)
-    return filename;
-
-  if(!for_write && ec->ec_bypass_file_acl_read)
-    return filename;
-
-  if(strstr(filename, "../") || strstr(filename, "/.."))
-    duk_error(ctx, DUK_ERR_ERROR,
-              "Bad filename %s -- Contains parent references", filename);
-
-  if((ec->ec_storage != NULL && mystrbegins(filename, ec->ec_storage)) ||
-     (ec->ec_path    != NULL && mystrbegins(filename, ec->ec_path)))
-    return filename;
-
-  duk_error(ctx, DUK_ERR_ERROR, "Bad filename %s -- Access not allowed",
-            filename);
+  filename_is_allowed(ctx, filename, ec, for_write, 1);
+  return filename;
 }
 
 /**
@@ -119,19 +132,28 @@ es_file_open(duk_context *ctx)
   //  int mode = duk_to_int(ctx, 2);
 
   int flags;
-
+  int can_read;
+  int can_write;
+  const char *filename = duk_to_string(ctx, 0);
 
   if(!strcmp(flagsstr, "r")) {
     flags = 0;
+    filename_is_allowed(ctx, filename, ec, 0, 1);
+    can_read = 1;
+    can_write = 0;
   } else if(!strcmp(flagsstr, "w")) {
     flags = FA_WRITE;
+    filename_is_allowed(ctx, filename, ec, 1, 1);
+    can_read = filename_is_allowed(ctx, filename, ec, 0, 0);
+    can_write = 1;
   } else if(!strcmp(flagsstr, "a")) {
     flags = FA_WRITE | FA_APPEND;
+    filename_is_allowed(ctx, filename, ec, 1, 1);
+    can_read = filename_is_allowed(ctx, filename, ec, 0, 0);
+    can_write = 1;
   } else {
     duk_error(ctx, DUK_ERR_ERROR, "Invalid flags '%s' to open", flagsstr);
   }
-
-  const char *filename = get_filename(ctx, 0, ec, !!flags);
 
   fa_handle_t *fh = fa_open_ex(filename, errbuf, sizeof(errbuf), flags, NULL);
   if(fh == NULL)
@@ -141,6 +163,8 @@ es_file_open(duk_context *ctx)
   es_fd_t *efd = es_resource_create(ec, &es_resource_fd, 0);
   efd->efd_path = strdup(filename);
   efd->efd_fh = fh;
+  efd->efd_can_read = can_read;
+  efd->efd_can_write = can_write;
 
   es_resource_push(ctx, &efd->super);
   return 1;
@@ -168,6 +192,9 @@ static int
 es_file_read(duk_context *ctx)
 {
   es_fd_t *efd = es_fd_get(ctx, 0);
+  if(!efd->efd_can_read)
+    duk_error(ctx, DUK_ERR_ERROR, "Read access denied for '%s'",
+              efd->efd_path);
   duk_size_t bufsize;
   char *buf = duk_require_buffer_data(ctx, 1, &bufsize);
 
@@ -200,6 +227,9 @@ static int
 es_file_write(duk_context *ctx)
 {
   es_fd_t *efd = es_fd_get(ctx, 0);
+  if(!efd->efd_can_write)
+    duk_error(ctx, DUK_ERR_ERROR, "Write access denied for '%s'",
+              efd->efd_path);
   duk_size_t bufsize;
   char *buf = duk_to_buffer(ctx, 1, &bufsize);
   int len;
@@ -252,6 +282,9 @@ static int
 es_file_ftruncate(duk_context *ctx)
 {
   es_fd_t *efd = es_fd_get(ctx, 0);
+  if(!efd->efd_can_write)
+    duk_error(ctx, DUK_ERR_ERROR, "Write access denied for '%s'",
+              efd->efd_path);
   int status = fa_ftruncate(efd->efd_fh, duk_to_number(ctx, 1));
   if(status < 0)
     duk_error(ctx, DUK_ERR_ERROR, "Unable to truncate '%s' -- %s",

--- a/src/ecmascript/es_fs.c
+++ b/src/ecmascript/es_fs.c
@@ -252,7 +252,10 @@ static int
 es_file_ftruncate(duk_context *ctx)
 {
   es_fd_t *efd = es_fd_get(ctx, 0);
-  fa_ftruncate(efd->efd_fh, duk_to_number(ctx, 1));
+  int status = fa_ftruncate(efd->efd_fh, duk_to_number(ctx, 1));
+  if(status < 0)
+    duk_error(ctx, DUK_ERR_ERROR, "Unable to truncate '%s' -- %s",
+              efd->efd_path, fa_err_code_str(status));
   return 0;
 }
 
@@ -293,6 +296,76 @@ es_file_mkdirs(duk_context *ctx)
               filename, errbuf);
 
   return 0;
+}
+
+
+/**
+ * filename
+ */
+static int
+es_file_unlink(duk_context *ctx)
+{
+  es_context_t *ec = es_get(ctx);
+
+  const char *filename = get_filename(ctx, 0, ec, 1);
+  char errbuf[512];
+
+  if(fa_unlink(filename, errbuf, sizeof(errbuf)))
+    duk_error(ctx, DUK_ERR_ERROR, "Unable to remove '%s' -- %s",
+              filename, errbuf);
+
+  return 0;
+}
+
+
+/**
+ * path
+ */
+static int
+es_file_rmdir(duk_context *ctx)
+{
+  es_context_t *ec = es_get(ctx);
+
+  const char *path = get_filename(ctx, 0, ec, 1);
+  char errbuf[512];
+
+  if(fa_rmdir(path, errbuf, sizeof(errbuf)))
+    duk_error(ctx, DUK_ERR_ERROR, "Unable to remove directory '%s' -- %s",
+              path, errbuf);
+
+  return 0;
+}
+
+
+/**
+ * path
+ */
+static int
+es_file_readdir(duk_context *ctx)
+{
+  es_context_t *ec = es_get(ctx);
+
+  const char *path = get_filename(ctx, 0, ec, 0);
+  char errbuf[512];
+
+  fa_dir_t *fd = fa_scandir(path, errbuf, sizeof(errbuf));
+  if(fd == NULL)
+    duk_error(ctx, DUK_ERR_ERROR, "Unable to scan directory '%s' -- %s",
+              path, errbuf);
+
+  duk_push_array(ctx);
+  int idx = 0;
+  fa_dir_entry_t *fde;
+  RB_FOREACH(fde, &fd->fd_entries, fde_link) {
+    const char *name = rstr_get(fde->fde_filename);
+    if(!strcmp(name, ".") || !strcmp(name, ".."))
+      continue;
+    duk_push_string(ctx, name);
+    duk_put_prop_index(ctx, -2, idx++);
+  }
+
+  fa_dir_free(fd);
+  return 1;
 }
 
 
@@ -364,9 +437,13 @@ static const duk_function_list_entry fnlist_fs[] = {
   { "read",             es_file_read,             5 },
   { "write",            es_file_write,            5 },
   { "fsize",            es_file_fsize,            1 },
+  { "ftruncate",        es_file_ftruncate,        2 },
   { "ftrunctae",        es_file_ftruncate,        2 },
   { "rename",           es_file_rename,           2 },
   { "mkdirs",           es_file_mkdirs,           2 },
+  { "unlink",           es_file_unlink,           1 },
+  { "rmdir",            es_file_rmdir,            1 },
+  { "readdir",          es_file_readdir,          1 },
   { "dirname",          es_file_dirname,          1 },
   { "basename",         es_file_basename,         1 },
   { "copyfile",         es_file_copy,             2 },

--- a/src/fileaccess/smb/fa_nativesmb.c
+++ b/src/fileaccess/smb/fa_nativesmb.c
@@ -199,6 +199,9 @@ smberr_write(char *errbuf, size_t errlen, int code)
   case 0xc0000034:
     r = _("Object name not found");
     break;
+  case 0xc000000d:
+    r = _("Invalid parameters");
+    break;
   default:
     snprintf(errbuf, errlen, "NTStatus: 0x%08x", code);
     return;
@@ -723,6 +726,7 @@ smb_setup_andX(cifs_connection_t *cc, char *errbuf, size_t errlen,
   req->capabilities = htole_32(CLIENT_CAP_LARGE_READX | CLIENT_CAP_UNICODE | CLIENT_CAP_LARGE_FILES | CLIENT_CAP_NT_SMBS | CLIENT_CAP_STATUS32);
 
 
+  req->ascii_password_length = 0;
   req->wide_password_length = htole_16(password_len);
   req->bytecount = htole_16(bytecount);
 

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -590,10 +590,13 @@ movian_smb2_scan_host(fa_dir_t *fd, const char *url,
       struct srvsvc_SHARE_INFO_1 *share =
         &shares->Buffer->share_info_1[i];
       const char *name = share->netname.utf8;
-      int add = name != NULL && share->type == SHARE_TYPE_DISKTREE;
+      uint32_t share_type = share->type;
+      int add = name != NULL &&
+        (share_type & 3) == SHARE_TYPE_DISKTREE &&
+        !(share_type & SHARE_TYPE_HIDDEN);
 
       SMB2TRACE("Enumerated share %s type=0x%x -> %s",
-                name != NULL ? name : "<null>", share->type,
+                name != NULL ? name : "<null>", share_type,
                 add ? "add" : "filtered");
 
       if(!add)

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -23,8 +23,14 @@
 #include "main.h"
 #include "keyring.h"
 #include "fileaccess/fa_proto.h"
+#include "misc/rstr.h"
 
 #define SMB2_DEFAULT_TIMEOUT 15
+
+#define SMB2TRACE(x, ...) do {                                 \
+    if(gconf.enable_smb_debug)                                 \
+      tracelog(0, TRACE_DEBUG, "SMB2", x, ##__VA_ARGS__);       \
+  } while(0)
 
 typedef struct {
   char *server;
@@ -161,7 +167,7 @@ movian_smb2_default_credentials(const movian_smb2_target_t *target,
   credentials->user = strdup(target->user != NULL ? target->user : "guest");
   credentials->password = NULL;
   credentials->domain =
-    target->domain != NULL ? strdup(target->domain) : NULL;
+    strdup(target->domain != NULL ? target->domain : "WORKGROUP");
 }
 
 
@@ -218,6 +224,17 @@ movian_smb2_is_auth_error(int status, const char *reason)
 }
 
 
+static int
+movian_smb2_can_query_user(int flags)
+{
+  if(flags & (FA_NON_INTERACTIVE | FA_DISABLE_AUTH))
+    return 0;
+
+  char name[64];
+  return strcmp(hts_thread_name(name, sizeof(name)), "asyncio");
+}
+
+
 static fa_err_code_t
 movian_smb2_errno_to_fap(int status)
 {
@@ -256,8 +273,15 @@ movian_smb2_connect_once(const movian_smb2_target_t *target,
   if(smb2 == NULL) {
     *status = -ENOMEM;
     snprintf(errbuf, errlen, "Unable to initialize SMB2");
+    SMB2TRACE("Unable to initialize SMB2 context");
     return NULL;
   }
+
+  SMB2TRACE("Connecting to %s/%s timeout=%d",
+            target->server, share != NULL ? share : "", timeout);
+  SMB2TRACE("SETUP %s:%s:%s", user,
+            credentials->password != NULL ? "<set>" : "<unset>",
+            credentials->domain != NULL ? credentials->domain : "<unset>");
 
   smb2_set_timeout(smb2, timeout);
   smb2_set_security_mode(smb2, SMB2_NEGOTIATE_SIGNING_ENABLED);
@@ -267,10 +291,14 @@ movian_smb2_connect_once(const movian_smb2_target_t *target,
     smb2_set_domain(smb2, credentials->domain);
 
   *status = smb2_connect_share(smb2, target->server, share, user);
-  if(*status == 0)
+  if(*status == 0) {
+    SMB2TRACE("%s/%s Session setup", target->server,
+              share != NULL ? share : "");
     return smb2;
+  }
 
   snprintf(errbuf, errlen, "%s", smb2_get_error(smb2));
+  SMB2TRACE("SETUP status=%d reason=%s", *status, errbuf);
   smb2_destroy_context(smb2);
   return NULL;
 }
@@ -296,6 +324,9 @@ movian_smb2_connect_impl(const movian_smb2_target_t *target, const char *share,
   int keyring_status =
     keyring_lookup(keyring_id, &credentials.user, &credentials.password,
                    &credentials.domain, NULL, NULL, NULL, 0);
+  int have_saved_credentials = keyring_status == KEYRING_OK;
+  SMB2TRACE("Keyring lookup %s for %s",
+            have_saved_credentials ? "hit" : "miss", keyring_id);
   if(keyring_status != KEYRING_OK) {
     movian_smb2_default_credentials(target, &credentials);
   } else if(movian_smb2_apply_target_identity(target, &credentials,
@@ -319,8 +350,15 @@ movian_smb2_connect_impl(const movian_smb2_target_t *target, const char *share,
   if(auth_error && auth_needed != NULL)
     *auth_needed = 1;
 
-  if(flags & (FA_NON_INTERACTIVE | FA_DISABLE_AUTH) ||
-     !auth_error) {
+  int can_query_user = movian_smb2_can_query_user(flags);
+  char thread_name[64];
+  SMB2TRACE("Auth retry auth_error=%d can_query=%d flags=0x%x "
+            "thread=%s status=%d reason=%s",
+            auth_error, can_query_user, flags,
+            hts_thread_name(thread_name, sizeof(thread_name)), status,
+            reason);
+
+  if(!can_query_user || !auth_error) {
     snprintf(errbuf, errlen, "Unable to connect to SMB2 share: %s", reason);
     movian_smb2_credentials_fini(&credentials);
     free(keyring_id);
@@ -333,6 +371,14 @@ movian_smb2_connect_impl(const movian_smb2_target_t *target, const char *share,
                                        errbuf, errlen)) {
     free(keyring_id);
     return NULL;
+  }
+  if(credentials.domain == NULL) {
+    credentials.domain = strdup("WORKGROUP");
+    if(credentials.domain == NULL) {
+      snprintf(errbuf, errlen, "Out of memory while preparing SMB2 login");
+      free(keyring_id);
+      return NULL;
+    }
   }
 
   size_t source_len = strlen(target->server) + 16;
@@ -349,17 +395,20 @@ movian_smb2_connect_impl(const movian_smb2_target_t *target, const char *share,
                    target->user != NULL ? NULL : &credentials.user,
                    &credentials.password,
                    target->domain != NULL ? NULL : &credentials.domain,
-                   NULL, source, reason,
+                   NULL, source,
+                   have_saved_credentials ? reason : "Login required",
                    KEYRING_QUERY_USER | KEYRING_SHOW_REMEMBER_ME |
                    KEYRING_REMEMBER_ME_SET);
   free(source);
 
   if(keyring_status != KEYRING_OK) {
+    SMB2TRACE("Credential query rejected status=%d", keyring_status);
     snprintf(errbuf, errlen, "Authentication rejected by user");
     movian_smb2_credentials_fini(&credentials);
     free(keyring_id);
     return NULL;
   }
+  SMB2TRACE("Credential query accepted");
 
   smb2 = movian_smb2_connect_once(target, share, &credentials, timeout,
                                   &status, reason, sizeof(reason));
@@ -403,6 +452,23 @@ movian_smb2_child_url(const char *parent, const char *name)
   if(url != NULL)
     snprintf(url, len, "%.*s/%s", (int)parent_len, parent, name);
   return url;
+}
+
+
+static rstr_t *
+movian_smb2_redirect(fa_protocol_t *fap, const char *url)
+{
+  const char *path = url + strlen("smb2://");
+  if(*path == '\0' || strchr(path, '/') != NULL)
+    return NULL;
+
+  char redirected[URL_MAX];
+  if(snprintf(redirected, sizeof(redirected), "%s/", url) >=
+     sizeof(redirected))
+    return NULL;
+
+  SMB2TRACE("Redirecting %s -> %s", url, redirected);
+  return rstr_alloc(redirected);
 }
 
 
@@ -456,6 +522,7 @@ movian_smb2_scan_host(fa_dir_t *fd, const char *url,
                       const movian_smb2_target_t *target, int flags,
                       char *errbuf, size_t errlen)
 {
+  SMB2TRACE("Enumerating shares on %s", target->server);
   struct smb2_context *smb2 =
     movian_smb2_connect(target, "IPC$", flags, SMB2_DEFAULT_TIMEOUT,
                         errbuf, errlen);
@@ -469,6 +536,8 @@ movian_smb2_scan_host(fa_dir_t *fd, const char *url,
      state.status != 0 || state.reply == NULL) {
     snprintf(errbuf, errlen, "Unable to enumerate SMB2 shares: %s",
              smb2_get_error(smb2));
+    SMB2TRACE("Share enumeration failed status=%d reason=%s",
+              state.status, errbuf);
     if(state.reply != NULL)
       smb2_free_data(smb2, state.reply);
     movian_smb2_disconnect(smb2);
@@ -482,8 +551,13 @@ movian_smb2_scan_host(fa_dir_t *fd, const char *url,
       struct srvsvc_SHARE_INFO_1 *share =
         &shares->Buffer->share_info_1[i];
       const char *name = share->netname.utf8;
+      int add = name != NULL && share->type == SHARE_TYPE_DISKTREE;
 
-      if((share->type & 3) != SHARE_TYPE_DISKTREE || name == NULL)
+      SMB2TRACE("Enumerated share %s type=0x%x -> %s",
+                name != NULL ? name : "<null>", share->type,
+                add ? "add" : "filtered");
+
+      if(!add)
         continue;
 
       char *child = movian_smb2_child_url(url, name);
@@ -756,7 +830,7 @@ movian_smb2_stat(fa_protocol_t *fap, const char *url, struct fa_stat *fs,
 
   memset(fs, 0, sizeof(*fs));
   if(target.share == NULL || target.share[0] == '\0') {
-    fs->fs_type = CONTENT_DIR;
+    fs->fs_type = CONTENT_SHARE;
     movian_smb2_target_fini(&target);
     return FAP_OK;
   }
@@ -1007,6 +1081,7 @@ static fa_protocol_t fa_protocol_smb2 = {
   .fap_fsinfo = movian_smb2_fsinfo,
   .fap_set_read_timeout = movian_smb2_set_read_timeout,
   .fap_no_parking = movian_smb2_no_parking,
+  .fap_redirect = movian_smb2_redirect,
 };
 
 FAP_REGISTER(smb2);

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -106,16 +106,23 @@ movian_smb2_target_parse(const char *url, movian_smb2_target_t *target,
     return -1;
   }
 
+  int has_share = parsed->share != NULL;
+  int has_user = parsed->user != NULL;
+  int has_domain = parsed->domain != NULL;
+
   target->server = strdup(parsed->server);
-  target->share = parsed->share != NULL ? strdup(parsed->share) : NULL;
+  target->share = has_share ? strdup(parsed->share) : NULL;
   target->path = parsed->path != NULL ? strdup(parsed->path) : strdup("");
-  target->user = parsed->user != NULL ? strdup(parsed->user) : NULL;
-  target->domain = parsed->domain != NULL ? strdup(parsed->domain) : NULL;
+  target->user = has_user ? strdup(parsed->user) : NULL;
+  target->domain = has_domain ? strdup(parsed->domain) : NULL;
 
   smb2_destroy_url(parsed);
   smb2_destroy_context(smb2);
 
-  if(target->server == NULL || target->path == NULL) {
+  if(target->server == NULL || target->path == NULL ||
+     (has_share && target->share == NULL) ||
+     (has_user && target->user == NULL) ||
+     (has_domain && target->domain == NULL)) {
     snprintf(errbuf, errlen, "Out of memory while parsing SMB2 URL");
     movian_smb2_target_fini(target);
     memset(target, 0, sizeof(*target));
@@ -447,10 +454,17 @@ movian_smb2_child_url(const char *parent, const char *name)
   while(parent_len > 0 && parent[parent_len - 1] == '/')
     parent_len--;
 
-  size_t len = parent_len + strlen(name) + 2;
+  size_t name_len = strlen(name);
+  if(parent_len > SIZE_MAX - name_len - 2)
+    return NULL;
+
+  size_t len = parent_len + name_len + 2;
   char *url = malloc(len);
-  if(url != NULL)
-    snprintf(url, len, "%.*s/%s", (int)parent_len, parent, name);
+  if(url != NULL) {
+    memcpy(url, parent, parent_len);
+    url[parent_len] = '/';
+    memcpy(url + parent_len + 1, name, name_len + 1);
+  }
   return url;
 }
 
@@ -463,12 +477,37 @@ movian_smb2_redirect(fa_protocol_t *fap, const char *url)
     return NULL;
 
   char redirected[URL_MAX];
-  if(snprintf(redirected, sizeof(redirected), "%s/", url) >=
-     sizeof(redirected))
+  int len = snprintf(redirected, sizeof(redirected), "%s/", url);
+  if(len < 0 || (size_t)len >= sizeof(redirected))
     return NULL;
 
   SMB2TRACE("Redirecting %s -> %s", url, redirected);
   return rstr_alloc(redirected);
+}
+
+
+static int
+movian_smb2_normalize(fa_protocol_t *fap, const char *url,
+                      char *dst, size_t dstlen)
+{
+  movian_smb2_target_t target = {};
+  char errbuf[128];
+
+  if(movian_smb2_target_parse(url, &target, errbuf, sizeof(errbuf)))
+    return -1;
+
+  int host_root = target.share == NULL || target.share[0] == '\0';
+  movian_smb2_target_fini(&target);
+
+  if(!host_root)
+    return -1;
+
+  size_t len = strlen(url);
+  if(dstlen == 0 || len >= dstlen)
+    return -1;
+
+  memcpy(dst, url, len + 1);
+  return 0;
 }
 
 
@@ -801,7 +840,7 @@ movian_smb2_ftruncate(fa_handle_t *fh, uint64_t newsize)
   hts_mutex_lock(&file->mutex);
   int status = smb2_ftruncate(file->smb2, file->fh, newsize);
   if(status == 0)
-    file->size = newsize;
+    file->size = newsize > INT64_MAX ? INT64_MAX : (int64_t)newsize;
   hts_mutex_unlock(&file->mutex);
 
   return status < 0 ? movian_smb2_errno_to_fap(status) : FAP_OK;
@@ -1045,8 +1084,11 @@ movian_smb2_fsinfo(fa_protocol_t *fap, const char *url, fa_fsinfo_t *ffi)
   struct smb2_statvfs vfs;
   int status = smb2_statvfs(smb2, target.path[0] ? target.path : "", &vfs);
   if(status == 0) {
-    ffi->ffi_size = (uint64_t)vfs.f_blocks * vfs.f_frsize;
-    ffi->ffi_avail = (uint64_t)vfs.f_bavail * vfs.f_frsize;
+    uint64_t frsize = vfs.f_frsize;
+    ffi->ffi_size = frsize != 0 && vfs.f_blocks > UINT64_MAX / frsize ?
+      UINT64_MAX : (uint64_t)vfs.f_blocks * frsize;
+    ffi->ffi_avail = frsize != 0 && vfs.f_bavail > UINT64_MAX / frsize ?
+      UINT64_MAX : (uint64_t)vfs.f_bavail * frsize;
   }
 
   movian_smb2_disconnect(smb2);
@@ -1082,6 +1124,7 @@ static fa_protocol_t fa_protocol_smb2 = {
   .fap_set_read_timeout = movian_smb2_set_read_timeout,
   .fap_no_parking = movian_smb2_no_parking,
   .fap_redirect = movian_smb2_redirect,
+  .fap_normalize = movian_smb2_normalize,
 };
 
 FAP_REGISTER(smb2);

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -196,9 +196,49 @@ movian_smb2_apply_target_identity(const movian_smb2_target_t *target,
 static int
 movian_smb2_is_auth_error(int status, const char *reason)
 {
-  return status == -EACCES || status == -EPERM ||
-    (status == -ECONNREFUSED && reason != NULL &&
-     strstr(reason, "STATUS_LOGON_FAILURE") != NULL);
+  if(status == -EACCES || status == -EPERM)
+    return 1;
+  if(reason == NULL)
+    return 0;
+  return strstr(reason, "STATUS_LOGON_FAILURE") != NULL ||
+    strstr(reason, "STATUS_ACCESS_DENIED") != NULL ||
+    strstr(reason, "STATUS_NETWORK_ACCESS_DENIED") != NULL ||
+    strstr(reason, "STATUS_INVALID_PARAMETER") != NULL ||
+    strstr(reason, "STATUS_INVALID_ACCOUNT_NAME") != NULL ||
+    strstr(reason, "STATUS_WRONG_PASSWORD") != NULL ||
+    strstr(reason, "STATUS_ACCOUNT_RESTRICTION") != NULL ||
+    strstr(reason, "STATUS_INVALID_LOGON_HOURS") != NULL ||
+    strstr(reason, "STATUS_PASSWORD_EXPIRED") != NULL ||
+    strstr(reason, "STATUS_PASSWORD_MUST_CHANGE") != NULL ||
+    strstr(reason, "STATUS_ACCOUNT_DISABLED") != NULL ||
+    strstr(reason, "STATUS_ACCOUNT_EXPIRED") != NULL ||
+    strstr(reason, "STATUS_ACCOUNT_LOCKED_OUT") != NULL ||
+    strstr(reason, "STATUS_LOGON_NOT_GRANTED") != NULL ||
+    strstr(reason, "STATUS_LOGON_TYPE_NOT_GRANTED") != NULL;
+}
+
+
+static fa_err_code_t
+movian_smb2_errno_to_fap(int status)
+{
+  int err = -status;
+  if(status < -4096)
+    err = nterror_to_errno((uint32_t)status);
+
+  switch(err) {
+  case 0:
+    return FAP_OK;
+  case ENOENT:
+    return FAP_NOENT;
+  case EEXIST:
+    return FAP_EXIST;
+  case EACCES:
+  case EPERM:
+  case EROFS:
+    return FAP_PERMISSION_DENIED;
+  default:
+    return FAP_ERROR;
+  }
 }
 
 
@@ -237,12 +277,16 @@ movian_smb2_connect_once(const movian_smb2_target_t *target,
 
 
 static struct smb2_context *
-movian_smb2_connect(const movian_smb2_target_t *target, const char *share,
-                    int flags, int timeout, char *errbuf, size_t errlen)
+movian_smb2_connect_impl(const movian_smb2_target_t *target, const char *share,
+                         int flags, int timeout, int *auth_needed,
+                         char *errbuf, size_t errlen)
 {
   movian_smb2_credentials_t credentials = {};
   char *keyring_id = movian_smb2_keyring_id(target);
   int status;
+
+  if(auth_needed != NULL)
+    *auth_needed = 0;
 
   if(keyring_id == NULL) {
     snprintf(errbuf, errlen, "Out of memory while preparing SMB2 login");
@@ -271,8 +315,12 @@ movian_smb2_connect(const movian_smb2_target_t *target, const char *share,
     return smb2;
   }
 
+  int auth_error = movian_smb2_is_auth_error(status, reason);
+  if(auth_error && auth_needed != NULL)
+    *auth_needed = 1;
+
   if(flags & (FA_NON_INTERACTIVE | FA_DISABLE_AUTH) ||
-     !movian_smb2_is_auth_error(status, reason)) {
+     !auth_error) {
     snprintf(errbuf, errlen, "Unable to connect to SMB2 share: %s", reason);
     movian_smb2_credentials_fini(&credentials);
     free(keyring_id);
@@ -321,6 +369,15 @@ movian_smb2_connect(const movian_smb2_target_t *target, const char *share,
   movian_smb2_credentials_fini(&credentials);
   free(keyring_id);
   return smb2;
+}
+
+
+static struct smb2_context *
+movian_smb2_connect(const movian_smb2_target_t *target, const char *share,
+                    int flags, int timeout, char *errbuf, size_t errlen)
+{
+  return movian_smb2_connect_impl(target, share, flags, timeout, NULL,
+                                  errbuf, errlen);
 }
 
 
@@ -537,7 +594,14 @@ movian_smb2_open(fa_protocol_t *fap, const char *url,
     return NULL;
   }
 
-  struct smb2fh *fh = smb2_open(smb2, target.path, O_RDONLY);
+  int open_flags = O_RDONLY;
+  if(flags & FA_WRITE) {
+    open_flags = O_RDWR | O_CREAT;
+    if(!(flags & FA_APPEND))
+      open_flags |= O_TRUNC;
+  }
+
+  struct smb2fh *fh = smb2_open(smb2, target.path, open_flags);
   if(fh == NULL) {
     snprintf(errbuf, errlen, "Unable to open SMB2 file: %s",
              smb2_get_error(smb2));
@@ -572,6 +636,19 @@ movian_smb2_open(fa_protocol_t *fap, const char *url,
   file->size = statbuf.smb2_size;
   hts_mutex_init(&file->mutex);
 
+  if(flags & FA_APPEND) {
+    if(smb2_lseek(file->smb2, file->fh, 0, SEEK_END, NULL) < 0) {
+      snprintf(errbuf, errlen, "Unable to seek SMB2 file: %s",
+               smb2_get_error(smb2));
+      hts_mutex_destroy(&file->mutex);
+      free(file);
+      smb2_close(smb2, fh);
+      movian_smb2_disconnect(smb2);
+      movian_smb2_target_fini(&target);
+      return NULL;
+    }
+  }
+
   movian_smb2_target_fini(&target);
   return &file->h;
 }
@@ -604,6 +681,24 @@ movian_smb2_read(fa_handle_t *fh, void *buf, size_t size)
 }
 
 
+static int
+movian_smb2_write(fa_handle_t *fh, const void *buf, size_t size)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+  uint32_t count = size > INT_MAX ? INT_MAX : size;
+
+  hts_mutex_lock(&file->mutex);
+  int status = smb2_write(file->smb2, file->fh, buf, count);
+  if(status > 0) {
+    int64_t pos = smb2_lseek(file->smb2, file->fh, 0, SEEK_CUR, NULL);
+    if(pos > file->size)
+      file->size = pos;
+  }
+  hts_mutex_unlock(&file->mutex);
+  return status;
+}
+
+
 static int64_t
 movian_smb2_seek(fa_handle_t *fh, int64_t pos, int whence, int lazy)
 {
@@ -621,6 +716,21 @@ movian_smb2_fsize(fa_handle_t *fh)
 {
   movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
   return file->size;
+}
+
+
+static fa_err_code_t
+movian_smb2_ftruncate(fa_handle_t *fh, uint64_t newsize)
+{
+  movian_smb2_file_t *file = (movian_smb2_file_t *)fh;
+
+  hts_mutex_lock(&file->mutex);
+  int status = smb2_ftruncate(file->smb2, file->fh, newsize);
+  if(status == 0)
+    file->size = newsize;
+  hts_mutex_unlock(&file->mutex);
+
+  return status < 0 ? movian_smb2_errno_to_fap(status) : FAP_OK;
 }
 
 
@@ -651,12 +761,14 @@ movian_smb2_stat(fa_protocol_t *fap, const char *url, struct fa_stat *fs,
     return FAP_OK;
   }
 
+  int auth_needed = 0;
   struct smb2_context *smb2 =
-    movian_smb2_connect(&target, target.share, flags, SMB2_DEFAULT_TIMEOUT,
-                        errbuf, errlen);
+    movian_smb2_connect_impl(&target, target.share, flags,
+                             SMB2_DEFAULT_TIMEOUT, &auth_needed,
+                             errbuf, errlen);
   if(smb2 == NULL) {
     movian_smb2_target_fini(&target);
-    return FAP_ERROR;
+    return auth_needed ? FAP_NEED_AUTH : FAP_ERROR;
   }
 
   int status = FAP_OK;
@@ -683,6 +795,193 @@ movian_smb2_stat(fa_protocol_t *fap, const char *url, struct fa_stat *fs,
 
 
 static int
+movian_smb2_unlink(const fa_protocol_t *fap, const char *url,
+                   char *errbuf, size_t errlen)
+{
+  movian_smb2_target_t target = {};
+  if(movian_smb2_target_parse(url, &target, errbuf, errlen))
+    return -1;
+
+  if(target.share == NULL || target.share[0] == '\0' ||
+     target.path[0] == '\0') {
+    snprintf(errbuf, errlen, "SMB2 URL does not identify a file");
+    movian_smb2_target_fini(&target);
+    return -1;
+  }
+
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&target, target.share, 0, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, errlen);
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&target);
+    return -1;
+  }
+
+  int status = smb2_unlink(smb2, target.path);
+  if(status < 0)
+    snprintf(errbuf, errlen, "Unable to delete SMB2 file: %s",
+             smb2_get_error(smb2));
+
+  movian_smb2_disconnect(smb2);
+  movian_smb2_target_fini(&target);
+  return status < 0 ? -1 : 0;
+}
+
+
+static int
+movian_smb2_rmdir(const fa_protocol_t *fap, const char *url,
+                  char *errbuf, size_t errlen)
+{
+  movian_smb2_target_t target = {};
+  if(movian_smb2_target_parse(url, &target, errbuf, errlen))
+    return -1;
+
+  if(target.share == NULL || target.share[0] == '\0' ||
+     target.path[0] == '\0') {
+    snprintf(errbuf, errlen, "SMB2 URL does not identify a directory");
+    movian_smb2_target_fini(&target);
+    return -1;
+  }
+
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&target, target.share, 0, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, errlen);
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&target);
+    return -1;
+  }
+
+  int status = smb2_rmdir(smb2, target.path);
+  if(status < 0)
+    snprintf(errbuf, errlen, "Unable to remove SMB2 directory: %s",
+             smb2_get_error(smb2));
+
+  movian_smb2_disconnect(smb2);
+  movian_smb2_target_fini(&target);
+  return status < 0 ? -1 : 0;
+}
+
+
+static int
+movian_smb2_rename(const fa_protocol_t *fap, const char *old_url,
+                   const char *new_url, char *errbuf, size_t errlen)
+{
+  movian_smb2_target_t old_target = {};
+  movian_smb2_target_t new_target = {};
+
+  if(movian_smb2_target_parse(old_url, &old_target, errbuf, errlen))
+    return -1;
+
+  if(movian_smb2_target_parse(new_url, &new_target, errbuf, errlen)) {
+    movian_smb2_target_fini(&old_target);
+    return -1;
+  }
+
+  if(old_target.share == NULL || old_target.share[0] == '\0' ||
+     new_target.share == NULL || new_target.share[0] == '\0' ||
+     old_target.path[0] == '\0' || new_target.path[0] == '\0') {
+    snprintf(errbuf, errlen, "SMB2 URL does not identify a path");
+    movian_smb2_target_fini(&old_target);
+    movian_smb2_target_fini(&new_target);
+    return -1;
+  }
+
+  if(strcmp(old_target.server, new_target.server) != 0 ||
+     strcmp(old_target.share, new_target.share) != 0) {
+    snprintf(errbuf, errlen, "Cross-share SMB2 rename not supported");
+    movian_smb2_target_fini(&old_target);
+    movian_smb2_target_fini(&new_target);
+    return -2;
+  }
+
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&old_target, old_target.share, 0,
+                        SMB2_DEFAULT_TIMEOUT, errbuf, errlen);
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&old_target);
+    movian_smb2_target_fini(&new_target);
+    return -1;
+  }
+
+  int status = smb2_rename(smb2, old_target.path, new_target.path);
+  if(status < 0)
+    snprintf(errbuf, errlen, "Unable to rename SMB2 path: %s",
+             smb2_get_error(smb2));
+
+  movian_smb2_disconnect(smb2);
+  movian_smb2_target_fini(&old_target);
+  movian_smb2_target_fini(&new_target);
+  return status == -EXDEV ? -2 : status < 0 ? -1 : 0;
+}
+
+
+static fa_err_code_t
+movian_smb2_makedir(fa_protocol_t *fap, const char *url)
+{
+  char errbuf[256];
+  movian_smb2_target_t target = {};
+  if(movian_smb2_target_parse(url, &target, errbuf, sizeof(errbuf)))
+    return FAP_ERROR;
+
+  if(target.share == NULL || target.share[0] == '\0' ||
+     target.path[0] == '\0') {
+    movian_smb2_target_fini(&target);
+    return FAP_ERROR;
+  }
+
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&target, target.share, 0, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, sizeof(errbuf));
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&target);
+    return FAP_ERROR;
+  }
+
+  int status = smb2_mkdir(smb2, target.path);
+  movian_smb2_disconnect(smb2);
+  movian_smb2_target_fini(&target);
+  return status < 0 ? movian_smb2_errno_to_fap(status) : FAP_OK;
+}
+
+
+static fa_err_code_t
+movian_smb2_fsinfo(fa_protocol_t *fap, const char *url, fa_fsinfo_t *ffi)
+{
+  char errbuf[256];
+  movian_smb2_target_t target = {};
+
+  memset(ffi, 0, sizeof(*ffi));
+
+  if(movian_smb2_target_parse(url, &target, errbuf, sizeof(errbuf)))
+    return FAP_ERROR;
+
+  if(target.share == NULL || target.share[0] == '\0') {
+    movian_smb2_target_fini(&target);
+    return FAP_ERROR;
+  }
+
+  struct smb2_context *smb2 =
+    movian_smb2_connect(&target, target.share, 0, SMB2_DEFAULT_TIMEOUT,
+                        errbuf, sizeof(errbuf));
+  if(smb2 == NULL) {
+    movian_smb2_target_fini(&target);
+    return FAP_ERROR;
+  }
+
+  struct smb2_statvfs vfs;
+  int status = smb2_statvfs(smb2, target.path[0] ? target.path : "", &vfs);
+  if(status == 0) {
+    ffi->ffi_size = (uint64_t)vfs.f_blocks * vfs.f_frsize;
+    ffi->ffi_avail = (uint64_t)vfs.f_bavail * vfs.f_frsize;
+  }
+
+  movian_smb2_disconnect(smb2);
+  movian_smb2_target_fini(&target);
+  return status < 0 ? movian_smb2_errno_to_fap(status) : FAP_OK;
+}
+
+
+static int
 movian_smb2_no_parking(fa_handle_t *fh)
 {
   return 1;
@@ -696,9 +995,16 @@ static fa_protocol_t fa_protocol_smb2 = {
   .fap_open = movian_smb2_open,
   .fap_close = movian_smb2_close,
   .fap_read = movian_smb2_read,
+  .fap_write = movian_smb2_write,
   .fap_seek = movian_smb2_seek,
   .fap_fsize = movian_smb2_fsize,
+  .fap_ftruncate = movian_smb2_ftruncate,
   .fap_stat = movian_smb2_stat,
+  .fap_unlink = movian_smb2_unlink,
+  .fap_rmdir = movian_smb2_rmdir,
+  .fap_rename = movian_smb2_rename,
+  .fap_makedir = movian_smb2_makedir,
+  .fap_fsinfo = movian_smb2_fsinfo,
   .fap_set_read_timeout = movian_smb2_set_read_timeout,
   .fap_no_parking = movian_smb2_no_parking,
 };

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -1,0 +1,61 @@
+# SMB/SMB2 Smoke Tests
+
+This directory contains opt-in runtime smoke tests for the SMB2 fileaccess
+backend. The tests are intended for developer machines with a known writable
+test share.
+
+No credentials are stored in the repository. Pass them through environment
+variables when running the scripts.
+
+## Required Environment
+
+```sh
+export SMB_SMOKE_HOST=192.0.2.10
+export SMB_SMOKE_SHARE=Users
+export SMB_SMOKE_PATH='public/test'
+export SMB_SMOKE_USER=example
+export SMB_SMOKE_PASSWORD='secret'
+export SMB_SMOKE_DOMAIN=WORKGROUP
+```
+
+`SMB_SMOKE_PATH` must point to a disposable/writable test directory. The GDB
+write smoke creates and removes a unique `codex-gdb-*` subdirectory below it.
+
+Optional variables:
+
+- `SMB_SMOKE_ART`: artifact directory. Defaults under `/tmp`.
+- `SMB_SMOKE_ROOT`: Movian checkout. Defaults to current working directory.
+- `SMB_SMOKE_MOVIAN`: Movian binary. Defaults to
+  `$SMB_SMOKE_ROOT/build.debug/movian`.
+- `SMB_SMOKE_TIMEOUT`: per-case timeout in seconds.
+
+## Fast Navigation Smoke
+
+```sh
+support/smb-smoke/run-http-nav-smoke.sh
+```
+
+Checks:
+
+- `smb2://$SMB_SMOKE_HOST` redirects/normalizes to host root with `/`;
+- `smb2://$SMB_SMOKE_HOST/` reaches `loading=0`;
+- the configured share/path reaches `loading=0`;
+- first page nodes are captured for comparison.
+
+## GDB Smoke
+
+```sh
+support/smb-smoke/run-gdb-smoke.sh
+```
+
+Checks under GDB:
+
+- host root with and without trailing slash;
+- configured share/path navigation;
+- write, truncate, append, read, rename, unlink, and rmdir in a unique
+  temporary subdirectory below `SMB_SMOKE_PATH`;
+- absence of `SIGSEGV`, `SIGABRT`, `SIGBUS`, stack-smashing, and obvious
+  buffer-overflow diagnostics.
+
+The scripts seed credentials into an isolated Movian profile and remove the
+seeded keyring before exit. Logs are also sanitized for the password string.

--- a/support/smb-smoke/common.sh
+++ b/support/smb-smoke/common.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+smb_smoke_require_config() {
+  : "${SMB_SMOKE_HOST:?set SMB_SMOKE_HOST}"
+  : "${SMB_SMOKE_SHARE:?set SMB_SMOKE_SHARE}"
+  : "${SMB_SMOKE_PATH:?set SMB_SMOKE_PATH}"
+  : "${SMB_SMOKE_USER:?set SMB_SMOKE_USER}"
+  : "${SMB_SMOKE_PASSWORD:?set SMB_SMOKE_PASSWORD}"
+
+  SMB_SMOKE_DOMAIN="${SMB_SMOKE_DOMAIN:-WORKGROUP}"
+  SMB_SMOKE_ROOT="${SMB_SMOKE_ROOT:-$(pwd)}"
+  SMB_SMOKE_MOVIAN="${SMB_SMOKE_MOVIAN:-$SMB_SMOKE_ROOT/build.debug/movian}"
+  SMB_SMOKE_TIMEOUT="${SMB_SMOKE_TIMEOUT:-45}"
+
+  if [ ! -x "$SMB_SMOKE_MOVIAN" ]; then
+    echo "Movian binary not executable: $SMB_SMOKE_MOVIAN" >&2
+    exit 2
+  fi
+}
+
+smb_smoke_trim_slashes() {
+  local value="$1"
+  value="${value#/}"
+  value="${value%/}"
+  printf '%s' "$value"
+}
+
+smb_smoke_base_url() {
+  local path
+  path="$(smb_smoke_trim_slashes "$SMB_SMOKE_PATH")"
+  if [ -n "$path" ]; then
+    printf 'smb2://%s/%s/%s' "$SMB_SMOKE_HOST" "$SMB_SMOKE_SHARE" "$path"
+  else
+    printf 'smb2://%s/%s' "$SMB_SMOKE_HOST" "$SMB_SMOKE_SHARE"
+  fi
+}
+
+smb_smoke_keyring_json() {
+  python3 - "$SMB_SMOKE_HOST" "$SMB_SMOKE_USER"     "$SMB_SMOKE_PASSWORD" "$SMB_SMOKE_DOMAIN" <<'PY'
+import json
+import sys
+
+host, user, password, domain = sys.argv[1:5]
+print(json.dumps({
+    f"smb2:connection:{host}": {
+        "username": user,
+        "password": password,
+        "domain": domain,
+    }
+}, separators=(",", ":")))
+PY
+}
+
+smb_smoke_write_profile() {
+  local profile="$1"
+  mkdir -p "$profile/persistent/settings" "$profile/cache"
+  smb_smoke_keyring_json >"$profile/persistent/settings/keyring"
+}
+
+smb_smoke_sanitize_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  python3 - "$file" "${SMB_SMOKE_PASSWORD:-}" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+password = sys.argv[2]
+data = path.read_text(errors="replace")
+if password:
+    data = data.replace(password, "<redacted>")
+data = re.sub(r'"password":"[^"]*"', '"password":"<redacted>"', data)
+path.write_text(data)
+PY
+}
+
+smb_smoke_cleanup_profiles() {
+  local art="$1"
+  find "$art" -maxdepth 1 -type d -name '*-profile' -prune -exec rm -rf {} +
+  rm -rf "$art/profile"
+}
+
+smb_smoke_check_no_secret() {
+  local art="$1"
+  if [ -n "${SMB_SMOKE_PASSWORD:-}" ] &&
+     grep -R --fixed-strings "$SMB_SMOKE_PASSWORD" "$art" >/dev/null 2>&1; then
+    echo "Secret leaked into artifacts under $art" >&2
+    return 1
+  fi
+}

--- a/support/smb-smoke/run-gdb-smoke.sh
+++ b/support/smb-smoke/run-gdb-smoke.sh
@@ -33,16 +33,26 @@ summarize() {
   local target="$2"
   local rc="$3"
   local log="$4"
+  local crash=0
+  local exited=0
+
+  if grep -Eq "Program received signal SIG(SEGV|ABRT|BUS|ILL)|AddressSanitizer|stack smashing|buffer overflow" "$log"; then
+    crash=1
+  fi
+  if grep -q "Inferior 1.*exited normally" "$log"; then
+    exited=1
+  fi
+
   {
     echo "[$name]"
     echo "target=$target"
     echo "gdb_exit=$rc"
-    if grep -Eq "Program received signal SIG(SEGV|ABRT|BUS|ILL)|AddressSanitizer|stack smashing|buffer overflow" "$log"; then
+    if [ "$crash" -ne 0 ]; then
       echo "crash_signal=yes"
     else
       echo "crash_signal=no"
     fi
-    if grep -q "Inferior 1.*exited normally" "$log"; then
+    if [ "$exited" -ne 0 ]; then
       echo "exited_normally=yes"
     else
       echo "exited_normally=no"
@@ -51,6 +61,15 @@ summarize() {
     grep -E "Program received signal|exited normally|SMB2_GDB|SMB2|navigator|ERROR|AddressSanitizer|stack smashing|buffer overflow|Unable|TRACE" "$log" | tail -120 || true
     echo
   } | tee -a "$ART/summary.txt"
+
+  if [ "$crash" -ne 0 ]; then
+    return 1
+  fi
+
+  case "$rc" in
+    0|124) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 run_nav_case() {
@@ -133,6 +152,10 @@ JS
   smb_smoke_sanitize_file "$log"
   smb_smoke_sanitize_file "$script"
   summarize "$name" "$script" "$rc" "$log"
+  if ! grep -q "SMB2_GDB done" "$log"; then
+    echo "SMB2_GDB done marker missing" | tee -a "$ART/summary.txt"
+    return 1
+  fi
 }
 
 cd "$SMB_SMOKE_ROOT"

--- a/support/smb-smoke/run-gdb-smoke.sh
+++ b/support/smb-smoke/run-gdb-smoke.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+smb_smoke_require_config
+command -v gdb >/dev/null || {
+  echo "gdb not found" >&2
+  exit 2
+}
+
+ART="${SMB_SMOKE_ART:-/tmp/fa_libsmb2-real-gdb-smoke}"
+rm -rf "$ART"
+mkdir -p "$ART"
+
+sanitize_artifacts() {
+  for f in "$ART"/*.log "$ART"/*.js "$ART"/summary.txt; do
+    [ -e "$f" ] && smb_smoke_sanitize_file "$f"
+  done
+}
+
+cleanup() {
+  sanitize_artifacts
+  smb_smoke_cleanup_profiles "$ART"
+  smb_smoke_check_no_secret "$ART"
+}
+trap cleanup EXIT
+
+summarize() {
+  local name="$1"
+  local target="$2"
+  local rc="$3"
+  local log="$4"
+  {
+    echo "[$name]"
+    echo "target=$target"
+    echo "gdb_exit=$rc"
+    if grep -Eq "Program received signal SIG(SEGV|ABRT|BUS|ILL)|AddressSanitizer|stack smashing|buffer overflow" "$log"; then
+      echo "crash_signal=yes"
+    else
+      echo "crash_signal=no"
+    fi
+    if grep -q "Inferior 1.*exited normally" "$log"; then
+      echo "exited_normally=yes"
+    else
+      echo "exited_normally=no"
+    fi
+    echo "interesting_log_lines:"
+    grep -E "Program received signal|exited normally|SMB2_GDB|SMB2|navigator|ERROR|AddressSanitizer|stack smashing|buffer overflow|Unable|TRACE" "$log" | tail -120 || true
+    echo
+  } | tee -a "$ART/summary.txt"
+}
+
+run_nav_case() {
+  local name="$1"
+  local url="$2"
+  local profile="$ART/$name-profile"
+  local log="$ART/$name.gdb.log"
+  smb_smoke_write_profile "$profile"
+
+  set +e
+  timeout --signal=INT --kill-after=5s "$SMB_SMOKE_TIMEOUT"s     gdb -q --batch       -ex "set pagination off"       -ex "set confirm off"       -ex "set print thread-events off"       -ex "handle SIGPIPE nostop noprint pass"       -ex "run -d --no-ui --disable-upgrades --persistent $profile/persistent --cache $profile/cache $url"       -ex "info program"       -ex "info threads"       -ex "thread apply all bt full"       --args "$SMB_SMOKE_MOVIAN"       >"$log" 2>&1
+  local rc=$?
+  set -e
+  smb_smoke_sanitize_file "$log"
+  summarize "$name" "$url" "$rc" "$log"
+}
+
+run_js_case() {
+  local name="js-write-truncate"
+  local profile="$ART/$name-profile"
+  local script="$ART/$name.js"
+  local log="$ART/$name.gdb.log"
+  local base_url="$1"
+  smb_smoke_write_profile "$profile"
+
+  cat >"$script" <<JS
+var fs = require('native/fs');
+var base = '$base_url';
+var stamp = 'codex-gdb-' + Date.now();
+var dir = base + '/' + stamp;
+var file = dir + '/file.bin';
+var renamed = dir + '/renamed.bin';
+
+function destroy(handle) {
+  if (handle) Core.resourceDestroy(handle);
+}
+
+console.log('SMB2_GDB start ' + dir);
+fs.mkdirs(dir);
+
+var fd = fs.open(file, 'w');
+try {
+  var data = Duktape.Buffer('abcdef');
+  var written = fs.write(fd, data, 0, null, 0);
+  console.log('SMB2_GDB written=' + written + ' size=' + fs.fsize(fd));
+  fs.ftruncate(fd, 3);
+  console.log('SMB2_GDB truncated size=' + fs.fsize(fd));
+} finally {
+  destroy(fd);
+}
+
+fd = fs.open(file, 'a');
+try {
+  var more = Duktape.Buffer('XYZ');
+  console.log('SMB2_GDB append=' + fs.write(fd, more, 0, null, null));
+  console.log('SMB2_GDB append size=' + fs.fsize(fd));
+} finally {
+  destroy(fd);
+}
+
+fd = fs.open(file, 'r');
+try {
+  var buf = new Duktape.Buffer(fs.fsize(fd));
+  var read = fs.read(fd, buf.valueOf(), 0, buf.length, 0);
+  console.log('SMB2_GDB read=' + read);
+} finally {
+  destroy(fd);
+}
+
+fs.rename(file, renamed);
+fs.unlink(renamed);
+fs.rmdir(dir);
+console.log('SMB2_GDB done');
+JS
+
+  set +e
+  timeout --signal=INT --kill-after=5s "$SMB_SMOKE_TIMEOUT"s     gdb -q --batch       -ex "set pagination off"       -ex "set confirm off"       -ex "set print thread-events off"       -ex "handle SIGPIPE nostop noprint pass"       -ex "run -d --no-ui --disable-upgrades --bypass-ecmascript-acl --persistent $profile/persistent --cache $profile/cache --ecmascript $script"       -ex "info program"       -ex "info threads"       -ex "thread apply all bt full"       --args "$SMB_SMOKE_MOVIAN"       >"$log" 2>&1
+  local rc=$?
+  set -e
+  smb_smoke_sanitize_file "$log"
+  smb_smoke_sanitize_file "$script"
+  summarize "$name" "$script" "$rc" "$log"
+}
+
+cd "$SMB_SMOKE_ROOT"
+: >"$ART/summary.txt"
+BASE_URL="$(smb_smoke_base_url)"
+run_nav_case "nav-share-path" "$BASE_URL/"
+run_nav_case "nav-host-no-slash" "smb2://$SMB_SMOKE_HOST"
+run_nav_case "nav-host-with-slash" "smb2://$SMB_SMOKE_HOST/"
+run_js_case "$BASE_URL"
+
+echo "ART=$ART"

--- a/support/smb-smoke/run-http-nav-smoke.sh
+++ b/support/smb-smoke/run-http-nav-smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+. "$SCRIPT_DIR/common.sh"
+
+smb_smoke_require_config
+
+ART="${SMB_SMOKE_ART:-/tmp/fa_libsmb2-http-nav-smoke}"
+rm -rf "$ART"
+mkdir -p "$ART/profile/persistent/settings" "$ART/profile/cache"
+smb_smoke_write_profile "$ART/profile"
+
+cleanup() {
+  if [ -n "${PID:-}" ]; then
+    kill "$PID" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+      if ! kill -0 "$PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    kill -KILL "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+  fi
+  rm -f "$ART/profile/persistent/settings/keyring"
+  smb_smoke_sanitize_file "$ART/movian.log"
+  smb_smoke_check_no_secret "$ART"
+}
+trap cleanup EXIT
+
+cd "$SMB_SMOKE_ROOT"
+"$SMB_SMOKE_MOVIAN" -d --disable-upgrades \
+  --persistent "$ART/profile/persistent" \
+  --cache "$ART/profile/cache" \
+  >"$ART/movian.log" 2>&1 &
+PID=$!
+
+for _ in $(seq 1 120); do
+  port=$(sed -n 's/.*http-server: Listening on port \([0-9][0-9]*\).*/\1/p' "$ART/movian.log" | tail -1)
+  [ -n "${port:-}" ] && break
+  sleep 0.25
+done
+[ -n "${port:-}" ]
+BASE="http://127.0.0.1:$port"
+
+wait_http() {
+  for _ in $(seq 1 80); do
+    if curl -fsS "$BASE/api/diag" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+wait_http
+sleep "${SMB_SMOKE_UI_SETTLE:-5}"
+
+prop_value() {
+  curl -fsS "$BASE/api/prop/$1" 2>/dev/null | sed -n '1s/^.* is a //p' || true
+}
+
+open_url() {
+  local url="$1"
+  local open_target="$url"
+  case "$url" in
+    smb://*|smb2://*) open_target="search:$url" ;;
+  esac
+  for _ in $(seq 1 80); do
+    if curl -fsS --get --data-urlencode "url=$open_target" "$BASE/api/open" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+wait_page() {
+  local expected="$1"
+  local expected_url
+  for _ in $(seq 1 160); do
+    page_url=$(prop_value global/navigators/current/currentpage/url)
+    loading=$(prop_value global/navigators/current/currentpage/model/loading)
+    case "$expected" in
+      "smb2://$SMB_SMOKE_HOST") expected_url="smb2://$SMB_SMOKE_HOST/" ;;
+      *) expected_url="$expected" ;;
+    esac
+    if [ "$page_url" = "$expected_url" ] && [ "$loading" = "0" ]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+dump_case() {
+  local name="$1"
+  local url="$2"
+  open_url "$url"
+  if ! wait_page "$url"; then
+    {
+      echo "[$name]"
+      echo "url=$url"
+      echo "status=failed"
+      echo "page_url=$(prop_value global/navigators/current/currentpage/url)"
+      echo "title=$(prop_value global/navigators/current/currentpage/model/metadata/title)"
+      echo "loading=$(prop_value global/navigators/current/currentpage/model/loading)"
+      echo
+    } | tee -a "$ART/summary.txt"
+    return 1
+  fi
+  {
+    echo "[$name]"
+    echo "url=$url"
+    echo "page_url=$(prop_value global/navigators/current/currentpage/url)"
+    echo "title=$(prop_value global/navigators/current/currentpage/model/metadata/title)"
+    echo "loading=$(prop_value global/navigators/current/currentpage/model/loading)"
+    for i in $(seq 0 8); do
+      title=$(prop_value "global/navigators/current/currentpage/model/nodes/*$i/metadata/title")
+      type=$(prop_value "global/navigators/current/currentpage/model/nodes/*$i/type")
+      node_url=$(prop_value "global/navigators/current/currentpage/model/nodes/*$i/url")
+      [ -n "$title$type$node_url" ] &&
+        printf 'node[%s]\ttype=%s\ttitle=%s\turl=%s\n' "$i" "$type" "$title" "$node_url"
+    done
+    echo
+  } | tee -a "$ART/summary.txt"
+}
+
+BASE_URL="$(smb_smoke_base_url)"
+dump_case host-no-slash "smb2://$SMB_SMOKE_HOST"
+dump_case host-with-slash "smb2://$SMB_SMOKE_HOST/"
+dump_case share-path "$BASE_URL/"
+
+echo "ART=$ART"


### PR DESCRIPTION
## Summary
- Add writable SMB2 file operations, truncate support, fsinfo, and path operation error handling.
- Expose the corrected `native/fs.ftruncate` alias while keeping legacy `ftrunctae` compatibility.
- Align SMB2 navigation/auth behavior with SMB1, including first prompt text, root URL redirect/normalize, and hidden share filtering.
- Harden SMB2 URL construction, optional URL component allocation checks, truncate size caching, redirect bounds, and `statvfs` multiplication.
- Add opt-in SMB2 HTTP navigation and GDB write/truncate smoke tests under `support/smb-smoke`.
- Document SMB/SMB2 navigation lifecycle research, WSL workspace guardrails, and plugin filesystem ACL/security findings.

## Validation
- `git diff --check`
- `git diff --check HEAD~3..HEAD`
- `bash -n support/smb-smoke/common.sh support/smb-smoke/run-http-nav-smoke.sh support/smb-smoke/run-gdb-smoke.sh`
- `make -j2 BUILD=debug`
- `support/smb-smoke/run-http-nav-smoke.sh` against the Windows test share with env-provided credentials
- `support/smb-smoke/run-gdb-smoke.sh` against the Windows test share with env-provided credentials
- Runtime SMB/SMB2 navigation smoke tests with isolated profiles, popup inspection, seeded keyring, and STPP popup propref probe

## Notes
- Directory entry type/count differences are documented as an observed server/libsmb2 metadata difference pending raw attribute testing.
- The plugin filesystem audit documents that ordinary plugins without bypass entitlements are blocked from destructive SMB2 writes, while the existing `native/fs.copyfile(from, to)` read-scope behavior remains a separate pre-existing issue.
