### PR TITLE
SMB2 server read-only MVP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,5 +28,5 @@
 	branch = main
 [submodule "ext/libsmb2"]
 	path = ext/libsmb2
-	url = https://github.com/sahlberg/libsmb2.git
+	url = https://github.com/Buksa/libsmb2.git
 	ref = refs/tags/libsmb2-6.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -29,4 +29,4 @@
 [submodule "ext/libsmb2"]
 	path = ext/libsmb2
 	url = https://github.com/Buksa/libsmb2.git
-	ref = refs/tags/libsmb2-6.2
+	branch = codex/movian-server-isolation

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ SRCS += src/networking/net_common.c \
 	src/networking/websocket.c \
 
 SRCS-$(CONFIG_FTPSERVER) += src/networking/ftp_server.c
+SRCS-$(CONFIG_LIBSMB2) += src/networking/smb2_server.c
 
 SRCS-$(CONFIG_POLARSSL) += src/networking/net_polarssl.c
 SRCS-$(CONFIG_OPENSSL)  += src/networking/net_openssl.c

--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ SRCS += src/networking/net_common.c \
 	src/networking/websocket.c \
 
 SRCS-$(CONFIG_FTPSERVER) += src/networking/ftp_server.c
-SRCS-$(CONFIG_LIBSMB2) += src/networking/smb2_server.c
+SRCS-$(CONFIG_LIBSMB2_SERVER) += src/networking/smb2_server.c
 
 SRCS-$(CONFIG_POLARSSL) += src/networking/net_polarssl.c
 SRCS-$(CONFIG_OPENSSL)  += src/networking/net_openssl.c

--- a/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
+++ b/docs/Guides/FLATPAK_STEAMOS_GUIDE.md
@@ -130,6 +130,12 @@ For the full Linux, Flatpak, runtime, and manual Steam Deck checklist, see:
 docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
 ```
 
+For SSH-assisted copy/install/log collection on a real Steam Deck, see:
+
+```text
+docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+```
+
 ## Install And Run
 
 Install the generated bundle:
@@ -159,6 +165,11 @@ Mode through Discover or CLI:
 flatpak install --user --reinstall --bundle \
   ~/Downloads/dev.uzver.Movian.flatpak
 ```
+
+For repeat remote cycles, copy the bundle to `~/Downloads` with a unique
+filename, verify its SHA-256 hash, install it over SSH, then ask the Deck user
+to launch Movian manually if `flatpak run` from SSH exits without opening the
+GLW UI.
 
 Minimum smoke checklist:
 

--- a/docs/Guides/LINUX_SMB2_BACKEND.md
+++ b/docs/Guides/LINUX_SMB2_BACKEND.md
@@ -1,7 +1,10 @@
 # Linux SMB2 and SMB3 Backend
 
-Linux builds include a bundled, read-only SMB2/SMB3 backend based on
-`libsmb2-6.2`. It is available through the temporary `smb2://` scheme while
+Linux builds include a bundled SMB2/SMB3 backend based on a pinned
+`ext/libsmb2` submodule commit. The current Movian branch tracks the
+`Buksa/libsmb2` `codex/movian-server-isolation` branch, rebased on current
+upstream `sahlberg/libsmb2` master, with a small Movian embedding hardening
+patch. It is available through the temporary `smb2://` scheme while
 the existing `smb://` backend remains unchanged for compatibility and A/B
 testing.
 
@@ -27,16 +30,17 @@ its system D-Bus service.
 
 ## Supported Operations
 
-The initial backend supports:
+The backend supports:
 
 - host share enumeration;
 - directory browsing;
 - path metadata;
 - file open, read, seek, size, and close;
+- write, append, truncate, rename, unlink, rmdir, mkdir, and filesystem
+  free-space queries where the remote share permits them;
 - guest and authenticated sessions.
 
-It is intentionally read-only. Write, create, rename, delete, directory
-mutation, and extended-attribute operations are not implemented.
+Extended-attribute operations are not implemented.
 
 Each open file or directory operation owns its own libsmb2 context. This keeps
 parallel resources independent and avoids sharing mutable connection state

--- a/docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md
+++ b/docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md
@@ -5,8 +5,8 @@ from ordinary Windows clients.
 
 ## Current State
 
-The Movian SMB2 server MVP runs inside the local Flatpak and serves a read-only
-share on a non-privileged development port. On the Steam Deck test host:
+The Movian SMB2 server MVP currently serves a read-only share on a
+non-privileged development port. On the Steam Deck Flatpak test host:
 
 - `192.168.1.56:1445` is open and accepts libsmb2 session setup.
 - `192.168.1.56:445` is closed.
@@ -16,6 +16,10 @@ share on a non-privileged development port. On the Steam Deck test host:
 
 The MVP request handlers are therefore usable on high ports, but Windows
 Explorer and `net use` still need a way to reach the server on TCP `445`.
+
+This is not only a Flatpak problem. It is a general host-platform exposure
+problem: Windows SMB clients expect TCP `445`, while many platforms reserve or
+heavily restrict that port for privileged/system services.
 
 ## Windows Requirements
 
@@ -30,6 +34,33 @@ This is separate from network-neighborhood visibility. Even after TCP `445`
 works, auto-appearance under Explorer's Network view may require a Windows
 discovery layer such as WS-Discovery. The first acceptance target should be
 manual UNC access by IP address.
+
+## Platform Scope
+
+The SMB2 request handlers can be portable, but Windows-visible service exposure
+is platform-specific:
+
+- Linux and SteamOS reserve TCP ports below `1024` for privileged processes by
+  default. A regular Movian process cannot bind TCP `445` without root,
+  `CAP_NET_BIND_SERVICE`, a host redirect/proxy, socket activation, or a global
+  privileged-port policy change.
+- Flatpak adds sandbox constraints on top of the normal Linux rule. The current
+  local Flatpak does not receive Linux capabilities, so the host must expose or
+  forward TCP `445`.
+- Android uses a Linux kernel but runs apps inside an application sandbox.
+  Binding TCP `445` should be treated as a platform integration problem that
+  would require Android-specific privileges, service lifecycle, and foreground
+  networking policy. A normal Android app should not be assumed able to expose
+  a Windows SMB server on TCP `445`.
+- macOS and other Unix-like systems also treat low ports as privileged or
+  otherwise system-managed. A native package would need a helper, launchd/system
+  service, pf redirect, or equivalent host integration.
+- Windows as a server platform is different again: TCP `445` may already be
+  owned by the OS SMB Server service, and firewall/service ownership must be
+  handled through Windows packaging and service policy.
+
+Therefore, keep the core SMB2 server on an unprivileged configurable port, and
+solve TCP `445` exposure with a platform-specific host helper.
 
 ## Flatpak Capability Result
 
@@ -50,6 +81,9 @@ Unknown option --cap-add=NET_BIND_SERVICE
 not a Linux capability grant. Inside the running Flatpak sandbox, capability
 sets were empty (`CapEff`, `CapBnd`, and `CapAmb` all zero). Treat TCP `445`
 exposure as host packaging or forwarding work, not as a manifest finish-arg.
+Native non-Flatpak Linux builds may use normal host mechanisms such as
+`setcap cap_net_bind_service=+ep` on the binary, but that is still a host
+installation decision rather than SMB2 handler logic.
 
 ## Option A: Host Port Redirect
 
@@ -76,7 +110,7 @@ Cons:
 - Needs careful persistence and removal scripts.
 - Port ownership and firewall behavior are outside the Flatpak manifest.
 
-This is a strong candidate for a Steam Deck helper once the exact rule is
+This is a strong candidate for a Linux/SteamOS helper once the exact rule is
 validated.
 
 ## Option B: systemd Socket Proxy
@@ -119,6 +153,10 @@ Cons:
 This is the recommended next experiment because it is reversible and does not
 require changing Movian's SMB2 server internals.
 
+The same pattern applies to native Linux packages and Flatpak installations:
+the host service manager owns privileged TCP `445`; Movian continues to run as
+an unprivileged process on a high port.
+
 ## Option C: Direct systemd Socket Activation
 
 In direct socket activation, systemd binds TCP `445`, starts Movian, and passes
@@ -136,8 +174,9 @@ the current MVP:
 - Flatpak fd inheritance through the launcher must be verified separately.
 - Stop/restart lifecycle must avoid shutting down a systemd-owned listening fd.
 
-This is a plausible v2/v3 design if we want to remove the proxy layer, but it is
-more invasive than a host redirect or systemd socket proxy.
+This is a plausible v2/v3 design if we want to remove the proxy layer. It
+applies to native Linux too, but it is more invasive than a host redirect or
+systemd socket proxy.
 
 ## Option D: Lower `ip_unprivileged_port_start`
 
@@ -149,7 +188,8 @@ Linux can allow unprivileged processes to bind low ports by changing:
 
 The tested Steam Deck uses the normal value `1024`. Lowering it to `0` would let
 ordinary user processes bind TCP `445`, but this is a global host security
-change. It is not recommended as the default product path.
+change. It affects all unprivileged processes, not only Movian. It is not
+recommended as the default product path.
 
 ## Discovery Layer
 
@@ -167,7 +207,8 @@ cmd /c "net use \\192.168.1.56\Media /user:movian 123 /persistent:no"
 
 ## Recommended Next Step
 
-Validate a reversible systemd socket proxy on the Steam Deck:
+Validate a reversible systemd socket proxy on Linux/SteamOS, starting with the
+Steam Deck test host:
 
 1. Keep Movian SMB2 serving on `127.0.0.1:1445` / `0.0.0.0:1445`.
 2. Install temporary root-owned `movian-smb2-forward.socket` and
@@ -180,7 +221,6 @@ Test-NetConnection 192.168.1.56 -Port 445
 cmd /c "net use \\192.168.1.56\Media /user:movian 123 /persistent:no"
 ```
 
-If this passes, document the unit files as the first Steam Deck Windows-access
-helper. If it fails, capture the Windows error, Movian log tail, and the proxy
-service journal before trying nftables.
-
+If this passes, document the unit files as the first Linux/SteamOS
+Windows-access helper. If it fails, capture the Windows error, Movian log tail,
+and the proxy service journal before trying nftables.

--- a/docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md
+++ b/docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md
@@ -1,0 +1,186 @@
+# SMB2 Windows Visibility Research
+
+This note captures the current research for making Movian's SMB2 server usable
+from ordinary Windows clients.
+
+## Current State
+
+The Movian SMB2 server MVP runs inside the local Flatpak and serves a read-only
+share on a non-privileged development port. On the Steam Deck test host:
+
+- `192.168.1.56:1445` is open and accepts libsmb2 session setup.
+- `192.168.1.56:445` is closed.
+- Windows `\\192.168.1.56\Media` does not connect while port `445` is closed.
+- Non-standard Windows paths such as `\\192.168.1.56@1445\Media` are not a
+  reliable user-facing path.
+
+The MVP request handlers are therefore usable on high ports, but Windows
+Explorer and `net use` still need a way to reach the server on TCP `445`.
+
+## Windows Requirements
+
+Modern Windows SMB clients use direct-hosted SMB over TCP `445` for normal UNC
+paths such as:
+
+```text
+\\192.168.1.56\Media
+```
+
+This is separate from network-neighborhood visibility. Even after TCP `445`
+works, auto-appearance under Explorer's Network view may require a Windows
+discovery layer such as WS-Discovery. The first acceptance target should be
+manual UNC access by IP address.
+
+## Flatpak Capability Result
+
+Adding a Docker/Podman-style capability argument is not a viable Flatpak
+solution:
+
+```text
+flatpak build-finish --cap-add=NET_BIND_SERVICE ...
+```
+
+Local testing with Flatpak 1.14 reports:
+
+```text
+Unknown option --cap-add=NET_BIND_SERVICE
+```
+
+`flatpak run` and `flatpak override` expose similar sandbox permission flags but
+not a Linux capability grant. Inside the running Flatpak sandbox, capability
+sets were empty (`CapEff`, `CapBnd`, and `CapAmb` all zero). Treat TCP `445`
+exposure as host packaging or forwarding work, not as a manifest finish-arg.
+
+## Option A: Host Port Redirect
+
+A root-owned host rule can redirect incoming TCP `445` to the Movian high port:
+
+```text
+host:445 -> 127.0.0.1:1445
+```
+
+Possible implementations:
+
+- `nftables` redirect rule;
+- `iptables` redirect rule on older systems.
+
+Pros:
+
+- Movian and Flatpak remain unprivileged.
+- No changes are required in libsmb2's server loop.
+- The SMB2 request-handler smoke remains identical on `1445`.
+
+Cons:
+
+- Requires privileged host setup.
+- Needs careful persistence and removal scripts.
+- Port ownership and firewall behavior are outside the Flatpak manifest.
+
+This is a strong candidate for a Steam Deck helper once the exact rule is
+validated.
+
+## Option B: systemd Socket Proxy
+
+systemd can bind privileged TCP `445` and launch a small proxy to the Movian
+high port:
+
+```ini
+# movian-smb2-forward.socket
+[Socket]
+ListenStream=0.0.0.0:445
+Accept=yes
+
+[Install]
+WantedBy=sockets.target
+```
+
+```ini
+# movian-smb2-forward@.service
+[Service]
+User=deck
+StandardInput=socket
+StandardOutput=socket
+ExecStart=/usr/bin/socat - TCP:127.0.0.1:1445
+```
+
+Pros:
+
+- Uses systemd to own the privileged port.
+- Keeps Movian unprivileged and unchanged.
+- Easier to disable than a raw firewall rule.
+- `socat` is present on the tested Steam Deck.
+
+Cons:
+
+- Still requires privileged host unit installation.
+- Adds one proxy process per connection with `Accept=yes`.
+- Needs runtime validation with Windows `net use`.
+
+This is the recommended next experiment because it is reversible and does not
+require changing Movian's SMB2 server internals.
+
+## Option C: Direct systemd Socket Activation
+
+In direct socket activation, systemd binds TCP `445`, starts Movian, and passes
+the listening socket through file descriptor `3` using the `LISTEN_FDS`
+protocol. The daemon must call `sd_listen_fds()` or implement the same protocol
+and then accept clients from the inherited descriptor.
+
+This is architecturally clean, but it is not a small packaging-only change for
+the current MVP:
+
+- `src/networking/smb2_server.c` currently calls `smb2_serve_port()`.
+- `smb2_serve_port()` in bundled libsmb2 calls `smb2_bind_and_listen()` itself.
+- libsmb2 exposes `smb2_serve_port_async(fd, ...)`, so the pieces exist, but
+  Movian/libsmb2 would need a `serve_fd` path or a local copy of the serve loop.
+- Flatpak fd inheritance through the launcher must be verified separately.
+- Stop/restart lifecycle must avoid shutting down a systemd-owned listening fd.
+
+This is a plausible v2/v3 design if we want to remove the proxy layer, but it is
+more invasive than a host redirect or systemd socket proxy.
+
+## Option D: Lower `ip_unprivileged_port_start`
+
+Linux can allow unprivileged processes to bind low ports by changing:
+
+```text
+/proc/sys/net/ipv4/ip_unprivileged_port_start
+```
+
+The tested Steam Deck uses the normal value `1024`. Lowering it to `0` would let
+ordinary user processes bind TCP `445`, but this is a global host security
+change. It is not recommended as the default product path.
+
+## Discovery Layer
+
+TCP `445` is required for manual UNC access, but it does not guarantee the
+device appears under Explorer's Network view. For modern Windows network
+discovery, plan a separate WS-Discovery/wsdd-style responder after manual UNC
+access works.
+
+Do not block the MVP on discovery. The first Windows acceptance should be:
+
+```powershell
+Test-NetConnection 192.168.1.56 -Port 445
+cmd /c "net use \\192.168.1.56\Media /user:movian 123 /persistent:no"
+```
+
+## Recommended Next Step
+
+Validate a reversible systemd socket proxy on the Steam Deck:
+
+1. Keep Movian SMB2 serving on `127.0.0.1:1445` / `0.0.0.0:1445`.
+2. Install temporary root-owned `movian-smb2-forward.socket` and
+   `movian-smb2-forward@.service`.
+3. Start the socket and verify host TCP `445` is listening.
+4. From Windows, run:
+
+```powershell
+Test-NetConnection 192.168.1.56 -Port 445
+cmd /c "net use \\192.168.1.56\Media /user:movian 123 /persistent:no"
+```
+
+If this passes, document the unit files as the first Steam Deck Windows-access
+helper. If it fails, capture the Windows error, Movian log tail, and the proxy
+service journal before trying nftables.
+

--- a/docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md
+++ b/docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md
@@ -17,6 +17,12 @@ non-privileged development port. On the Steam Deck Flatpak test host:
 The MVP request handlers are therefore usable on high ports, but Windows
 Explorer and `net use` still need a way to reach the server on TCP `445`.
 
+Authentication is a separate current blocker from TCP visibility. Runtime tests
+against the AG build on Steam Deck show anonymous high-port browsing succeeds
+with Samba `smbclient`, while password-protected NTLM sessions fail before the
+first directory create/query request. Do not treat anonymous high-port success
+as proof that ordinary Windows password-authenticated UNC access is complete.
+
 This is not only a Flatpak problem. It is a general host-platform exposure
 problem: Windows SMB clients expect TCP `445`, while many platforms reserve or
 heavily restrict that port for privileged/system services.

--- a/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+++ b/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
@@ -70,9 +70,13 @@ scp -i ~/.ssh/movian_deck \
 Install remotely:
 
 ```sh
-ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+ssh -n -i ~/.ssh/movian_deck deck@<deck-ip> \
   'flatpak install --user -y /home/deck/Downloads/dev.uzver.Movian-<short-sha>.flatpak'
 ```
+
+Use `ssh -n` in scripted workflows where more local commands follow the SSH
+call. Without it, OpenSSH can consume the rest of a here-doc or pipeline as
+remote stdin.
 
 If `flatpak install` appears to hang, check whether it is still working in the
 Flatpak repository:
@@ -85,15 +89,30 @@ ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
 Verify the installed commit and version:
 
 ```sh
-ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+ssh -n -i ~/.ssh/movian_deck deck@<deck-ip> \
   'flatpak info --user dev.uzver.Movian | sed -n "1,80p"'
 ```
 
 ## Launch And Observe
 
-Launching the GLW UI through SSH can exit immediately in some Deck desktop
-sessions. If this happens, ask the Deck user to start Movian normally, then
-continue the remote smoke through SSH and HTTP.
+Launching the GLW UI through a plain SSH command can exit when the SSH session
+ends. In Desktop Mode, prefer a transient user systemd unit with the Plasma X11
+display and the current random `xauth_*` file:
+
+```sh
+ssh -n -i ~/.ssh/movian_deck deck@<deck-ip> '
+  flatpak kill dev.uzver.Movian 2>/dev/null || true
+  systemctl --user stop movian-codex-test.service 2>/dev/null || true
+  XAUTH=$(find /run/user/1000 -maxdepth 1 -name "xauth_*" | head -1)
+  systemd-run --user --unit=movian-codex-test --collect \
+    --setenv=DISPLAY=:0 --setenv=XAUTHORITY="$XAUTH" \
+    flatpak run dev.uzver.Movian
+'
+```
+
+`xauth_*` changes after reboot. Resolve it dynamically. If this still fails,
+ask the Deck user to start Movian normally, then continue the remote smoke
+through SSH and HTTP.
 
 Useful probes:
 
@@ -142,6 +161,12 @@ no CRASH / Signal lines in /api/logfile/0 or /api/logfile/1
 If setting port `445` is accepted but no listener remains on `445`, classify the
 result as privileged-port packaging/forwarding work unless request-handler
 smokes also fail on a high port.
+
+Do not add Docker/Podman-style capability arguments to the Flatpak manifest.
+Flatpak 1.14 `build-finish`, `run`, and `override` do not support
+`--cap-add=NET_BIND_SERVICE`; a test run reports `Unknown option
+--cap-add=NET_BIND_SERVICE`. Keep high-port handler smokes separate from the
+product/packaging work needed to expose TCP `445` to ordinary Windows clients.
 
 If an unavailable port is rejected, the previous working listener should remain
 alive. Verify the old high port still accepts TCP and SMB2 session setup before

--- a/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+++ b/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
@@ -138,6 +138,13 @@ For the SMB2 server MVP, test these as separate claims:
 - The SMB2 server logs `SMB2-SERVER Listening on port <port>`.
 - TCP connects to that port.
 - A libsmb2 client can perform session setup and browse/read.
+  Record whether the run is anonymous or password-protected; these are
+  different protocol claims. Current observed state: anonymous
+  `smbclient //deck/share -p 1445 -U "anonymous%" -m SMB2/SMB3 -c ls`
+  passes on the AG build, but switching that same build to username/password
+  fails with `NT_STATUS_ACCESS_DENIED` or a bad SMB2 signature before
+  listing. Keep password auth/signing work separate from read-only anonymous
+  browse/read smokes.
 - Read-only mutation attempts fail.
 - Runtime port changes through settings restart the server without crashing.
 - Windows native acceptance uses TCP `445`; non-445 ports are development-only

--- a/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+++ b/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
@@ -143,6 +143,10 @@ If setting port `445` is accepted but no listener remains on `445`, classify the
 result as privileged-port packaging/forwarding work unless request-handler
 smokes also fail on a high port.
 
+If an unavailable port is rejected, the previous working listener should remain
+alive. Verify the old high port still accepts TCP and SMB2 session setup before
+continuing.
+
 Before leaving the Deck, restore the last known working development port and
 confirm it listens.
 

--- a/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+++ b/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
@@ -167,6 +167,8 @@ Flatpak 1.14 `build-finish`, `run`, and `override` do not support
 `--cap-add=NET_BIND_SERVICE`; a test run reports `Unknown option
 --cap-add=NET_BIND_SERVICE`. Keep high-port handler smokes separate from the
 product/packaging work needed to expose TCP `445` to ordinary Windows clients.
+For the current Windows-access research and candidate host-side forwarding
+options, see `docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md`.
 
 If an unavailable port is rejected, the previous working listener should remain
 alive. Verify the old high port still accepts TCP and SMB2 session setup before

--- a/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+++ b/docs/Guides/STEAM_DECK_REMOTE_TESTING.md
@@ -1,0 +1,159 @@
+# Steam Deck Remote Testing
+
+Use this workflow when a Movian Flatpak needs to be installed and smoke-tested
+on a Steam Deck from a Windows/WSL development machine.
+
+The goal is to automate copy/install/log collection while still allowing the
+Deck user to launch the UI manually when the desktop session does not accept
+GUI launches from SSH.
+
+## One-Time Deck Setup
+
+On the Steam Deck, in Desktop Mode:
+
+```sh
+passwd
+sudo systemctl enable --now sshd
+ip -4 addr show wlan0
+```
+
+Prefer key auth over passwords. From Windows PowerShell:
+
+```powershell
+mkdir $HOME\.ssh -Force
+ssh-keygen -t ed25519 -f $HOME\.ssh\movian_deck -C movian-deck
+$pub = Get-Content $HOME\.ssh\movian_deck.pub
+ssh deck@<deck-ip> "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo '$pub' >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+```
+
+Windows usually does not provide `ssh-copy-id`. The PowerShell command above is
+the portable replacement.
+
+## WSL Key Copy
+
+Do not use the private key directly from `/mnt/c/...` with WSL OpenSSH. Windows
+mounted files can appear as mode `0777`, and OpenSSH will reject the key as too
+open.
+
+Copy the key into WSL once:
+
+```sh
+mkdir -p ~/.ssh
+cp /mnt/c/Users/<windows-user>/.ssh/movian_deck ~/.ssh/movian_deck
+cp /mnt/c/Users/<windows-user>/.ssh/movian_deck.pub ~/.ssh/movian_deck.pub
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/movian_deck
+chmod 644 ~/.ssh/movian_deck.pub
+ssh -i ~/.ssh/movian_deck deck@<deck-ip> 'whoami; uname -srm; cat /etc/hostname'
+```
+
+Use `cat /etc/hostname` rather than assuming `hostname` exists in the Deck SSH
+environment.
+
+## Copy And Install A Bundle
+
+Build locally:
+
+```sh
+support/flatpak/build-local.sh
+sha256sum build.flatpak/dev.uzver.Movian.flatpak
+```
+
+Copy to the Deck with a unique filename so an older download is not overwritten:
+
+```sh
+scp -i ~/.ssh/movian_deck \
+  build.flatpak/dev.uzver.Movian.flatpak \
+  deck@<deck-ip>:/home/deck/Downloads/dev.uzver.Movian-<short-sha>.flatpak
+```
+
+Install remotely:
+
+```sh
+ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+  'flatpak install --user -y /home/deck/Downloads/dev.uzver.Movian-<short-sha>.flatpak'
+```
+
+If `flatpak install` appears to hang, check whether it is still working in the
+Flatpak repository:
+
+```sh
+ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+  'pgrep -a -f "flatpak install|dev.uzver.Movian"; flatpak info --user dev.uzver.Movian | sed -n "1,80p"'
+```
+
+Verify the installed commit and version:
+
+```sh
+ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+  'flatpak info --user dev.uzver.Movian | sed -n "1,80p"'
+```
+
+## Launch And Observe
+
+Launching the GLW UI through SSH can exit immediately in some Deck desktop
+sessions. If this happens, ask the Deck user to start Movian normally, then
+continue the remote smoke through SSH and HTTP.
+
+Useful probes:
+
+```sh
+curl -fsS http://<deck-ip>:42000/api/diag
+curl -fsS http://<deck-ip>:42000/api/logfile/0 -o /tmp/steamdeck-log0.txt
+
+ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+  'ps -eo pid,comm,args | grep -iE "/app/bin/showtime|movian|flatpak run" | grep -v grep || true'
+
+ssh -i ~/.ssh/movian_deck deck@<deck-ip> \
+  'ss -ltnp 2>/dev/null | grep -E ":(42000|1445|445)" || true'
+```
+
+When the Deck sleeps, the whole host can disappear from the network. Distinguish
+that from an app crash by checking ping, SSH, and HTTP together.
+
+## SMB2 Server Remote Smoke
+
+For the SMB2 server MVP, test these as separate claims:
+
+- Movian process is alive and HTTP responds.
+- The SMB2 server logs `SMB2-SERVER Listening on port <port>`.
+- TCP connects to that port.
+- A libsmb2 client can perform session setup and browse/read.
+- Read-only mutation attempts fail.
+- Runtime port changes through settings restart the server without crashing.
+- Windows native acceptance uses TCP `445`; non-445 ports are development-only
+  for Windows Explorer users.
+
+Use STPP for live settings changes. HTTP prop aliases such as `*0` are useful
+for inspection but are not STPP path segments. Open `settings:network`,
+subscribe to `navigators.current.currentpage.model.nodes`, find the row whose
+`metadata.title` is `Server TCP port`, and set that row's `value`.
+
+A successful port-change smoke includes:
+
+```text
+old TCP port refuses connections
+new TCP port accepts connections
+SMB2-SERVER Server loop exited ...
+SMB2-SERVER Listening on port <new-port>
+no CRASH / Signal lines in /api/logfile/0 or /api/logfile/1
+```
+
+If setting port `445` is accepted but no listener remains on `445`, classify the
+result as privileged-port packaging/forwarding work unless request-handler
+smokes also fail on a high port.
+
+Before leaving the Deck, restore the last known working development port and
+confirm it listens.
+
+## Windows-Side Check
+
+Native Windows SMB clients expect TCP `445`:
+
+```powershell
+Test-NetConnection <deck-ip> -Port 445
+cmd /c "net use \\<deck-ip>\<share> /user:<user> <password> /persistent:no"
+```
+
+Do not treat `\\host@port\share` or `\\host:port\share` as a reliable
+user-facing acceptance path.

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,7 @@ The Flatpak work is a local sideload package, not a Flathub recipe. The main
 guide is:
 
 - `Guides/FLATPAK_STEAMOS_GUIDE.md`
+- `Guides/STEAM_DECK_REMOTE_TESTING.md`
 
 The source-of-truth packaging files live under:
 

--- a/src/fileaccess/smb2/fa_libsmb2.c
+++ b/src/fileaccess/smb2/fa_libsmb2.c
@@ -584,12 +584,12 @@ movian_smb2_scan_host(fa_dir_t *fd, const char *url,
   }
 
   struct srvsvc_SHARE_INFO_1_CONTAINER *shares =
-    &state.reply->ses.ShareInfo.Level1;
-  if(shares->Buffer != NULL) {
+    &state.reply->ses.ShareEnum.Level1;
+  if(shares->share_info_1 != NULL) {
     for(uint32_t i = 0; i < shares->EntriesRead; i++) {
       struct srvsvc_SHARE_INFO_1 *share =
-        &shares->Buffer->share_info_1[i];
-      const char *name = share->netname.utf8;
+        &shares->share_info_1[i];
+      const char *name = share->netname;
       uint32_t share_type = share->type;
       int add = name != NULL &&
         (share_type & 3) == SHARE_TYPE_DISKTREE &&

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -9,6 +9,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -456,8 +457,10 @@ smb2srv_create(struct smb2_server *srvr, struct smb2_context *smb2,
   hts_mutex_lock(&smb2srv.mutex);
   root = smb2srv.share_root != NULL ? strdup(smb2srv.share_root) : NULL;
   hts_mutex_unlock(&smb2srv.mutex);
-  if(root == NULL)
+  if(root == NULL || root[0] == '\0') {
+    free(root);
     return smb2srv_queue_status(smb2, SMB2_CREATE, SMB2_STATUS_ACCESS_DENIED);
+  }
 
   url = smb2srv_map_path(root, req->name);
   free(root);
@@ -580,8 +583,11 @@ smb2srv_read(struct smb2_server *srvr, struct smb2_context *smb2,
   if(h == NULL || h->fh == NULL)
     return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_INVALID_HANDLE);
 
-  if(count == 0)
-    count = 1;
+  if(count == 0) {
+    memset(rep, 0, sizeof(*rep));
+    return 0;
+  }
+
   buf = malloc(count);
   if(buf == NULL)
     return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_NO_MEMORY);
@@ -622,7 +628,7 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
   smb2srv_handle_t *h;
   fa_dir_entry_t *fde, *selected = NULL;
   struct smb2_fileidbothdirectoryinformation *out;
-  size_t seen = 0, stride, bytes = 0;
+  size_t seen = 0, stride;
   char errbuf[512];
 
   hts_mutex_lock(&smb2srv.mutex);
@@ -684,10 +690,8 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
   }
 
   stride = (sizeof(*out) + 7) & ~7;
-  bytes = (sizeof(*out) +
-           smb2srv_name_utf16_len(rstr_get(selected->fde_filename)) + 7) & ~7;
   free(h->dir_info);
-  h->dir_info = calloc(1, bytes);
+  h->dir_info = calloc(1, stride);
   if(h->dir_info == NULL)
     return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
                                 SMB2_STATUS_NO_MEMORY);
@@ -721,10 +725,10 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
 
   h->dir_sent++;
   rep->output_buffer = (uint8_t *)out;
-  rep->output_buffer_length = bytes;
+  rep->output_buffer_length = stride;
   SMB2SRV_TRACE(TRACE_DEBUG,
-                "query-directory reply entries=1 bytes=%zu stride=%zu",
-                bytes, stride);
+                "query-directory reply entries=1 stride=%zu",
+                stride);
   return 0;
 }
 
@@ -836,8 +840,8 @@ smb2srv_query_info(struct smb2_server *srvr, struct smb2_context *smb2,
   TRACE(TRACE_ERROR, "SMB2-SERVER",
         "Unsupported query-info type=%u class=%u for %s",
         req->info_type, req->file_info_class, h->vfs_url);
-  rep->output_buffer_length = -1;
-  return 0;
+  return smb2srv_queue_status(smb2, SMB2_QUERY_INFO,
+                              SMB2_STATUS_INVALID_INFO_CLASS);
 }
 
 
@@ -1015,13 +1019,31 @@ smb2srv_sync_port_setting(int port)
 static void
 smb2srv_stop_locked(int restart)
 {
-  if(smb2srv.server.fd > 0) {
+  if(smb2srv.server.fd >= 0) {
+    int fd = smb2srv.server.fd;
+
     if(smb2srv.thread_running) {
+      int wake_fd = open("/dev/null", O_RDONLY);
+
       if(restart)
         smb2srv.restart_requested = 1;
-      shutdown(smb2srv.server.fd, SHUT_RDWR);
+
+      /*
+       * libsmb2 owns server.fd once smb2_serve_port() is running and closes
+       * that descriptor on exit. Close the real listener here so the TCP port
+       * stops accepting immediately, then hand libsmb2 a harmless readable fd
+       * so its select()/accept() loop wakes and exits without double-closing a
+       * descriptor that the process may have already reused.
+       */
+      if(wake_fd >= 0) {
+        smb2srv.server.fd = wake_fd;
+        shutdown(fd, SHUT_RDWR);
+        close(fd);
+      } else {
+        shutdown(fd, SHUT_RDWR);
+      }
     } else {
-      close(smb2srv.server.fd);
+      close(fd);
       smb2srv.server.fd = -1;
     }
   }
@@ -1054,8 +1076,9 @@ smb2srv_enable_disable(void)
       smb2srv_trace_port_unavailable(smb2srv.port);
     }
   } else if(smb2srv.enabled && !smb2srv_config_ready_locked()) {
+    smb2srv_stop_locked(0);
     SMB2SRV_TRACE(TRACE_DEBUG,
-                  "not starting: username, password, share and path are required");
+                  "not running: username, password, share and path are required");
   }
   hts_mutex_unlock(&smb2srv.mutex);
 

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -934,7 +934,12 @@ static void
 smb2srv_client_connected(struct smb2_context *smb2, void *cb_data)
 {
   SMB2SRV_TRACE(TRACE_DEBUG, "client connected");
-  smb2_set_version(smb2, SMB2_VERSION_ANY);
+  /*
+   * The embedded read-only server only needs SMB 2.0.2 for the MVP.
+   * Newer libsmb2 negotiates signing for authenticated SMB 3.1.1 sessions,
+   * and the server-side signing path is not ready for Movian yet.
+   */
+  smb2_set_version(smb2, SMB2_VERSION_0202);
 }
 
 

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -37,6 +37,8 @@
     TRACE((level), "SMB2-SERVER", fmt, ##__VA_ARGS__);              \
 } while(0)
 
+extern fa_protocol_t fa_protocol_vfs;
+
 typedef struct smb2srv_handle {
   LIST_ENTRY(smb2srv_handle) link;
   smb2_file_id file_id;
@@ -323,6 +325,32 @@ smb2srv_request_share_name(const char *path)
   if(slash != NULL)
     name = slash + 1;
   return name;
+}
+
+
+static fa_dir_t *
+smb2srv_scandir(const char *url, char *errbuf, size_t errlen)
+{
+  const char *vfs_path;
+  fa_dir_t *fd;
+
+  if(strncmp(url, "vfs:", 4))
+    return fa_scandir(url, errbuf, errlen);
+
+  if(!strncmp(url, "vfs://", 6))
+    vfs_path = url + 6;
+  else
+    vfs_path = url + 4;
+  if(vfs_path[0] == '\0')
+    vfs_path = "/";
+
+  fd = fa_dir_alloc();
+  if(fa_protocol_vfs.fap_scan(&fa_protocol_vfs, fd, vfs_path,
+                              errbuf, errlen, FA_NON_INTERACTIVE)) {
+    fa_dir_free(fd);
+    return NULL;
+  }
+  return fd;
 }
 
 
@@ -677,7 +705,7 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
                 h->dir_pattern != NULL ? h->dir_pattern : "*", h->vfs_url);
 
   if(h->dir == NULL) {
-    h->dir = fa_scandir(h->vfs_url, errbuf, sizeof(errbuf));
+    h->dir = smb2srv_scandir(h->vfs_url, errbuf, sizeof(errbuf));
     if(h->dir == NULL) {
       SMB2SRV_TRACE(TRACE_ERROR, "scan failed for %s: %s", h->vfs_url, errbuf);
       return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
@@ -694,8 +722,9 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
     break;
   }
   if(selected == NULL) {
-    return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
-                                SMB2_STATUS_NO_MORE_FILES);
+    rep->output_buffer = NULL;
+    rep->output_buffer_length = 0;
+    return 0;
   }
 
   stride = (sizeof(*out) + 7) & ~7;

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -64,6 +64,7 @@ typedef struct smb2srv_state {
   setting_t *port_setting;
   int enabled;
   int thread_running;
+  int stop_requested;
   int restart_requested;
   int reverting_port_setting;
   int port;
@@ -384,8 +385,15 @@ smb2srv_tree_connect(struct smb2_server *srvr, struct smb2_context *smb2,
 {
   char *path = req != NULL && req->path != NULL && req->path_length > 0 ?
     (char *)smb2_utf16_to_utf8(req->path, req->path_length / 2) : NULL;
-  const char *name = smb2srv_request_share_name(path);
+  const char *name;
   int ok;
+
+  if(path == NULL) {
+    SMB2SRV_TRACE(TRACE_ERROR, "tree-connect missing path");
+    return -1;
+  }
+
+  name = smb2srv_request_share_name(path);
 
   hts_mutex_lock(&smb2srv.mutex);
   ok = smb2srv.share_name != NULL && !strcmp(name, smb2srv.share_name);
@@ -600,7 +608,7 @@ smb2srv_read(struct smb2_server *srvr, struct smb2_context *smb2,
   }
 
   r = fa_read(h->fh, buf, count);
-  if(r < 0) {
+  if(r <= 0 || (req->minimum_count != 0 && r < req->minimum_count)) {
     free(buf);
     return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_END_OF_FILE);
   }
@@ -703,9 +711,12 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
     struct fa_stat *st = &selected->fde_stat;
     const char *name = rstr_get(selected->fde_filename);
     uint32_t name_len = smb2srv_name_utf16_len(name);
+    int type = selected->fde_type;
 
     if(!selected->fde_statdone && fa_dir_entry_stat(selected))
       memset(st, 0, sizeof(*st));
+    if(selected->fde_statdone)
+      type = st->fs_type;
 
     di->file_index = h->dir_sent;
     smb2srv_fill_time(&di->creation_time, st->fs_mtime);
@@ -714,14 +725,14 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
     smb2srv_fill_time(&di->change_time, st->fs_mtime);
     di->end_of_file = st->fs_size > 0 ? st->fs_size : 0;
     di->allocation_size = di->end_of_file;
-    di->file_attributes = smb2srv_attrs_from_type(st->fs_type);
+    di->file_attributes = smb2srv_attrs_from_type(type);
     di->file_name_length = name_len;
     di->short_name_length = name_len < sizeof(di->short_name) ?
       name_len : sizeof(di->short_name);
     di->name = name;
     SMB2SRV_TRACE(TRACE_DEBUG,
                   "dir-entry name=%s type=%d size=%"PRId64" name_len=%u",
-                  name, st->fs_type, di->end_of_file, name_len);
+                  name, type, di->end_of_file, name_len);
   }
 
   h->dir_sent++;
@@ -935,7 +946,9 @@ smb2srv_thread(void *aux)
 
   hts_mutex_lock(&smb2srv.mutex);
   smb2srv.thread_running = 1;
+  smb2srv.stop_requested = 0;
   memset(&smb2srv.server, 0, sizeof(smb2srv.server));
+  smb2srv.server.fd = -1;
   smb2srv.server.handlers = &smb2srv_handlers;
   smb2srv.server.signing_enabled = 1;
   smb2srv.server.allow_anonymous = 0;
@@ -943,6 +956,20 @@ smb2srv_thread(void *aux)
   snprintf(smb2srv.server.hostname, sizeof(smb2srv.server.hostname),
            "%s", gconf.system_name[0] != '\0' ? gconf.system_name : "Movian");
   snprintf(smb2srv.server.domain, sizeof(smb2srv.server.domain), "WORKGROUP");
+  if(smb2srv.stop_requested || !smb2srv.enabled ||
+     !smb2srv_config_ready_locked()) {
+    if(smb2srv.restart_requested) {
+      smb2srv.restart_requested = 0;
+      restart = smb2srv.enabled && smb2srv_config_ready_locked();
+    }
+    smb2srv.stop_requested = 0;
+    smb2srv.thread_running = 0;
+    hts_mutex_unlock(&smb2srv.mutex);
+    if(restart)
+      hts_thread_create_detached("SMB2-server", smb2srv_thread, NULL,
+                                 THREAD_PRIO_BGTASK);
+    return NULL;
+  }
   hts_mutex_unlock(&smb2srv.mutex);
 
   TRACE(TRACE_INFO, "SMB2-SERVER", "Listening on port %d",
@@ -954,6 +981,7 @@ smb2srv_thread(void *aux)
 
   hts_mutex_lock(&smb2srv.mutex);
   smb2srv.thread_running = 0;
+  smb2srv.stop_requested = 0;
   smb2srv.server.fd = -1;
   if(smb2srv.restart_requested) {
     smb2srv.restart_requested = 0;
@@ -1032,33 +1060,37 @@ smb2srv_sync_port_setting(int port)
 static void
 smb2srv_stop_locked(int restart)
 {
-  if(smb2srv.server.fd >= 0) {
-    int fd = smb2srv.server.fd;
+  int fd = smb2srv.server.fd;
 
-    if(smb2srv.thread_running) {
-      int wake_fd = open("/dev/null", O_RDONLY);
+  if(smb2srv.thread_running) {
+    int wake_fd;
 
-      if(restart)
-        smb2srv.restart_requested = 1;
+    smb2srv.stop_requested = 1;
+    if(restart)
+      smb2srv.restart_requested = 1;
 
-      /*
-       * libsmb2 owns server.fd once smb2_serve_port() is running and closes
-       * that descriptor on exit. Close the real listener here so the TCP port
-       * stops accepting immediately, then hand libsmb2 a harmless readable fd
-       * so its select()/accept() loop wakes and exits without double-closing a
-       * descriptor that the process may have already reused.
-       */
-      if(wake_fd >= 0) {
-        smb2srv.server.fd = wake_fd;
-        shutdown(fd, SHUT_RDWR);
-        close(fd);
-      } else {
-        shutdown(fd, SHUT_RDWR);
-      }
-    } else {
+    if(fd < 0)
+      return;
+
+    wake_fd = open("/dev/null", O_RDONLY);
+
+    /*
+     * libsmb2 owns server.fd once smb2_serve_port() is running and closes
+     * that descriptor on exit. Close the real listener here so the TCP port
+     * stops accepting immediately, then hand libsmb2 a harmless readable fd
+     * so its select()/accept() loop wakes and exits without double-closing a
+     * descriptor that the process may have already reused.
+     */
+    if(wake_fd >= 0) {
+      smb2srv.server.fd = wake_fd;
+      shutdown(fd, SHUT_RDWR);
       close(fd);
-      smb2srv.server.fd = -1;
+    } else {
+      shutdown(fd, SHUT_RDWR);
     }
+  } else if(fd >= 0) {
+    close(fd);
+    smb2srv.server.fd = -1;
   }
 }
 

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -7,6 +7,7 @@
  *  (at your option) any later version.
  */
 
+#include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
@@ -43,6 +44,7 @@ typedef struct smb2srv_handle {
   fa_handle_t *fh;
   fa_dir_t *dir;
   uint8_t *dir_info;
+  char *dir_pattern;
   int dir_sent;
   int is_dir;
   int64_t size;
@@ -137,8 +139,24 @@ smb2srv_handle_close(smb2srv_handle_t *h)
   if(h->dir != NULL)
     fa_dir_free(h->dir);
   free(h->dir_info);
+  free(h->dir_pattern);
   free(h->vfs_url);
   free(h);
+}
+
+
+static void
+smb2srv_handles_close_for_context_locked(struct smb2_context *smb2)
+{
+  smb2srv_handle_t *h, *next;
+
+  for(h = LIST_FIRST(&smb2srv.handles); h != NULL; h = next) {
+    next = LIST_NEXT(h, link);
+    if(h->smb2 != smb2)
+      continue;
+    LIST_REMOVE(h, link);
+    smb2srv_handle_close(h);
+  }
 }
 
 
@@ -172,6 +190,45 @@ smb2srv_handle_make_id_locked(smb2srv_handle_t *h)
 
   memset(h->file_id, 0, sizeof(h->file_id));
   memcpy(h->file_id, &id, sizeof(id));
+}
+
+
+static int
+smb2srv_pattern_match(const char *pattern, const char *name)
+{
+  if(name == NULL)
+    name = "";
+
+  if(pattern == NULL || pattern[0] == '\0' ||
+     (pattern[0] == '*' && pattern[1] == '\0') ||
+     !strcmp(pattern, "*.*"))
+    return 1;
+
+  while(*pattern != '\0') {
+    if(*pattern == '*') {
+      while(*pattern == '*')
+        pattern++;
+      if(*pattern == '\0')
+        return 1;
+      while(*name != '\0') {
+        if(smb2srv_pattern_match(pattern, name))
+          return 1;
+        name++;
+      }
+      return 0;
+    }
+
+    if(*name == '\0')
+      return 0;
+
+    if(*pattern != '?' &&
+       tolower((unsigned char)*pattern) != tolower((unsigned char)*name))
+      return 0;
+
+    pattern++;
+    name++;
+  }
+  return *name == '\0';
 }
 
 
@@ -267,6 +324,17 @@ smb2srv_request_share_name(const char *path)
 
 
 static int
+smb2srv_destruction_event(struct smb2_server *srvr, struct smb2_context *smb2)
+{
+  SMB2SRV_TRACE(TRACE_DEBUG, "session destroyed");
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv_handles_close_for_context_locked(smb2);
+  hts_mutex_unlock(&smb2srv.mutex);
+  return 0;
+}
+
+
+static int
 smb2srv_authorize(struct smb2_server *srvr, struct smb2_context *smb2,
                   const char *user, const char *domain, const char *workstation)
 {
@@ -349,6 +417,9 @@ smb2srv_tree_disconnect(struct smb2_server *srvr, struct smb2_context *smb2,
                         const uint32_t tree_id)
 {
   SMB2SRV_TRACE(TRACE_DEBUG, "tree disconnect 0x%x", tree_id);
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv_handles_close_for_context_locked(smb2);
+  hts_mutex_unlock(&smb2srv.mutex);
   return 0;
 }
 
@@ -562,12 +633,33 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
     return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
                                 SMB2_STATUS_INVALID_HANDLE);
 
+  if(req->file_information_class != SMB2_FILE_ID_FULL_DIRECTORY_INFORMATION &&
+     req->file_information_class != SMB2_FILE_ID_BOTH_DIRECTORY_INFORMATION) {
+    SMB2SRV_TRACE(TRACE_DEBUG, "unsupported query-directory class=%u",
+                  req->file_information_class);
+    return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
+                                SMB2_STATUS_INVALID_INFO_CLASS);
+  }
+
   if(req->flags & SMB2_RESTART_SCANS)
     h->dir_sent = 0;
+
+  if(req->name != NULL && req->name[0] != '\0') {
+    if(h->dir_pattern == NULL || strcmp(h->dir_pattern, req->name)) {
+      char *pattern = strdup(req->name);
+      if(pattern == NULL)
+        return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
+                                    SMB2_STATUS_NO_MEMORY);
+      free(h->dir_pattern);
+      h->dir_pattern = pattern;
+      h->dir_sent = 0;
+    }
+  }
+
   SMB2SRV_TRACE(TRACE_DEBUG,
-                "query-directory class=%u flags=0x%x sent=%d path=%s",
+                "query-directory class=%u flags=0x%x sent=%d pattern=%s path=%s",
                 req->file_information_class, req->flags, h->dir_sent,
-                h->vfs_url);
+                h->dir_pattern != NULL ? h->dir_pattern : "*", h->vfs_url);
 
   if(h->dir == NULL) {
     h->dir = fa_scandir(h->vfs_url, errbuf, sizeof(errbuf));
@@ -579,6 +671,8 @@ smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
   }
 
   RB_FOREACH(fde, &h->dir->fd_entries, fde_link) {
+    if(!smb2srv_pattern_match(h->dir_pattern, rstr_get(fde->fde_filename)))
+      continue;
     if(seen++ < (size_t)h->dir_sent)
       continue;
     selected = fde;
@@ -784,7 +878,7 @@ smb2srv_echo(struct smb2_server *srvr, struct smb2_context *smb2)
 
 
 static struct smb2_server_request_handlers smb2srv_handlers = {
-  NULL,
+  smb2srv_destruction_event,
   smb2srv_authorize,
   smb2srv_session_established,
   smb2srv_logoff,

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -1,0 +1,1024 @@
+/*
+ *  Copyright (C) 2026 Movian contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <smb2/smb2.h>
+#include <smb2/libsmb2.h>
+#include <smb2/libsmb2-raw.h>
+
+#include "main.h"
+#include "arch/threads.h"
+#include "asyncio.h"
+#include "settings.h"
+#include "fileaccess/fileaccess.h"
+#include "fileaccess/fa_proto.h"
+#include "smb2_server.h"
+
+#define SMB2SRV_DEFAULT_PORT 1445
+#define SMB2SRV_MAX_CONNECTIONS 8
+
+#define SMB2SRV_TRACE(level, fmt, ...) do {                         \
+  if(gconf.enable_smb_debug)                                        \
+    TRACE((level), "SMB2-SERVER", fmt, ##__VA_ARGS__);              \
+} while(0)
+
+typedef struct smb2srv_handle {
+  LIST_ENTRY(smb2srv_handle) link;
+  smb2_file_id file_id;
+  struct smb2_context *smb2;
+  char *vfs_url;
+  fa_handle_t *fh;
+  fa_dir_t *dir;
+  uint8_t *dir_info;
+  int dir_sent;
+  int is_dir;
+  int64_t size;
+  time_t mtime;
+  struct smb2_file_basic_info basic_info;
+  struct smb2_file_standard_info standard_info;
+  struct smb2_file_all_info all_info;
+  struct smb2_file_network_open_info network_open_info;
+  struct smb2_file_fs_size_info fs_size_info;
+} smb2srv_handle_t;
+
+typedef struct smb2srv_state {
+  hts_mutex_t mutex;
+  struct smb2_server server;
+  int enabled;
+  int thread_running;
+  int port;
+  uint64_t next_file_id;
+  char *username;
+  char *password;
+  char *share_name;
+  char *share_root;
+  LIST_HEAD(, smb2srv_handle) handles;
+} smb2srv_state_t;
+
+static smb2srv_state_t smb2srv;
+
+
+static int smb2srv_config_ready_locked(void);
+
+
+static int
+smb2srv_queue_status(struct smb2_context *smb2, uint16_t command,
+                     uint32_t status)
+{
+  struct smb2_error_reply err;
+  struct smb2_pdu *pdu;
+
+  memset(&err, 0, sizeof(err));
+  pdu = smb2_cmd_error_reply_async(smb2, &err, command, status, NULL, NULL);
+  if(pdu == NULL)
+    return -1;
+  smb2_queue_pdu(smb2, pdu);
+  return 1;
+}
+
+
+static uint32_t
+smb2srv_attrs_from_type(int type)
+{
+  if(type == CONTENT_DIR || type == CONTENT_SHARE)
+    return SMB2_FILE_ATTRIBUTE_DIRECTORY;
+  return SMB2_FILE_ATTRIBUTE_NORMAL;
+}
+
+
+static void
+smb2srv_fill_time(struct smb2_timeval *tv, time_t t)
+{
+  tv->tv_sec = t > 0 ? t : 1;
+  tv->tv_usec = 0;
+}
+
+
+static uint32_t
+smb2srv_name_utf16_len(const char *name)
+{
+  struct smb2_utf16 *utf16;
+  uint32_t len;
+
+  if(name == NULL || name[0] == '\0')
+    return 0;
+
+  utf16 = smb2_utf8_to_utf16(name);
+  if(utf16 == NULL)
+    return 0;
+
+  len = 2 * utf16->len;
+  free(utf16);
+  return len;
+}
+
+
+static void
+smb2srv_handle_close(smb2srv_handle_t *h)
+{
+  if(h->fh != NULL)
+    fa_close(h->fh);
+  if(h->dir != NULL)
+    fa_dir_free(h->dir);
+  free(h->dir_info);
+  free(h->vfs_url);
+  free(h);
+}
+
+
+static smb2srv_handle_t *
+smb2srv_handle_find_locked(struct smb2_context *smb2, const smb2_file_id file_id)
+{
+  smb2srv_handle_t *h;
+  int compound = 1;
+
+  for(size_t i = 0; i < SMB2_FD_SIZE; i++) {
+    if(file_id[i] != 0xff) {
+      compound = 0;
+      break;
+    }
+  }
+
+  LIST_FOREACH(h, &smb2srv.handles, link) {
+    if(compound && h->smb2 == smb2)
+      return h;
+    if(!memcmp(h->file_id, file_id, SMB2_FD_SIZE))
+      return h;
+  }
+  return NULL;
+}
+
+
+static void
+smb2srv_handle_make_id_locked(smb2srv_handle_t *h)
+{
+  uint64_t id = ++smb2srv.next_file_id;
+
+  memset(h->file_id, 0, sizeof(h->file_id));
+  memcpy(h->file_id, &id, sizeof(id));
+}
+
+
+static int
+smb2srv_bad_segment(const char *start, size_t len)
+{
+  return len == 0 ||
+         (len == 1 && start[0] == '.') ||
+         (len == 2 && start[0] == '.' && start[1] == '.');
+}
+
+
+static char *
+smb2srv_map_path(const char *root, const char *smb_path)
+{
+  const char *p = smb_path != NULL ? smb_path : "";
+  char *clean, *out;
+  size_t root_len, clean_len, i, j = 0;
+  size_t seg_start = 0;
+  int in_segment = 0;
+
+  while(*p == '\\' || *p == '/')
+    p++;
+
+  clean = malloc(strlen(p) + 1);
+  if(clean == NULL)
+    return NULL;
+
+  for(i = 0; p[i] != '\0'; i++) {
+    char c = p[i] == '\\' ? '/' : p[i];
+
+    if(c == '/') {
+      if(in_segment && smb2srv_bad_segment(clean + seg_start,
+                                           j - seg_start)) {
+        free(clean);
+        return NULL;
+      }
+      in_segment = 0;
+      if(j > 0 && clean[j - 1] != '/')
+        clean[j++] = '/';
+      continue;
+    }
+
+    if(!in_segment) {
+      seg_start = j;
+      in_segment = 1;
+    }
+    clean[j++] = c;
+  }
+
+  if(in_segment && smb2srv_bad_segment(clean + seg_start, j - seg_start)) {
+    free(clean);
+    return NULL;
+  }
+  if(j > 0 && clean[j - 1] == '/')
+    j--;
+  clean[j] = '\0';
+
+  clean_len = strlen(clean);
+  if(clean_len == 0) {
+    out = strdup(root);
+    free(clean);
+    return out;
+  }
+
+  root_len = strlen(root);
+  out = malloc(root_len + clean_len + 2);
+  if(out != NULL)
+    snprintf(out, root_len + clean_len + 2, "%s%s%s", root,
+             root_len > 0 && root[root_len - 1] == '/' ? "" : "/",
+             clean);
+  free(clean);
+  return out;
+}
+
+
+static const char *
+smb2srv_request_share_name(const char *path)
+{
+  const char *name = path;
+  const char *slash;
+
+  if(name == NULL)
+    return "";
+  slash = strrchr(name, '\\');
+  if(slash != NULL)
+    name = slash + 1;
+  slash = strrchr(name, '/');
+  if(slash != NULL)
+    name = slash + 1;
+  return name;
+}
+
+
+static int
+smb2srv_authorize(struct smb2_server *srvr, struct smb2_context *smb2,
+                  const char *user, const char *domain, const char *workstation)
+{
+  int ok;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  ok = smb2srv.username != NULL && smb2srv.password != NULL &&
+       smb2srv.username[0] != '\0' && smb2srv.password[0] != '\0' &&
+       user != NULL && !strcmp(user, smb2srv.username);
+  if(ok)
+    smb2_set_password(smb2, smb2srv.password);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  SMB2SRV_TRACE(ok ? TRACE_DEBUG : TRACE_ERROR,
+                "auth user=%s domain=%s workstation=%s status=%s",
+                user != NULL ? user : "<unset>",
+                domain != NULL ? domain : "<unset>",
+                workstation != NULL ? workstation : "<unset>",
+                ok ? "ok" : "denied");
+  return ok ? 0 : -1;
+}
+
+
+static int
+smb2srv_session_established(struct smb2_server *srvr, struct smb2_context *smb2)
+{
+  SMB2SRV_TRACE(TRACE_DEBUG, "session established dialect=%04x",
+                smb2_get_dialect(smb2));
+  return 0;
+}
+
+
+static int
+smb2srv_logoff(struct smb2_server *srvr, struct smb2_context *smb2)
+{
+  SMB2SRV_TRACE(TRACE_DEBUG, "session logoff");
+  return 0;
+}
+
+
+static int
+smb2srv_tree_connect(struct smb2_server *srvr, struct smb2_context *smb2,
+                     struct smb2_tree_connect_request *req,
+                     struct smb2_tree_connect_reply *rep)
+{
+  char *path = req != NULL && req->path != NULL && req->path_length > 0 ?
+    (char *)smb2_utf16_to_utf8(req->path, req->path_length / 2) : NULL;
+  const char *name = smb2srv_request_share_name(path);
+  int ok;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  ok = smb2srv.share_name != NULL && !strcmp(name, smb2srv.share_name);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  SMB2SRV_TRACE(TRACE_DEBUG, "tree-connect path=%s share=%s status=%s",
+                path != NULL ? path : "<unset>", name,
+                ok ? "ok" : "denied");
+
+  if(!ok) {
+    SMB2SRV_TRACE(TRACE_ERROR, "unknown share '%s'", name);
+    free(path);
+    return smb2srv_queue_status(smb2, SMB2_TREE_CONNECT,
+                                SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+  }
+  free(path);
+
+  memset(rep, 0, sizeof(*rep));
+  rep->share_type = SMB2_SHARE_TYPE_DISK;
+  rep->share_flags = SMB2_SHAREFLAG_ACCESS_BASED_DIRECTORY_ENUM;
+  rep->capabilities = 0;
+  rep->maximal_access = SMB2_GENERIC_READ | SMB2_FILE_READ_DATA |
+    SMB2_FILE_LIST_DIRECTORY | SMB2_FILE_READ_EA | SMB2_FILE_READ_ATTRIBUTES |
+    SMB2_READ_CONTROL | SMB2_SYNCHRONIZE;
+  return 0;
+}
+
+
+static int
+smb2srv_tree_disconnect(struct smb2_server *srvr, struct smb2_context *smb2,
+                        const uint32_t tree_id)
+{
+  SMB2SRV_TRACE(TRACE_DEBUG, "tree disconnect 0x%x", tree_id);
+  return 0;
+}
+
+
+static int
+smb2srv_create(struct smb2_server *srvr, struct smb2_context *smb2,
+               struct smb2_create_request *req, struct smb2_create_reply *rep)
+{
+  smb2srv_handle_t *h;
+  struct fa_stat fs;
+  char errbuf[512];
+  char *root;
+  char *url;
+  int want_dir;
+
+  SMB2SRV_TRACE(TRACE_DEBUG,
+                "create name=%s access=0x%x disposition=0x%x options=0x%x",
+                req->name != NULL ? req->name : "",
+                req->desired_access, req->create_disposition,
+                req->create_options);
+
+  if(req->desired_access & (SMB2_FILE_WRITE_DATA | SMB2_FILE_APPEND_DATA |
+                            SMB2_FILE_WRITE_EA | SMB2_FILE_WRITE_ATTRIBUTES |
+                            SMB2_DELETE | SMB2_GENERIC_WRITE |
+                            SMB2_GENERIC_ALL)) {
+    return smb2srv_queue_status(smb2, SMB2_CREATE, SMB2_STATUS_ACCESS_DENIED);
+  }
+
+  if(req->create_disposition != SMB2_FILE_OPEN &&
+     req->create_disposition != SMB2_FILE_OPEN_IF) {
+    return smb2srv_queue_status(smb2, SMB2_CREATE, SMB2_STATUS_ACCESS_DENIED);
+  }
+
+  hts_mutex_lock(&smb2srv.mutex);
+  root = smb2srv.share_root != NULL ? strdup(smb2srv.share_root) : NULL;
+  hts_mutex_unlock(&smb2srv.mutex);
+  if(root == NULL)
+    return smb2srv_queue_status(smb2, SMB2_CREATE, SMB2_STATUS_ACCESS_DENIED);
+
+  url = smb2srv_map_path(root, req->name);
+  free(root);
+  if(url == NULL)
+    return smb2srv_queue_status(smb2, SMB2_CREATE,
+                                SMB2_STATUS_OBJECT_PATH_SYNTAX_BAD);
+
+  memset(&fs, 0, sizeof(fs));
+  if(fa_stat_ex(url, &fs, errbuf, sizeof(errbuf), FA_NON_INTERACTIVE)) {
+    SMB2SRV_TRACE(TRACE_ERROR, "stat failed for %s: %s", url, errbuf);
+    free(url);
+    return smb2srv_queue_status(smb2, SMB2_CREATE,
+                                SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+  }
+
+  want_dir = (req->create_options & SMB2_FILE_DIRECTORY_FILE) != 0;
+  if(want_dir && fs.fs_type != CONTENT_DIR && fs.fs_type != CONTENT_SHARE) {
+    free(url);
+    return smb2srv_queue_status(smb2, SMB2_CREATE,
+                                SMB2_STATUS_NOT_A_DIRECTORY);
+  }
+  if((req->create_options & SMB2_FILE_NON_DIRECTORY_FILE) &&
+     (fs.fs_type == CONTENT_DIR || fs.fs_type == CONTENT_SHARE)) {
+    free(url);
+    return smb2srv_queue_status(smb2, SMB2_CREATE,
+                                SMB2_STATUS_FILE_IS_A_DIRECTORY);
+  }
+
+  h = calloc(1, sizeof(*h));
+  if(h == NULL) {
+    free(url);
+    return smb2srv_queue_status(smb2, SMB2_CREATE, SMB2_STATUS_NO_MEMORY);
+  }
+  h->vfs_url = url;
+  h->smb2 = smb2;
+  h->is_dir = fs.fs_type == CONTENT_DIR || fs.fs_type == CONTENT_SHARE;
+  h->size = fs.fs_size > 0 ? fs.fs_size : 0;
+  h->mtime = fs.fs_mtime;
+
+  if(!h->is_dir) {
+    h->fh = fa_open_ex(url, errbuf, sizeof(errbuf), FA_NON_INTERACTIVE, NULL);
+    if(h->fh == NULL) {
+      SMB2SRV_TRACE(TRACE_ERROR, "open failed for %s: %s", url, errbuf);
+      smb2srv_handle_close(h);
+      return smb2srv_queue_status(smb2, SMB2_CREATE,
+                                  SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+    }
+  }
+
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv_handle_make_id_locked(h);
+  LIST_INSERT_HEAD(&smb2srv.handles, h, link);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  memset(rep, 0, sizeof(*rep));
+  rep->oplock_level = SMB2_OPLOCK_LEVEL_NONE;
+  rep->creation_time = smb2_timeval_to_win(&(struct smb2_timeval){h->mtime, 0});
+  rep->last_access_time = rep->creation_time;
+  rep->last_write_time = rep->creation_time;
+  rep->change_time = rep->creation_time;
+  rep->end_of_file = h->size;
+  rep->allocation_size = h->size;
+  rep->file_attributes = smb2srv_attrs_from_type(fs.fs_type);
+  memcpy(rep->file_id, h->file_id, SMB2_FD_SIZE);
+  return 0;
+}
+
+
+static int
+smb2srv_close(struct smb2_server *srvr, struct smb2_context *smb2,
+              struct smb2_close_request *req, struct smb2_close_reply *rep)
+{
+  smb2srv_handle_t *h;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  h = smb2srv_handle_find_locked(smb2, req->file_id);
+  if(h != NULL)
+    LIST_REMOVE(h, link);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  if(h == NULL)
+    return smb2srv_queue_status(smb2, SMB2_CLOSE, SMB2_STATUS_INVALID_HANDLE);
+
+  memset(rep, 0, sizeof(*rep));
+  rep->end_of_file = h->size;
+  rep->allocation_size = h->size;
+  rep->creation_time = smb2_timeval_to_win(&(struct smb2_timeval){h->mtime, 0});
+  rep->last_access_time = rep->creation_time;
+  rep->last_write_time = rep->creation_time;
+  rep->change_time = rep->creation_time;
+  rep->file_attributes = h->is_dir ? SMB2_FILE_ATTRIBUTE_DIRECTORY :
+    SMB2_FILE_ATTRIBUTE_NORMAL;
+  smb2srv_handle_close(h);
+  return 0;
+}
+
+
+static int
+smb2srv_flush(struct smb2_server *srvr, struct smb2_context *smb2,
+              struct smb2_flush_request *req)
+{
+  return 0;
+}
+
+
+static int
+smb2srv_read(struct smb2_server *srvr, struct smb2_context *smb2,
+             struct smb2_read_request *req, struct smb2_read_reply *rep)
+{
+  smb2srv_handle_t *h;
+  uint32_t count = req->length;
+  uint8_t *buf;
+  int64_t pos;
+  int r;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  h = smb2srv_handle_find_locked(smb2, req->file_id);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  if(h == NULL || h->fh == NULL)
+    return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_INVALID_HANDLE);
+
+  if(count == 0)
+    count = 1;
+  buf = malloc(count);
+  if(buf == NULL)
+    return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_NO_MEMORY);
+
+  pos = fa_seek(h->fh, req->offset, SEEK_SET);
+  if(pos < 0) {
+    free(buf);
+    return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_INVALID_PARAMETER);
+  }
+
+  r = fa_read(h->fh, buf, count);
+  if(r < 0) {
+    free(buf);
+    return smb2srv_queue_status(smb2, SMB2_READ, SMB2_STATUS_END_OF_FILE);
+  }
+
+  memset(rep, 0, sizeof(*rep));
+  rep->data_length = r;
+  rep->data_remaining = 0;
+  rep->data = buf;
+  return 0;
+}
+
+
+static int
+smb2srv_write(struct smb2_server *srvr, struct smb2_context *smb2,
+              struct smb2_write_request *req, struct smb2_write_reply *rep)
+{
+  return smb2srv_queue_status(smb2, SMB2_WRITE, SMB2_STATUS_ACCESS_DENIED);
+}
+
+
+static int
+smb2srv_query_directory(struct smb2_server *srvr, struct smb2_context *smb2,
+                        struct smb2_query_directory_request *req,
+                        struct smb2_query_directory_reply *rep)
+{
+  smb2srv_handle_t *h;
+  fa_dir_entry_t *fde, *selected = NULL;
+  struct smb2_fileidbothdirectoryinformation *out;
+  size_t seen = 0, stride, bytes = 0;
+  char errbuf[512];
+
+  hts_mutex_lock(&smb2srv.mutex);
+  h = smb2srv_handle_find_locked(smb2, req->file_id);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  if(h == NULL || !h->is_dir)
+    return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
+                                SMB2_STATUS_INVALID_HANDLE);
+
+  if(req->flags & SMB2_RESTART_SCANS)
+    h->dir_sent = 0;
+  SMB2SRV_TRACE(TRACE_DEBUG,
+                "query-directory class=%u flags=0x%x sent=%d path=%s",
+                req->file_information_class, req->flags, h->dir_sent,
+                h->vfs_url);
+
+  if(h->dir == NULL) {
+    h->dir = fa_scandir(h->vfs_url, errbuf, sizeof(errbuf));
+    if(h->dir == NULL) {
+      SMB2SRV_TRACE(TRACE_ERROR, "scan failed for %s: %s", h->vfs_url, errbuf);
+      return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
+                                  SMB2_STATUS_OBJECT_NAME_NOT_FOUND);
+    }
+  }
+
+  RB_FOREACH(fde, &h->dir->fd_entries, fde_link) {
+    if(seen++ < (size_t)h->dir_sent)
+      continue;
+    selected = fde;
+    break;
+  }
+  if(selected == NULL) {
+    return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
+                                SMB2_STATUS_NO_MORE_FILES);
+  }
+
+  stride = (sizeof(*out) + 7) & ~7;
+  bytes = (sizeof(*out) +
+           smb2srv_name_utf16_len(rstr_get(selected->fde_filename)) + 7) & ~7;
+  free(h->dir_info);
+  h->dir_info = calloc(1, bytes);
+  if(h->dir_info == NULL)
+    return smb2srv_queue_status(smb2, SMB2_QUERY_DIRECTORY,
+                                SMB2_STATUS_NO_MEMORY);
+  out = (void *)h->dir_info;
+
+  {
+    struct smb2_fileidbothdirectoryinformation *di = out;
+    struct fa_stat *st = &selected->fde_stat;
+    const char *name = rstr_get(selected->fde_filename);
+    uint32_t name_len = smb2srv_name_utf16_len(name);
+
+    if(!selected->fde_statdone && fa_dir_entry_stat(selected))
+      memset(st, 0, sizeof(*st));
+
+    di->file_index = h->dir_sent;
+    smb2srv_fill_time(&di->creation_time, st->fs_mtime);
+    smb2srv_fill_time(&di->last_access_time, st->fs_mtime);
+    smb2srv_fill_time(&di->last_write_time, st->fs_mtime);
+    smb2srv_fill_time(&di->change_time, st->fs_mtime);
+    di->end_of_file = st->fs_size > 0 ? st->fs_size : 0;
+    di->allocation_size = di->end_of_file;
+    di->file_attributes = smb2srv_attrs_from_type(st->fs_type);
+    di->file_name_length = name_len;
+    di->short_name_length = name_len < sizeof(di->short_name) ?
+      name_len : sizeof(di->short_name);
+    di->name = name;
+    SMB2SRV_TRACE(TRACE_DEBUG,
+                  "dir-entry name=%s type=%d size=%"PRId64" name_len=%u",
+                  name, st->fs_type, di->end_of_file, name_len);
+  }
+
+  h->dir_sent++;
+  rep->output_buffer = (uint8_t *)out;
+  rep->output_buffer_length = bytes;
+  SMB2SRV_TRACE(TRACE_DEBUG,
+                "query-directory reply entries=1 bytes=%zu stride=%zu",
+                bytes, stride);
+  return 0;
+}
+
+
+static int
+smb2srv_query_info(struct smb2_server *srvr, struct smb2_context *smb2,
+                   struct smb2_query_info_request *req,
+                   struct smb2_query_info_reply *rep)
+{
+  smb2srv_handle_t *h;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  h = smb2srv_handle_find_locked(smb2, req->file_id);
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  if(h == NULL)
+    return smb2srv_queue_status(smb2, SMB2_QUERY_INFO,
+                                SMB2_STATUS_INVALID_HANDLE);
+
+  SMB2SRV_TRACE(TRACE_DEBUG, "query-info type=%u class=%u for %s",
+                req->info_type, req->file_info_class, h->vfs_url);
+
+  if(req->info_type == SMB2_0_INFO_FILE &&
+     req->file_info_class == SMB2_FILE_ALL_INFORMATION) {
+    struct smb2_file_all_info *info = &h->all_info;
+    memset(info, 0, sizeof(*info));
+    smb2srv_fill_time(&info->basic.creation_time, h->mtime);
+    smb2srv_fill_time(&info->basic.last_access_time, h->mtime);
+    smb2srv_fill_time(&info->basic.last_write_time, h->mtime);
+    smb2srv_fill_time(&info->basic.change_time, h->mtime);
+    info->basic.file_attributes = h->is_dir ? SMB2_FILE_ATTRIBUTE_DIRECTORY :
+      SMB2_FILE_ATTRIBUTE_NORMAL;
+    info->standard.allocation_size = h->size;
+    info->standard.end_of_file = h->size;
+    info->standard.number_of_links = 1;
+    info->standard.directory = h->is_dir ? 1 : 0;
+    info->access_flags = SMB2_FILE_READ_DATA | SMB2_FILE_READ_ATTRIBUTES;
+    if(h->is_dir)
+      info->access_flags |= SMB2_FILE_LIST_DIRECTORY;
+    rep->output_buffer = (uint8_t *)info;
+    rep->output_buffer_length = sizeof(*info);
+    return 0;
+  }
+
+  if(req->info_type == SMB2_0_INFO_FILE &&
+     req->file_info_class == SMB2_FILE_BASIC_INFORMATION) {
+    struct smb2_file_basic_info *info = &h->basic_info;
+    memset(info, 0, sizeof(*info));
+    smb2srv_fill_time(&info->creation_time, h->mtime);
+    smb2srv_fill_time(&info->last_access_time, h->mtime);
+    smb2srv_fill_time(&info->last_write_time, h->mtime);
+    smb2srv_fill_time(&info->change_time, h->mtime);
+    info->file_attributes = h->is_dir ? SMB2_FILE_ATTRIBUTE_DIRECTORY :
+      SMB2_FILE_ATTRIBUTE_NORMAL;
+    rep->output_buffer = (uint8_t *)info;
+    rep->output_buffer_length = sizeof(*info);
+    return 0;
+  }
+
+  if(req->info_type == SMB2_0_INFO_FILE &&
+     req->file_info_class == SMB2_FILE_STANDARD_INFORMATION) {
+    struct smb2_file_standard_info *info = &h->standard_info;
+    memset(info, 0, sizeof(*info));
+    info->allocation_size = h->size;
+    info->end_of_file = h->size;
+    info->number_of_links = 1;
+    info->directory = h->is_dir ? 1 : 0;
+    rep->output_buffer = (uint8_t *)info;
+    rep->output_buffer_length = sizeof(*info);
+    return 0;
+  }
+
+  if(req->info_type == SMB2_0_INFO_FILE &&
+     req->file_info_class == SMB2_FILE_NETWORK_OPEN_INFORMATION) {
+    struct smb2_file_network_open_info *info = &h->network_open_info;
+    memset(info, 0, sizeof(*info));
+    smb2srv_fill_time(&info->creation_time, h->mtime);
+    smb2srv_fill_time(&info->last_access_time, h->mtime);
+    smb2srv_fill_time(&info->last_write_time, h->mtime);
+    smb2srv_fill_time(&info->change_time, h->mtime);
+    info->allocation_size = h->size;
+    info->end_of_file = h->size;
+    info->file_attributes = h->is_dir ? SMB2_FILE_ATTRIBUTE_DIRECTORY :
+      SMB2_FILE_ATTRIBUTE_NORMAL;
+    rep->output_buffer = (uint8_t *)info;
+    rep->output_buffer_length = sizeof(*info);
+    return 0;
+  }
+
+  if(req->info_type == SMB2_0_INFO_FILESYSTEM &&
+     req->file_info_class == SMB2_FILE_FS_SIZE_INFORMATION) {
+    struct smb2_file_fs_size_info *info = &h->fs_size_info;
+    fa_fsinfo_t ffi;
+
+    memset(info, 0, sizeof(*info));
+    if(fa_fsinfo(h->vfs_url, &ffi)) {
+      ffi.ffi_size = 0;
+      ffi.ffi_avail = 0;
+    }
+    info->total_allocation_units = ffi.ffi_size / 512;
+    info->available_allocation_units = ffi.ffi_avail / 512;
+    info->sectors_per_allocation_unit = 1;
+    info->bytes_per_sector = 512;
+    rep->output_buffer = (uint8_t *)info;
+    rep->output_buffer_length = sizeof(*info);
+    return 0;
+  }
+
+  TRACE(TRACE_ERROR, "SMB2-SERVER",
+        "Unsupported query-info type=%u class=%u for %s",
+        req->info_type, req->file_info_class, h->vfs_url);
+  rep->output_buffer_length = -1;
+  return 0;
+}
+
+
+static int
+smb2srv_set_info(struct smb2_server *srvr, struct smb2_context *smb2,
+                 struct smb2_set_info_request *req)
+{
+  return smb2srv_queue_status(smb2, SMB2_SET_INFO, SMB2_STATUS_ACCESS_DENIED);
+}
+
+
+static int
+smb2srv_ioctl(struct smb2_server *srvr, struct smb2_context *smb2,
+              struct smb2_ioctl_request *req, struct smb2_ioctl_reply *rep)
+{
+  if(req->ctl_code != SMB2_FSCTL_VALIDATE_NEGOTIATE_INFO)
+    return smb2srv_queue_status(smb2, SMB2_IOCTL, SMB2_STATUS_NOT_SUPPORTED);
+
+  memset(rep, 0, sizeof(*rep));
+  rep->ctl_code = req->ctl_code;
+  memcpy(rep->file_id, req->file_id, SMB2_FD_SIZE);
+  return 0;
+}
+
+
+static int
+smb2srv_cancel(struct smb2_server *srvr, struct smb2_context *smb2)
+{
+  return 0;
+}
+
+
+static int
+smb2srv_echo(struct smb2_server *srvr, struct smb2_context *smb2)
+{
+  return 0;
+}
+
+
+static struct smb2_server_request_handlers smb2srv_handlers = {
+  NULL,
+  smb2srv_authorize,
+  smb2srv_session_established,
+  smb2srv_logoff,
+  smb2srv_tree_connect,
+  smb2srv_tree_disconnect,
+  smb2srv_create,
+  smb2srv_close,
+  smb2srv_flush,
+  smb2srv_read,
+  smb2srv_write,
+  NULL,
+  NULL,
+  NULL,
+  smb2srv_ioctl,
+  smb2srv_cancel,
+  smb2srv_echo,
+  smb2srv_query_directory,
+  NULL,
+  smb2srv_query_info,
+  smb2srv_set_info
+};
+
+
+static void
+smb2srv_client_connected(struct smb2_context *smb2, void *cb_data)
+{
+  SMB2SRV_TRACE(TRACE_DEBUG, "client connected");
+  smb2_set_version(smb2, SMB2_VERSION_ANY);
+}
+
+
+static void *
+smb2srv_thread(void *aux)
+{
+  int err;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv.thread_running = 1;
+  memset(&smb2srv.server, 0, sizeof(smb2srv.server));
+  smb2srv.server.handlers = &smb2srv_handlers;
+  smb2srv.server.signing_enabled = 1;
+  smb2srv.server.allow_anonymous = 0;
+  smb2srv.server.port = smb2srv.port;
+  snprintf(smb2srv.server.hostname, sizeof(smb2srv.server.hostname),
+           "%s", gconf.system_name[0] != '\0' ? gconf.system_name : "Movian");
+  snprintf(smb2srv.server.domain, sizeof(smb2srv.server.domain), "WORKGROUP");
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  TRACE(TRACE_INFO, "SMB2-SERVER", "Listening on port %d",
+        smb2srv.server.port);
+  err = smb2_serve_port(&smb2srv.server, SMB2SRV_MAX_CONNECTIONS,
+                        smb2srv_client_connected, NULL);
+  TRACE(err ? TRACE_ERROR : TRACE_INFO, "SMB2-SERVER",
+        "Server loop exited with %d", err);
+
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv.thread_running = 0;
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  return NULL;
+}
+
+
+static int
+smb2srv_config_ready_locked(void)
+{
+  return smb2srv.port > 0 &&
+    smb2srv.username != NULL && smb2srv.username[0] != '\0' &&
+    smb2srv.password != NULL && smb2srv.password[0] != '\0' &&
+    smb2srv.share_name != NULL && smb2srv.share_name[0] != '\0' &&
+    smb2srv.share_root != NULL && smb2srv.share_root[0] != '\0';
+}
+
+
+static void
+smb2srv_stop_locked(void)
+{
+  if(smb2srv.server.fd > 0) {
+    shutdown(smb2srv.server.fd, SHUT_RDWR);
+    close(smb2srv.server.fd);
+    smb2srv.server.fd = -1;
+  }
+}
+
+
+static void
+smb2srv_enable_disable(void)
+{
+  int start = 0;
+
+  hts_mutex_lock(&smb2srv.mutex);
+  if(!smb2srv.enabled) {
+    smb2srv_stop_locked();
+  } else if(!smb2srv.thread_running && smb2srv_config_ready_locked()) {
+    start = 1;
+  } else if(smb2srv.enabled && !smb2srv_config_ready_locked()) {
+    SMB2SRV_TRACE(TRACE_DEBUG,
+                  "not starting: username, password, share and path are required");
+  }
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  if(start)
+    hts_thread_create_detached("SMB2-server", smb2srv_thread, NULL,
+                               THREAD_PRIO_MODEL);
+}
+
+
+static void
+smb2srv_set_enable(void *opaque, int v)
+{
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv.enabled = v;
+  hts_mutex_unlock(&smb2srv.mutex);
+  smb2srv_enable_disable();
+}
+
+
+static void
+smb2srv_set_port(void *opaque, const char *str)
+{
+  int port = atoi(str);
+
+  hts_mutex_lock(&smb2srv.mutex);
+  if(port < 1 || port > 65535)
+    port = SMB2SRV_DEFAULT_PORT;
+  if(smb2srv.port != port && smb2srv.thread_running)
+    smb2srv_stop_locked();
+  smb2srv.port = port;
+  hts_mutex_unlock(&smb2srv.mutex);
+  smb2srv_enable_disable();
+}
+
+
+static void
+smb2srv_set_username(void *opaque, const char *str)
+{
+  hts_mutex_lock(&smb2srv.mutex);
+  mystrset(&smb2srv.username, str);
+  hts_mutex_unlock(&smb2srv.mutex);
+  smb2srv_enable_disable();
+}
+
+
+static void
+smb2srv_set_password(void *opaque, const char *str)
+{
+  hts_mutex_lock(&smb2srv.mutex);
+  mystrset(&smb2srv.password, str);
+  hts_mutex_unlock(&smb2srv.mutex);
+  smb2srv_enable_disable();
+}
+
+
+static void
+smb2srv_set_share_name(void *opaque, const char *str)
+{
+  hts_mutex_lock(&smb2srv.mutex);
+  mystrset(&smb2srv.share_name, str);
+  hts_mutex_unlock(&smb2srv.mutex);
+  smb2srv_enable_disable();
+}
+
+
+static void
+smb2srv_set_share_root(void *opaque, const char *str)
+{
+  hts_mutex_lock(&smb2srv.mutex);
+  mystrset(&smb2srv.share_root, str);
+  hts_mutex_unlock(&smb2srv.mutex);
+  smb2srv_enable_disable();
+}
+
+
+void
+smb2_server_init(void)
+{
+  hts_mutex_init(&smb2srv.mutex);
+  LIST_INIT(&smb2srv.handles);
+  smb2srv.server.fd = -1;
+  smb2srv.port = SMB2SRV_DEFAULT_PORT;
+  TRACE(TRACE_INFO, "SMB2-SERVER", "Initializing SMB2 file server settings");
+
+  settings_create_separator(gconf.settings_network, _p("SMB2 file server"));
+
+  setting_create(SETTING_BOOL, gconf.settings_network, SETTINGS_INITIAL_UPDATE,
+                 SETTING_TITLE(_p("Enable SMB2 file server")),
+                 SETTING_VALUE(0),
+                 SETTING_CALLBACK(smb2srv_set_enable, NULL),
+                 SETTING_STORE("smb2server", "enable"),
+                 SETTING_COURIER(asyncio_courier),
+                 NULL);
+
+  setting_create(SETTING_STRING, gconf.settings_network,
+                 SETTINGS_INITIAL_UPDATE,
+                 SETTING_TITLE(_p("Server TCP port")),
+                 SETTING_VALUE("1445"),
+                 SETTING_CALLBACK(smb2srv_set_port, NULL),
+                 SETTING_STORE("smb2server", "port"),
+                 SETTING_COURIER(asyncio_courier),
+                 NULL);
+
+  setting_create(SETTING_STRING, gconf.settings_network,
+                 SETTINGS_INITIAL_UPDATE,
+                 SETTING_TITLE(_p("Username")),
+                 SETTING_VALUE("movian"),
+                 SETTING_CALLBACK(smb2srv_set_username, NULL),
+                 SETTING_STORE("smb2server", "username"),
+                 SETTING_COURIER(asyncio_courier),
+                 NULL);
+
+  setting_create(SETTING_STRING, gconf.settings_network,
+                 SETTINGS_INITIAL_UPDATE | SETTINGS_PASSWORD,
+                 SETTING_TITLE(_p("Password")),
+                 SETTING_VALUE(""),
+                 SETTING_CALLBACK(smb2srv_set_password, NULL),
+                 SETTING_STORE("smb2server", "password"),
+                 SETTING_COURIER(asyncio_courier),
+                 NULL);
+
+  setting_create(SETTING_STRING, gconf.settings_network,
+                 SETTINGS_INITIAL_UPDATE,
+                 SETTING_TITLE(_p("Share name")),
+                 SETTING_VALUE("Media"),
+                 SETTING_CALLBACK(smb2srv_set_share_name, NULL),
+                 SETTING_STORE("smb2server", "share"),
+                 SETTING_COURIER(asyncio_courier),
+                 NULL);
+
+  setting_create(SETTING_STRING, gconf.settings_network,
+                 SETTINGS_INITIAL_UPDATE,
+                 SETTING_TITLE(_p("Share path")),
+                 SETTING_VALUE("vfs:///"),
+                 SETTING_CALLBACK(smb2srv_set_share_root, NULL),
+                 SETTING_STORE("smb2server", "path"),
+                 SETTING_COURIER(asyncio_courier),
+                 NULL);
+}
+
+
+INITME(INIT_GROUP_ASYNCIO, smb2_server_init, NULL, 0);

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -57,9 +57,11 @@ typedef struct smb2srv_handle {
 typedef struct smb2srv_state {
   hts_mutex_t mutex;
   struct smb2_server server;
+  setting_t *port_setting;
   int enabled;
   int thread_running;
   int restart_requested;
+  int reverting_port_setting;
   int port;
   uint64_t next_file_id;
   char *username;
@@ -895,6 +897,28 @@ smb2srv_trace_port_unavailable(int port)
 
 
 static void
+smb2srv_sync_port_setting(int port)
+{
+  char portbuf[16];
+
+  hts_mutex_lock(&smb2srv.mutex);
+  if(smb2srv.port_setting == NULL || smb2srv.reverting_port_setting) {
+    hts_mutex_unlock(&smb2srv.mutex);
+    return;
+  }
+  smb2srv.reverting_port_setting = 1;
+  hts_mutex_unlock(&smb2srv.mutex);
+
+  snprintf(portbuf, sizeof(portbuf), "%d", port);
+  setting_set(smb2srv.port_setting, SETTING_STRING, portbuf);
+
+  hts_mutex_lock(&smb2srv.mutex);
+  smb2srv.reverting_port_setting = 0;
+  hts_mutex_unlock(&smb2srv.mutex);
+}
+
+
+static void
 smb2srv_stop_locked(int restart)
 {
   if(smb2srv.server.fd > 0) {
@@ -928,6 +952,9 @@ smb2srv_enable_disable(void)
       TRACE(TRACE_INFO, "SMB2-SERVER", "Falling back to port %d",
             SMB2SRV_DEFAULT_PORT);
       smb2srv.port = SMB2SRV_DEFAULT_PORT;
+      hts_mutex_unlock(&smb2srv.mutex);
+      smb2srv_sync_port_setting(SMB2SRV_DEFAULT_PORT);
+      hts_mutex_lock(&smb2srv.mutex);
       start = 1;
     } else {
       smb2srv_trace_port_unavailable(smb2srv.port);
@@ -958,13 +985,23 @@ static void
 smb2srv_set_port(void *opaque, const char *str)
 {
   int port = atoi(str);
+  int revert_port = 0;
 
   hts_mutex_lock(&smb2srv.mutex);
   if(port < 1 || port > 65535)
     port = SMB2SRV_DEFAULT_PORT;
+
+  if(smb2srv.reverting_port_setting) {
+    smb2srv.port = port;
+    hts_mutex_unlock(&smb2srv.mutex);
+    return;
+  }
+
   if(smb2srv.port != port && !smb2srv_port_available(port)) {
     smb2srv_trace_port_unavailable(port);
+    revert_port = smb2srv.port;
     hts_mutex_unlock(&smb2srv.mutex);
+    smb2srv_sync_port_setting(revert_port);
     return;
   }
   if(smb2srv.port != port && smb2srv.thread_running)
@@ -1034,14 +1071,16 @@ smb2_server_init(void)
                  SETTING_COURIER(asyncio_courier),
                  NULL);
 
-  setting_create(SETTING_STRING, gconf.settings_network,
-                 SETTINGS_INITIAL_UPDATE,
-                 SETTING_TITLE(_p("Server TCP port")),
-                 SETTING_VALUE("1445"),
-                 SETTING_CALLBACK(smb2srv_set_port, NULL),
-                 SETTING_STORE("smb2server", "port"),
-                 SETTING_COURIER(asyncio_courier),
-                 NULL);
+  smb2srv.port_setting =
+    setting_create(SETTING_STRING, gconf.settings_network,
+                   SETTINGS_INITIAL_UPDATE,
+                   SETTING_TITLE(_p("Server TCP port")),
+                   SETTING_VALUE("1445"),
+                   SETTING_CALLBACK(smb2srv_set_port, NULL),
+                   SETTING_STORE("smb2server", "port"),
+                   SETTING_COURIER(asyncio_courier),
+                   NULL);
+  smb2srv_sync_port_setting(smb2srv.port);
 
   setting_create(SETTING_STRING, gconf.settings_network,
                  SETTINGS_INITIAL_UPDATE,

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -60,6 +60,7 @@ typedef struct smb2srv_handle {
 typedef struct smb2srv_state {
   hts_mutex_t mutex;
   struct smb2_server server;
+  struct smb2_ioctl_validate_negotiate_info validate_info;
   setting_t *port_setting;
   int enabled;
   int thread_running;
@@ -177,7 +178,7 @@ smb2srv_handle_find_locked(struct smb2_context *smb2, const smb2_file_id file_id
   LIST_FOREACH(h, &smb2srv.handles, link) {
     if(compound && h->smb2 == smb2)
       return h;
-    if(!memcmp(h->file_id, file_id, SMB2_FD_SIZE))
+    if(h->smb2 == smb2 && !memcmp(h->file_id, file_id, SMB2_FD_SIZE))
       return h;
   }
   return NULL;
@@ -857,12 +858,24 @@ static int
 smb2srv_ioctl(struct smb2_server *srvr, struct smb2_context *smb2,
               struct smb2_ioctl_request *req, struct smb2_ioctl_reply *rep)
 {
+  struct smb2_ioctl_validate_negotiate_info *out = &smb2srv.validate_info;
+  struct smb2_ioctl_validate_negotiate_info *in = req->input;
+
   if(req->ctl_code != SMB2_FSCTL_VALIDATE_NEGOTIATE_INFO)
     return smb2srv_queue_status(smb2, SMB2_IOCTL, SMB2_STATUS_NOT_SUPPORTED);
+
+  memset(out, 0, sizeof(*out));
+  out->capabilities = srvr->capabilities;
+  memcpy(out->guid, srvr->guid, sizeof(out->guid));
+  out->security_mode = srvr->security_mode;
+  out->dialect = req->input_count >= sizeof(*in) && in != NULL ?
+    in->dialect : SMB2_VERSION_0311;
 
   memset(rep, 0, sizeof(*rep));
   rep->ctl_code = req->ctl_code;
   memcpy(rep->file_id, req->file_id, SMB2_FD_SIZE);
+  rep->output = out;
+  rep->output_count = sizeof(*out);
   return 0;
 }
 

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -59,6 +59,7 @@ typedef struct smb2srv_state {
   struct smb2_server server;
   int enabled;
   int thread_running;
+  int restart_requested;
   int port;
   uint64_t next_file_id;
   char *username;
@@ -817,6 +818,7 @@ static void *
 smb2srv_thread(void *aux)
 {
   int err;
+  int restart = 0;
 
   hts_mutex_lock(&smb2srv.mutex);
   smb2srv.thread_running = 1;
@@ -839,8 +841,16 @@ smb2srv_thread(void *aux)
 
   hts_mutex_lock(&smb2srv.mutex);
   smb2srv.thread_running = 0;
+  smb2srv.server.fd = -1;
+  if(smb2srv.restart_requested) {
+    smb2srv.restart_requested = 0;
+    restart = smb2srv.enabled && smb2srv_config_ready_locked();
+  }
   hts_mutex_unlock(&smb2srv.mutex);
 
+  if(restart)
+    hts_thread_create_detached("SMB2-server", smb2srv_thread, NULL,
+                               THREAD_PRIO_BGTASK);
   return NULL;
 }
 
@@ -857,12 +867,17 @@ smb2srv_config_ready_locked(void)
 
 
 static void
-smb2srv_stop_locked(void)
+smb2srv_stop_locked(int restart)
 {
   if(smb2srv.server.fd > 0) {
-    shutdown(smb2srv.server.fd, SHUT_RDWR);
-    close(smb2srv.server.fd);
-    smb2srv.server.fd = -1;
+    if(smb2srv.thread_running) {
+      if(restart)
+        smb2srv.restart_requested = 1;
+      shutdown(smb2srv.server.fd, SHUT_RDWR);
+    } else {
+      close(smb2srv.server.fd);
+      smb2srv.server.fd = -1;
+    }
   }
 }
 
@@ -874,7 +889,8 @@ smb2srv_enable_disable(void)
 
   hts_mutex_lock(&smb2srv.mutex);
   if(!smb2srv.enabled) {
-    smb2srv_stop_locked();
+    smb2srv.restart_requested = 0;
+    smb2srv_stop_locked(0);
   } else if(!smb2srv.thread_running && smb2srv_config_ready_locked()) {
     start = 1;
   } else if(smb2srv.enabled && !smb2srv_config_ready_locked()) {
@@ -908,7 +924,7 @@ smb2srv_set_port(void *opaque, const char *str)
   if(port < 1 || port > 65535)
     port = SMB2SRV_DEFAULT_PORT;
   if(smb2srv.port != port && smb2srv.thread_running)
-    smb2srv_stop_locked();
+    smb2srv_stop_locked(1);
   smb2srv.port = port;
   hts_mutex_unlock(&smb2srv.mutex);
   smb2srv_enable_disable();

--- a/src/networking/smb2_server.c
+++ b/src/networking/smb2_server.c
@@ -866,6 +866,34 @@ smb2srv_config_ready_locked(void)
 }
 
 
+static int
+smb2srv_port_available(int port)
+{
+  int fd = -1;
+  int err = smb2_bind_and_listen(port, SMB2SRV_MAX_CONNECTIONS, &fd);
+
+  if(fd >= 0)
+    close(fd);
+
+  return err == 0;
+}
+
+
+static void
+smb2srv_trace_port_unavailable(int port)
+{
+  if(port < 1024 && geteuid() != 0) {
+    TRACE(TRACE_ERROR, "SMB2-SERVER",
+          "Cannot listen on privileged port %d as uid %d",
+          port, (int)geteuid());
+  } else {
+    TRACE(TRACE_ERROR, "SMB2-SERVER",
+          "Cannot listen on port %d; it may be unavailable or already in use",
+          port);
+  }
+}
+
+
 static void
 smb2srv_stop_locked(int restart)
 {
@@ -892,7 +920,18 @@ smb2srv_enable_disable(void)
     smb2srv.restart_requested = 0;
     smb2srv_stop_locked(0);
   } else if(!smb2srv.thread_running && smb2srv_config_ready_locked()) {
-    start = 1;
+    if(smb2srv_port_available(smb2srv.port)) {
+      start = 1;
+    } else if(smb2srv.port != SMB2SRV_DEFAULT_PORT &&
+              smb2srv_port_available(SMB2SRV_DEFAULT_PORT)) {
+      smb2srv_trace_port_unavailable(smb2srv.port);
+      TRACE(TRACE_INFO, "SMB2-SERVER", "Falling back to port %d",
+            SMB2SRV_DEFAULT_PORT);
+      smb2srv.port = SMB2SRV_DEFAULT_PORT;
+      start = 1;
+    } else {
+      smb2srv_trace_port_unavailable(smb2srv.port);
+    }
   } else if(smb2srv.enabled && !smb2srv_config_ready_locked()) {
     SMB2SRV_TRACE(TRACE_DEBUG,
                   "not starting: username, password, share and path are required");
@@ -923,6 +962,11 @@ smb2srv_set_port(void *opaque, const char *str)
   hts_mutex_lock(&smb2srv.mutex);
   if(port < 1 || port > 65535)
     port = SMB2SRV_DEFAULT_PORT;
+  if(smb2srv.port != port && !smb2srv_port_available(port)) {
+    smb2srv_trace_port_unavailable(port);
+    hts_mutex_unlock(&smb2srv.mutex);
+    return;
+  }
   if(smb2srv.port != port && smb2srv.thread_running)
     smb2srv_stop_locked(1);
   smb2srv.port = port;

--- a/src/networking/smb2_server.h
+++ b/src/networking/smb2_server.h
@@ -1,0 +1,12 @@
+/*
+ *  Copyright (C) 2026 Movian contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ */
+
+#pragma once
+
+void smb2_server_init(void);

--- a/src/settings.c
+++ b/src/settings.c
@@ -1207,7 +1207,10 @@ setting_set(setting_t *s, int type, ...)
     break;
 
   case SETTING_STRING:
-    abort();
+    str = va_arg(ap, const char *);
+    rstr_t *rstr = rstr_alloc(str);
+    prop_set_rstring(s->s_val, rstr);
+    rstr_release(rstr);
     break;
 
   case SETTING_MULTIOPT:

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -70,6 +70,7 @@ CONFIG_LIST="
  libpthread
  libpulse
  libsmb2
+ libsmb2_server
  librtmp
  libx11
  libxext
@@ -470,11 +471,15 @@ ext_setup() {
 
 libsmb2_setup() {
     if disabled libsmb2; then
+        disable libsmb2_server
         return
     fi
 
     which >/dev/null 2>&1 cmake || die
     update_ext_submodule libsmb2
+
+    LIBSMB2_SERVER_REQUESTED=${libsmb2_server}
+    disable libsmb2_server
 
     LIBSMB2_BUILD_DIR=${BUILDDIR}/libsmb2/build
     mkdir -p "${LIBSMB2_BUILD_DIR}"
@@ -499,9 +504,43 @@ libsmb2_setup() {
         -DENABLE_LIBKRB5=OFF \
         -DENABLE_GSSAPI=OFF || die
 
+    if [ "x${LIBSMB2_SERVER_REQUESTED}" != "xno" ] && check_libsmb2_server_api; then
+        enable libsmb2_server
+        echo "Using libsmb2 server API: yes"
+    else
+        echo "Using libsmb2 server API: no"
+    fi
+
     echo >>${CONFIG_MAK} "LIBSMB2_BUILD_DIR=${LIBSMB2_BUILD_DIR}"
     echo >>${CONFIG_MAK} "LDFLAGS_cfg += -lsmb2"
     add_stamp libsmb2
+}
+
+
+check_libsmb2_server_api() {
+    mkdir -p "${TMPDIR}"
+    cat >"${TMPDIR}/libsmb2_server_api.c" <<EOF
+#include <stdint.h>
+#include <time.h>
+#include <smb2/smb2.h>
+#include <smb2/libsmb2.h>
+#include <smb2/libsmb2-raw.h>
+
+int main(void)
+{
+    struct smb2_server server;
+    struct smb2_server_request_handlers handlers;
+    int (*bind_fn)(const uint16_t, const int, int *) = smb2_bind_and_listen;
+    int (*serve_fn)(struct smb2_server *, const int,
+                    smb2_client_connection, void *) = smb2_serve_port;
+    server.handlers = &handlers;
+    return bind_fn != 0 && serve_fn != 0 ? 0 : 1;
+}
+EOF
+
+    ${CC} -I"${TOPDIR}/ext/libsmb2/include" \
+        -c "${TMPDIR}/libsmb2_server_api.c" \
+        -o "${TMPDIR}/libsmb2_server_api.o" >/dev/null 2>&1
 }
 
 

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -34,6 +34,11 @@ The build log is written to:
 build.flatpak/flatpak-build.log
 ```
 
+`build-local.sh` removes old `build.flatpak/state/build` contents by default
+so repeated local builds do not grow without bound. Set
+`FLATPAK_KEEP_BUILD_DIRS=1` when debugging a failed Flatpak module build and
+you need to inspect the preserved builder work directories.
+
 ## Validate
 
 ```sh

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -118,6 +118,12 @@ Avahi service discovery uses the host daemon over the system D-Bus:
 This allows `_smb._tcp` servers to appear under Local network without
 granting broader system bus access.
 
+Flatpak 1.14 does not accept Linux capability finish args such as
+`--cap-add=NET_BIND_SERVICE`; `flatpak build-finish --cap-add=...` fails with
+`Unknown option`. Do not use Docker/Podman capability syntax in this manifest.
+For SMB2 server Windows acceptance, keep TCP `445` exposure as a separate
+packaging or host-forwarding problem from high-port request-handler smokes.
+
 AppStream metadata is generated from `dev.uzver.Movian.metainfo.xml.in`
 during the build. The version comes from:
 

--- a/support/flatpak/README.md
+++ b/support/flatpak/README.md
@@ -60,6 +60,12 @@ The full smoke checklist for Linux, Flatpak, runtime, and Steam Deck checks is:
 docs/Guides/LINUX_FLATPAK_SMOKE_CHECKLIST.md
 ```
 
+The SSH-assisted Steam Deck copy/install/log workflow is:
+
+```text
+docs/Guides/STEAM_DECK_REMOTE_TESTING.md
+```
+
 ## Install
 
 ```sh

--- a/support/flatpak/build-local.sh
+++ b/support/flatpak/build-local.sh
@@ -12,13 +12,20 @@ bundle_file="$log_dir/dev.uzver.Movian.flatpak"
 mkdir -p "$log_dir" "$repo_dir" "$state_dir"
 rm -f "$bundle_file"
 
+builder_keep_args=()
+if [ "${FLATPAK_KEEP_BUILD_DIRS:-0}" = "1" ]; then
+  builder_keep_args+=(--keep-build-dirs)
+else
+  rm -rf "$state_dir/build"
+fi
+
 cd "$script_dir"
 
 {
   flatpak-builder \
     --user \
     --verbose \
-    --keep-build-dirs \
+    "${builder_keep_args[@]}" \
     --force-clean \
     --state-dir="$state_dir" \
     --repo="$repo_dir" \

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -76,6 +76,22 @@ For Windows visibility, TCP `445`, and systemd/nft forwarding research, see
 
 Successful findings to preserve in future smokes:
 
+- For SMB/SMB2 authentication there are three valid test paths. Prefer an
+  isolated keyring seed when the credential values are known and the test is
+  protocol-level. Use STPP against `global.popups` child proprefs when the test
+  must validate the real auth popup tree and remembered-credential behavior.
+  Use X11 keypress fallback only when the popup must be exercised visually or
+  STPP child proprefs are unavailable. Always remove temporary keyring entries
+  after a non-isolated-profile run.
+- The auth popup is visible through HTTP at `/api/prop/global/popups/*0`, but
+  writes should use STPP child proprefs from a popup subscription. The HTTP
+  `*0` segment is an inspection alias, not a stable STPP path segment.
+- FTP server browse/list is a useful reference for SMB2 server VFS listing:
+  FTP calls `fa_protocol_vfs.fap_scan(..., FA_NON_INTERACTIVE)` directly for
+  VFS paths instead of going through generic `fa_scandir()`. For SMB2 server
+  directory listing, prefer the same direct VFS scan when the configured share
+  root is `vfs:` and keep generic `fa_scandir()` only as a fallback for other
+  URL roots.
 - Use STPP dot paths and real child proprefs for settings writes. HTTP paths
   such as `/api/prop/.../*0` are display aliases and are useful for inspection,
   but `*0` is not a valid STPP path segment.
@@ -85,6 +101,9 @@ Successful findings to preserve in future smokes:
 - A port-change smoke passes only when logs show the old server loop exiting
   and a new `SMB2-SERVER Listening on port ...` line, the old TCP port refuses
   connections, and the new port accepts a browse/read probe.
+  Keep a separate remote SMB2 client context alive during at least one
+  stop/restart smoke; unlike FTP's isolated per-session connections, libsmb2
+  keeps client and embedded-server contexts in one active list.
 - If the app aborts in thread `SMB2-server` during a port edit, preserve
   `/api/logfile/0` and `/api/logfile/1` and treat it as a server lifecycle
   bug before repeating the write against the same build.

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -71,6 +71,8 @@ runtime setting, not only as a process-start option.
 
 For the full SSH-assisted Steam Deck copy/install/log workflow, see
 `docs/Guides/STEAM_DECK_REMOTE_TESTING.md`.
+For Windows visibility, TCP `445`, and systemd/nft forwarding research, see
+`docs/Guides/SMB2_WINDOWS_VISIBILITY_RESEARCH.md`.
 
 Successful findings to preserve in future smokes:
 

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -93,3 +93,7 @@ Successful findings to preserve in future smokes:
 - If TCP `445` cannot be bound from Flatpak/Linux while higher ports work,
   keep handler correctness and privileged-port packaging/forwarding as separate
   test results.
+- A failed switch to an unavailable port must leave the previous working SMB2
+  server listener alive. Verify this by attempting a privileged or occupied
+  port, then checking that the previous high port still accepts TCP and SMB2
+  session setup.

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -92,9 +92,11 @@ Successful findings to preserve in future smokes:
   `1445` is acceptable. For ordinary Windows Explorer or `net use` acceptance,
   the service must be reachable on TCP `445`; Windows `\\host@port\share` and
   `\\host:port\share` are not reliable user-facing connection forms.
-- If TCP `445` cannot be bound from Flatpak/Linux while higher ports work,
+- If TCP `445` cannot be bound on the target platform while higher ports work,
   keep handler correctness and privileged-port packaging/forwarding as separate
-  test results.
+  test results. This applies beyond Flatpak: native Linux, SteamOS, Android,
+  macOS, and other targets need their own host integration story for Windows
+  SMB clients.
 - A failed switch to an unavailable port must leave the previous working SMB2
   server listener alive. Verify this by attempting a privileged or occupied
   port, then checking that the previous high port still accepts TCP and SMB2

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -69,6 +69,9 @@ seeded keyring before exit. Logs are also sanitized for the password string.
 The SMB2 server lives under Movian network settings and should be tested as a
 runtime setting, not only as a process-start option.
 
+For the full SSH-assisted Steam Deck copy/install/log workflow, see
+`docs/Guides/STEAM_DECK_REMOTE_TESTING.md`.
+
 Successful findings to preserve in future smokes:
 
 - Use STPP dot paths and real child proprefs for settings writes. HTTP paths

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -111,6 +111,12 @@ Successful findings to preserve in future smokes:
   `1445` is acceptable. For ordinary Windows Explorer or `net use` acceptance,
   the service must be reachable on TCP `445`; Windows `\\host@port\share` and
   `\\host:port\share` are not reliable user-facing connection forms.
+- Current Steam Deck/AG and local WSL runtime research shows a useful split:
+  anonymous read-only SMB2 browsing on a high port works with `smbclient` for
+  both SMB2 and SMB3 dialect selection, while password-protected NTLM sessions
+  fail before the first create/query request (`NT_STATUS_ACCESS_DENIED` or bad
+  SMB2 signature). Treat password auth/signing as a separate blocker from VFS
+  listing and high-port listener lifecycle.
 - If TCP `445` cannot be bound on the target platform while higher ports work,
   keep handler correctness and privileged-port packaging/forwarding as separate
   test results. This applies beyond Flatpak: native Linux, SteamOS, Android,

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -42,6 +42,10 @@ Checks:
 - the configured share/path reaches `loading=0`;
 - first page nodes are captured for comparison.
 
+For browser parity checks, keep using `search:smb2://...` through `/api/open`.
+This matches the user navigation path and catches root URL normalization, for
+example `smb2://host` becoming `smb2://host/`.
+
 ## GDB Smoke
 
 ```sh
@@ -59,3 +63,30 @@ Checks under GDB:
 
 The scripts seed credentials into an isolated Movian profile and remove the
 seeded keyring before exit. Logs are also sanitized for the password string.
+
+## SMB2 Server MVP Notes
+
+The SMB2 server lives under Movian network settings and should be tested as a
+runtime setting, not only as a process-start option.
+
+Successful findings to preserve in future smokes:
+
+- Use STPP dot paths and real child proprefs for settings writes. HTTP paths
+  such as `/api/prop/.../*0` are display aliases and are useful for inspection,
+  but `*0` is not a valid STPP path segment.
+- To change the server TCP port, open `settings:network`, subscribe to
+  `navigators.current.currentpage.model.nodes`, find the `Server TCP port`
+  row by `metadata.title`, and set that row's `value`.
+- A port-change smoke passes only when logs show the old server loop exiting
+  and a new `SMB2-SERVER Listening on port ...` line, the old TCP port refuses
+  connections, and the new port accepts a browse/read probe.
+- If the app aborts in thread `SMB2-server` during a port edit, preserve
+  `/api/logfile/0` and `/api/logfile/1` and treat it as a server lifecycle
+  bug before repeating the write against the same build.
+- For Linux/macOS/libsmb2 clients, a non-privileged development port such as
+  `1445` is acceptable. For ordinary Windows Explorer or `net use` acceptance,
+  the service must be reachable on TCP `445`; Windows `\\host@port\share` and
+  `\\host:port\share` are not reliable user-facing connection forms.
+- If TCP `445` cannot be bound from Flatpak/Linux while higher ports work,
+  keep handler correctness and privileged-port packaging/forwarding as separate
+  test results.

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -97,3 +97,7 @@ Successful findings to preserve in future smokes:
   server listener alive. Verify this by attempting a privileged or occupied
   port, then checking that the previous high port still accepts TCP and SMB2
   session setup.
+- If a persisted startup port such as `445` is unavailable, the server should
+  fall back to the default high port and the Network settings row should also
+  show the effective fallback port. A stale UI value is a failed smoke even when
+  the listener itself survived.


### PR DESCRIPTION
## Summary

Adds a read-only SMB2 server MVP for Movian/M7, exposed through Network settings and validated on Linux/Steam Deck Flatpak.

## What changed

- Add a libsmb2-backed read-only SMB2 server with manual share configuration.
- Add Network settings for enable, TCP port, username, password, share name, and share path.
- Keep mutation operations denied for the MVP.
- Harden port lifecycle so failed or unavailable ports do not kill the previous listener.
- Revert the visible port setting when startup or live changes fall back from unavailable TCP `445` to the working high port.
- Document Steam Deck remote testing, SMB smoke lessons, and Windows access research.

## Validation

- `git diff --check`
- `make -j2 BUILD=debug`
- `support/flatpak/build-local.sh`
- Steam Deck Flatpak install and launch through `systemd-run --user`
- Deck smoke: `445` unavailable, fallback to `1445`, UI setting shows `1445`
- Windows-side TCP probe: `1445` open, `445` closed before host forwarding
- libsmb2 session setup to `192.168.1.56:1445` returned `connect rc=0`

## Follow-up

Windows Explorer/native `net use` requires TCP `445`. This PR keeps the app unprivileged and documents candidate host-side forwarding paths. Follow-up issue #46 tracks `445` exposure and discovery.
