### PR TITLE
smb_server: fix SMB3 password-mode signing (all dialects) (#74)

### DIFF
--- a/docs/Guides/SMB_SERVER_SPECIFICATION.md
+++ b/docs/Guides/SMB_SERVER_SPECIFICATION.md
@@ -52,7 +52,7 @@
 * `smb2://host:port/` должен проходить через `IPC$` и pipe `srvsvc`. Минимальный `NetrShareEnum` возвращает только настроенную share и не включает network-neighborhood discovery.
 * Movian SMB2 client и часть внешних клиентов используют compound `CREATE + QUERY_INFO + CLOSE` для `stat()`. В таких цепочках `QUERY_INFO` и `CLOSE` могут передавать all-`FF` File ID как related-operation placeholder. Сервер хранит последний созданный handle в сессии и резолвит этот placeholder в реальный File ID.
 * Deep browse `smb2://host:port/share/zona/` должен логировать последовательность `Create OK` directory -> `QueryInfo: FILE/ALL` -> client `stat ok` -> `QueryDir`. Если `Create OK` есть, но `QueryInfo` нет, искать проблему в related compound File ID обработке.
-* Password SMB3 signing пока проверяется отдельным diagnostic smoke: password SMB2 write/read является обязательным baseline, anonymous SMB2/SMB3 navigation является обязательным baseline, а password SMB3 можно сделать обязательным через `SMB_SERVER_SMOKE_REQUIRE_PASSWORD_SMB3=1`.
+* Password SMB3 signing работает для всех SMB3 диалектов (Buksa/movian#74) и является обязательной hard-проверкой в embedded-server smoke: password SMB2 write/read, anonymous SMB2/SMB3 navigation и password SMB3 listing (`SMB3_00`/`SMB3_02`/`SMB3_11`, каждый диалект зафиксирован точно) — все обязательный baseline.
 
 ## 3. Таблица трансляции ошибок (Error Code Mappings)
 

--- a/support/smb-smoke/README.md
+++ b/support/smb-smoke/README.md
@@ -54,8 +54,9 @@ Checks a local Movian SMB2 server with an isolated profile:
   `profile-summary.txt` so saved torrent/bookmark/keyring state cannot quietly
   trigger unrelated remote SMB2 client scans;
 - password SMB2 `smbclient` listing and writable operations;
-- password SMB3 listing as a diagnostic check; set
-  `SMB_SERVER_SMOKE_REQUIRE_PASSWORD_SMB3=1` to make it mandatory;
+- password SMB3 listing (and wrong-password rejection) as a mandatory hard
+  check against `SMB3_00`, `SMB3_02` and `SMB3_11`, each dialect pinned
+  exactly (client min == max protocol);
 - wrong password rejection;
 - `get`, `put`, `mkdir`, `rename`, `del`, `rmdir` using
   `SMB_SERVER_SMOKE_FILE_DIALECT` (default `SMB2`);

--- a/support/smb-smoke/run-embedded-server-smoke.sh
+++ b/support/smb-smoke/run-embedded-server-smoke.sh
@@ -186,21 +186,28 @@ run_file_root_case() {
   [ ! -e /tmp/movian-ipc-denied.bin ] ||
     fail "IPC$ non-pipe create unexpectedly read from the disk share"
 
-  set +e
-  smbclient "//127.0.0.1/$SMB_SERVER_SMOKE_SHARE" \
-    -p "$port" -U "$SMB_SERVER_SMOKE_USER%$SMB_SERVER_SMOKE_PASSWORD" \
-    -m SMB3 -c 'ls; cd dir; ls' >"$ART/file-smb3-ls.log" 2>&1
-  smb3_ls_rc=$?
-  set -e
-  if [ "$smb3_ls_rc" -ne 0 ]; then
-    echo "WARN: password SMB3 listing failed; see $ART/file-smb3-ls.log" \
-      >"$ART/file-smb3-ls.warning"
-    [ "${SMB_SERVER_SMOKE_REQUIRE_PASSWORD_SMB3:-0}" != "1" ] ||
-      fail "password SMB3 listing failed"
-  else
-    grep -q 'movie.mkv' "$ART/file-smb3-ls.log" || fail "SMB3 ls did not show movie.mkv"
-    grep -q 'nested.mp4' "$ART/file-smb3-ls.log" || fail "SMB3 ls did not show nested.mp4"
-  fi
+  # Password SMB3 signing is a hard check by default: every SMB3 dialect
+  # must sign correctly against the embedded server (Buksa/movian#74).
+  for smb3_dialect in SMB3_00 SMB3_02 SMB3_11; do
+    smbclient "//127.0.0.1/$SMB_SERVER_SMOKE_SHARE" \
+      -p "$port" -U "$SMB_SERVER_SMOKE_USER%$SMB_SERVER_SMOKE_PASSWORD" \
+      -m "$smb3_dialect" -c 'ls; cd dir; ls' \
+      >"$ART/file-smb3-ls-$smb3_dialect.log" 2>&1 ||
+      fail "password $smb3_dialect listing failed; see $ART/file-smb3-ls-$smb3_dialect.log"
+    grep -q 'movie.mkv' "$ART/file-smb3-ls-$smb3_dialect.log" ||
+      fail "$smb3_dialect ls did not show movie.mkv"
+    grep -q 'nested.mp4' "$ART/file-smb3-ls-$smb3_dialect.log" ||
+      fail "$smb3_dialect ls did not show nested.mp4"
+
+    set +e
+    smbclient "//127.0.0.1/$SMB_SERVER_SMOKE_SHARE" \
+      -p "$port" -U "$SMB_SERVER_SMOKE_USER%wrongpass" \
+      -m "$smb3_dialect" -c 'ls' >"$ART/file-smb3-wrong-password-$smb3_dialect.log" 2>&1
+    smb3_wrong_rc=$?
+    set -e
+    [ "$smb3_wrong_rc" -ne 0 ] ||
+      fail "wrong password unexpectedly succeeded on $smb3_dialect"
+  done
 
   local file_dialect="${SMB_SERVER_SMOKE_FILE_DIALECT:-SMB2}"
 

--- a/support/smb-smoke/run-embedded-server-smoke.sh
+++ b/support/smb-smoke/run-embedded-server-smoke.sh
@@ -188,10 +188,16 @@ run_file_root_case() {
 
   # Password SMB3 signing is a hard check by default: every SMB3 dialect
   # must sign correctly against the embedded server (Buksa/movian#74).
+  # Pin BOTH the client min and max protocol to the exact dialect: -m only
+  # caps the maximum, so on its own a server that quietly stopped
+  # advertising e.g. SMB3_11 would let the client fall back to SMB3_02/SMB2
+  # and still pass this "every SMB3 dialect" gate. Forcing min == max makes
+  # negotiation fail (and this check fail) unless that exact dialect is used.
   for smb3_dialect in SMB3_00 SMB3_02 SMB3_11; do
     smbclient "//127.0.0.1/$SMB_SERVER_SMOKE_SHARE" \
       -p "$port" -U "$SMB_SERVER_SMOKE_USER%$SMB_SERVER_SMOKE_PASSWORD" \
-      -m "$smb3_dialect" -c 'ls; cd dir; ls' \
+      -m "$smb3_dialect" --option="client min protocol=$smb3_dialect" \
+      -c 'ls; cd dir; ls' \
       >"$ART/file-smb3-ls-$smb3_dialect.log" 2>&1 ||
       fail "password $smb3_dialect listing failed; see $ART/file-smb3-ls-$smb3_dialect.log"
     grep -q 'movie.mkv' "$ART/file-smb3-ls-$smb3_dialect.log" ||
@@ -202,7 +208,8 @@ run_file_root_case() {
     set +e
     smbclient "//127.0.0.1/$SMB_SERVER_SMOKE_SHARE" \
       -p "$port" -U "$SMB_SERVER_SMOKE_USER%wrongpass" \
-      -m "$smb3_dialect" -c 'ls' >"$ART/file-smb3-wrong-password-$smb3_dialect.log" 2>&1
+      -m "$smb3_dialect" --option="client min protocol=$smb3_dialect" \
+      -c 'ls' >"$ART/file-smb3-wrong-password-$smb3_dialect.log" 2>&1
     smb3_wrong_rc=$?
     set -e
     [ "$smb3_wrong_rc" -ne 0 ] ||


### PR DESCRIPTION
## Fix SMB3 password-mode signing in the embedded SMB2 server (#74)

The embedded SMB2 server (`smb_server.c` + the bundled `ext/libsmb2` server path) produced signatures that clients reject in **password mode for every SMB3 dialect**. SMB2 dialects and anonymous mode were fine, which is why all automated coverage passed while modern clients (Windows 8+, current samba negotiating 3.1.1) could not use a password-protected Movian share over SMB3.

Verified against `movian6` with a stock Linux `smbclient` dialect ladder before the fix: `SMB2_10` ✅, `SMB3_00`/`SMB3_02` ❌ (tree connect `NT_STATUS_ACCESS_DENIED`), `SMB3_11` ❌ (client rejects the server-signed session-setup response).

### Two root causes, both confirmed

**H1 — 3.0/3.0.2 never signed.** The server's negotiate handler forced signing only on dialect 2.1 or ≥3.1.1. A client that asserts `SIGNING_ENABLED` but not `SIGNING_REQUIRED` (samba's `smbclient`) left `smb2->sign == 0` on 3.0/3.0.2, so the server derived no keys and signed nothing; the client's signed `TREE_CONNECT` then failed server-side verification → `ACCESS_DENIED`. Per MS-SMB2 §3.3.4.1.1 an authenticated session must sign whenever both sides have signing enabled on any dialect ≥2.1. **Fix:** widen the check to `dialect >= SMB2_VERSION_0210`.

**H2 — 3.1.1 derived a wrong signing key (a use-after-free).** The server folded each reply into the pre-auth integrity hash by reading `pdu->out.niov/iov` *after* `smb2_queue_pdu()` returned. For the server role, `smb2_queue_pdu()` → `smb2_add_to_outqueue()` → `smb2_write_to_socket()` synchronously writes and then frees a fully-sent reply, and the free zeroes the iovector — so the reply was silently dropped from the hash chain. The server's `PreauthIntegrityHashValue` diverged from the client's, and since the 3.1.1 signing key is `KDF(session_key, "SMBSigningKey", PreauthIntegrityHashValue)` the derived keys differed, so the client's signature check on the session-setup response failed. 3.0/3.0.2 don't fold the pre-auth hash into derivation, hence the dialect-specific symptom. **Fix:** fold the pre-auth-hash update into `smb2_queue_pdu()` itself (role-gated, before the free), and drop the two now-unsafe post-queue calls.

Diagnosed with a temporary "client-as-oracle" instrumentation (the libsmb2 *client* derivation is proven correct against real servers): with an identical NTLMSSP session key on both sides, the server's pre-auth hash at derive time differed from the client's after the NEGOTIATE round-trip; after the fix both sides derive **byte-identical** signing keys. The instrumentation was removed before commit.

### Changes

- `ext/libsmb2` bumped to `0f21414` on Buksa/libsmb2 branch `ag-smb2-client-parity` (already pushed — gitlink resolves): the negotiate signing-policy widen + the pre-auth-hash UAF fix in `smb2_queue_pdu()`; `smb3_update_preauth_hash` exposed non-static via `smb2-signing.h`. Client-role call sites untouched.
- `support/smb-smoke/run-embedded-server-smoke.sh`: password SMB3 signing is now a **hard** default check across `SMB3_00`/`SMB3_02`/`SMB3_11`, each with its own wrong-password rejection, replacing the old WARN-unless-`SMB_SERVER_SMOKE_REQUIRE_PASSWORD_SMB3=1` carve-out.

### Verification

- Clean asan + debug builds, WSL GCC 13.3, no new warnings in `ext/libsmb2/` or `src/`.
- `run-embedded-server-smoke.sh` (hard-gated): PASS — `SMB3_00`/`SMB3_02`/`SMB3_11` each list the share with the correct password and reject the wrong one.
- `run-http-nav-smoke.sh` (real NAS): PASS — client-regression proof that the shared `pdu.c`/pre-auth changes don't disturb the client role.
- Post-fix oracle: server and client derive identical 3.1.1 signing keys.

Not covered here: a real-network run against the Ubuntu stand (loopback exercises the identical signing math, and the UAF manifests more readily on a fast local socket than over the wire, so loopback is the stronger test for this defect).

### Follow-ups (filed separately, out of scope for this PR)

- **#76** — the server does not enforce signing on signing-required sessions (unsigned PDUs are accepted); real verification exists inline but is gated on the incoming SIGNED flag rather than the session requirement, and `smb2_pdu_check_signature` is a dead stub.
- **#75** — decompose the 2333-line `smb_server.c`.
- The fix is a good candidate to contribute upstream to `sahlberg/libsmb2` (same defect exists there, unreported).

Issue delivered: #74.
