### PR TITLE
smb2: enforce signing on the embedded server (#76)

### DIFF
--- a/support/smb-smoke/run-embedded-server-smoke.sh
+++ b/support/smb-smoke/run-embedded-server-smoke.sh
@@ -216,6 +216,23 @@ run_file_root_case() {
       fail "wrong password unexpectedly succeeded on $smb3_dialect"
   done
 
+  # NOTE (Buksa/movian#76): the server now rejects any post-auth PDU that
+  # arrives with SMB2_FLAGS_SIGNED clear on a signing-required session
+  # (ext/libsmb2 lib/socket.c). There is no reliable *automated* negative
+  # test for this with stock tooling: `smbclient --option="client
+  # signing=disabled"` still signs its PDUs once the server advertises
+  # SMB2_NEGOTIATE_SIGNING_REQUIRED (verified manually — smbclient ignores
+  # the "disabled" preference and negotiates signing on anyway, so the
+  # command exits 0 and browses normally instead of failing). Adding that
+  # as a gate here would just be a no-op assertion, so it is intentionally
+  # left out. The bypass and the fix were instead proven with a throwaway,
+  # never-committed patch to Movian's own libsmb2 client (lib/pdu.c) that
+  # forced unsigned outgoing PDUs on a password/SMB3 session against this
+  # same embedded server: pre-fix the server served the request; post-fix
+  # it tore the connection down (smb_destruction "disconnected (abrupt)")
+  # before any file operation. See the issue #76 report for the captured
+  # smbdebug evidence.
+
   local file_dialect="${SMB_SERVER_SMOKE_FILE_DIALECT:-SMB2}"
 
   set +e


### PR DESCRIPTION
## Enforce SMB2 signing on the embedded server (#76)

The embedded SMB2 server verified a signature only when the incoming header already had `SMB2_FLAGS_SIGNED` set — so a PDU that omitted the flag entirely **skipped the check and was processed as valid**, silently bypassing signing enforcement on any authenticated, signing-required server session (MS-SMB2 §3.3.5.2.4). A MITM or malicious client could strip signatures at will.

### Fix (server-role only, in `ext/libsmb2`)

A server-only guard added immediately **before** the existing verify block in `lib/socket.c` — rejecting any post-`SESSION_SETUP` request that lacks `SMB2_FLAGS_SIGNED` while `smb2->sign` is set:

```c
if (smb2_is_server(smb2) && smb2->sign &&
    smb2->hdr.command != SMB2_SESSION_SETUP &&
    !(smb2->hdr.flags & SMB2_FLAGS_SIGNED)) {
        smb2_set_error(smb2, "Unsigned PDU on a signing-required session");
        return -1;
}
```

Rejection tears the connection down (`return -1`), matching the sibling wrong-signature path. The existing verify block is untouched, so the **`smb2://` client receive path is byte-identical**. Also removes the dead `smb2_pdu_check_signature` stub (`smb2-signing.c`/`.h`) — it unconditionally returned 0 and had zero callers.

Handshake legs stay safe: `NEGOTIATE` arrives before `smb2->sign` is set, `SESSION_SETUP` is excluded, and anonymous/guest sessions have `smb2->sign == 0` so the guard never fires.

### Verification

- **Falsifiable negative test** (throwaway, never-committed patch to Movian's own libsmb2 client forcing unsigned outgoing PDUs, driven at the embedded server in password/SMB3, keyring pre-seeded): **pre-fix** the server served the request; **post-fix** it tore the connection down before any file op. Reproduced independently by a fresh verifier.
- **No false rejection of legit clients:** `run-embedded-server-smoke.sh` passes — all password SMB2 + SMB3_00/02/11 signed flows and anonymous flows still succeed (the #74 hard gate stays green).
- **Client untouched:** `run-http-nav-smoke.sh` (real NAS) passes.
- **Debian stand (GCC 14):** clean build; embedded-server smoke green across all SMB3 dialects; external `smbclient` signed sessions not over-rejected (`signed SMB2 message` for every op).
- **Review:** `/code-review max` → 0 findings (guard condition, compound/related sub-PDUs, anonymous/guest path, `SMB2_CANCEL`/`ECHO`/`LOCK`, and the dead-stub deletion all checked and cleared, with MS-SMB2 citations).
- Clean build WSL GCC 13 (`make -j` + `BUILD=debug`), no new warnings in `ext/libsmb2/`.

### Notes

- The receive-side `smb2://` **client** is deliberately left as-is (rejecting unsigned server responses is a riskier interop change) — a candidate follow-up.
- Same provenance as #74: upstream `sahlberg/libsmb2` server code, unmodified by our fork; the gap exists upstream and is unreported — this fix is upstreamable (deferred).
- Unrelated to #79 (embedded-server idle/keepalive disconnect): that bug reproduces in anonymous mode where `smb2->sign == 0` and this guard cannot fire, and with a plain-dir root — it is not caused or worsened by this change.

Submodule fix on `ag-smb2-client-parity` (`eb95b21`); movian gitlink bump + a smoke-script comment.

Addresses Buksa/movian#76.
