### PR TITLE
sd: guard setting_destroy against NULL to fix AVAHI resolve-failure crash (#83)

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -367,6 +367,8 @@ setting_release(setting_t *s)
 void
 setting_destroy(setting_t *s)
 {
+  if(s == NULL)
+    return;
   if(s->s_on_group_list)
     LIST_REMOVE(s, s_group_link);
   s->s_callback = NULL;


### PR DESCRIPTION
## Fix AVAHI resolve-failure crash: guard `setting_destroy` against NULL

**Fixes Buksa/movian#83.**

On `AVAHI_RESOLVER_FAILURE` (and the resolver-creation failure branch),
`resolve_callback` in `src/sd/avahi.c` calls `si_destroy()` on a
`service_instance_t` that was only `calloc`'d in `browser()` and **never
resolved** — so `si_setting_enabled/title/type` and `si_url` are still `NULL`
(they're set later, in `sd_add_service`, only on the `AVAHI_RESOLVER_FOUND`
path). `si_destroy()` then passes those NULLs straight to `setting_destroy()`,
which dereferenced its argument on its first line:

```c
setting_destroy(setting_t *s) {
  if(s->s_on_group_list)   // s == NULL  =>  SIGSEGV
```

Result: any mDNS-advertised `_smb._tcp` / `_htsp._tcp` / `_webdav._tcp` service
that **fails to resolve** (a NAS that times out, a host that advertises then
disappears) crashes the whole app in the `AVAHI` thread. Pre-existing;
unrelated to the embedded SMB2 server work.

### Fix

Make `setting_destroy()` NULL-tolerant, symmetric with `prop_destroy()` (already
NULL-safe) — which the *same* `si_destroy()` teardown already relies on for
`si_settings`. One line, covers all three unguarded `setting_destroy` calls:

```c
void
setting_destroy(setting_t *s)
{
  if(s == NULL)
    return;
  ...
```

No successful-path caller is affected (they always pass non-NULL);
`setting_destroyp()` keeps its own separate guard.

### Verification

- Clean incremental build, WSL GCC 13 (`settings.o` recompiled, movian
  relinked); no new warnings; `git diff --check` clean.
- Root cause proven from the code path (`avahi.c:94` → `sd.c:66` →
  `settings.c:370`). A live repro needs an mDNS resolver *timeout*, which is
  environment-dependent; the guard makes the teardown safe for any
  partially-constructed `service_instance_t`.
