### PR TITLE
devtools: movian-metadata v1 — generated metadata artifact; viewdoc rewired (#98)

### DIFF
--- a/generated/movian-metadata.json
+++ b/generated/movian-metadata.json
@@ -1365,7 +1365,7 @@
           "file": "src/ui/glw/glw_view_attrib.c",
           "line": 1375
         },
-        "valueType": "string"
+        "valueType": "string|string[]"
       },
       {
         "attribConst": "GLW_ATTRIB_SPACING",
@@ -1786,6 +1786,7 @@
         "variadic": false
       },
       {
+        "condition": "#ifndef NDEBUG",
         "ctor": false,
         "dtor": false,
         "impl": "glwf_dumpdynamicstatements",
@@ -2685,11 +2686,12 @@
     ],
     "operators": [
       {
+        "anchor": "TOKEN_BOOLEAN_AND",
         "category": "boolean",
         "semantics": "Short-circuit-free boolean and/or/xor over token2bool() results -- this DSL's RPN evaluator resolves both operands before combining.",
         "source": {
           "file": "src/ui/glw/glw_view_lexer.c",
-          "line": 247
+          "line": 248
         },
         "symbols": [
           "&&",
@@ -2699,6 +2701,7 @@
         "token": "TOKEN_BOOLEAN_AND / TOKEN_BOOLEAN_OR / TOKEN_BOOLEAN_XOR"
       },
       {
+        "anchor": "TOKEN_ADD",
         "category": "arithmetic",
         "semantics": "Numeric arithmetic; '+' is overloaded for string concatenation when either operand is a string.",
         "source": {
@@ -2715,6 +2718,7 @@
         "token": "TOKEN_ADD / TOKEN_SUB / TOKEN_MULTIPLY / TOKEN_DIVIDE / TOKEN_MODULO"
       },
       {
+        "anchor": "TOKEN_REF_ASSIGNMENT",
         "category": "assignment",
         "semantics": "Reference assignment: the right side is not resolved to a value, it stays a property reference. Assigning a bare property with ':=' creates a live prop-symlink; assigning to self/args/itemModel/parentModel/tentative passes the actual prop_t* into the setter.",
         "source": {
@@ -2727,6 +2731,7 @@
         "token": "TOKEN_REF_ASSIGNMENT"
       },
       {
+        "anchor": "TOKEN_LINK_ASSIGNMENT",
         "category": "assignment",
         "semantics": "Link assignment: always creates a one-way, continuously-live prop_link_ex() link from the right-hand property to the left. The left side may be a bare identifier inside an args/block scope, auto-created as a child prop of the current target.",
         "source": {
@@ -2739,6 +2744,7 @@
         "token": "TOKEN_LINK_ASSIGNMENT"
       },
       {
+        "anchor": "TOKEN_ASSIGNMENT",
         "category": "assignment",
         "semantics": "Normal assignment. If the right side is a property path it is resolved through a live subscription (re-evaluates whenever the underlying prop changes), unless the target attribute is flagged GLW_ATTRIB_FLAG_NO_SUBSCRIPTION (self, itemModel, parentModel, tentative).",
         "source": {
@@ -2751,11 +2757,12 @@
         "token": "TOKEN_ASSIGNMENT"
       },
       {
+        "anchor": "TOKEN_EQ",
         "category": "comparison",
         "semantics": "Numeric/string comparison via token_cmp()-style helpers; mixed int/float compares by value.",
         "source": {
           "file": "src/ui/glw/glw_view_lexer.c",
-          "line": 289
+          "line": 290
         },
         "symbols": [
           "==",
@@ -2766,11 +2773,12 @@
         "token": "TOKEN_EQ / TOKEN_NEQ / TOKEN_LT / TOKEN_GT"
       },
       {
+        "anchor": "eval_tenary",
         "category": "other",
         "semantics": "'cond ? a : b': resolves cond via token2bool(), then (unlike '??') does not eagerly resolve both branches -- pushes the unresolved chosen branch.",
         "source": {
           "file": "src/ui/glw/glw_view_eval.c",
-          "line": 1087
+          "line": 1088
         },
         "symbols": [
           "?:"
@@ -2778,6 +2786,7 @@
         "token": "TOKEN_TENARY"
       },
       {
+        "anchor": "TOKEN_COND_ASSIGNMENT",
         "category": "assignment",
         "semantics": "Conditional assignment: identical to '=', except if the resolved right-hand value is void the assignment is skipped entirely and the left side keeps its previous value.",
         "source": {
@@ -2790,11 +2799,12 @@
         "token": "TOKEN_COND_ASSIGNMENT"
       },
       {
+        "anchor": "TOKEN_NULL_COALESCE",
         "category": "other",
         "semantics": "'a ?? b': resolves a; if a is void, evaluates to b, else to a. Idiom for falling back to a default only when a prop is genuinely unset.",
         "source": {
           "file": "src/ui/glw/glw_view_lexer.c",
-          "line": 301
+          "line": 302
         },
         "symbols": [
           "??"
@@ -2802,6 +2812,7 @@
         "token": "TOKEN_NULL_COALESCE"
       },
       {
+        "anchor": "TOKEN_DEBUG_ASSIGNMENT",
         "category": "assignment",
         "semantics": "Debug assignment: functionally identical to '=' for the common case; in the direct prop-to-prop link case it passes debug=1 into prop_link_ex(), turning on subscription-debug tracing for that link.",
         "source": {
@@ -2816,6 +2827,7 @@
     ],
     "scopes": [
       {
+        "anchor": "\"args\"",
         "meaning": "Arguments passed in via the args: attribute.",
         "name": "args",
         "source": {
@@ -2824,6 +2836,7 @@
         }
       },
       {
+        "anchor": "\"clone\"",
         "meaning": "Scratch root local to one cloner()-generated clone instance.",
         "name": "clone",
         "source": {
@@ -2832,6 +2845,7 @@
         }
       },
       {
+        "anchor": "\"core\"",
         "meaning": "Global core-service props (e.g. $core.stpp, $core.popups, $core.clipboard).",
         "name": "core",
         "source": {
@@ -2840,6 +2854,7 @@
         }
       },
       {
+        "anchor": "strcmp(name, \"global\")",
         "meaning": "Prop root's absolute global tree; rarely used directly in views.",
         "name": "global",
         "source": {
@@ -2848,6 +2863,7 @@
         }
       },
       {
+        "anchor": "PROP_TAG_NAMED_ROOT",
         "meaning": "The navigator ($nav.currentpage, $nav.pages), wired in via PROP_TAG_NAMED_ROOT.",
         "name": "nav",
         "source": {
@@ -2856,6 +2872,7 @@
         }
       },
       {
+        "anchor": "\"parent\"",
         "meaning": "The enclosing scope's self, one level up -- set when a loader/widget block rebinds self.",
         "name": "parent",
         "source": {
@@ -2864,6 +2881,7 @@
         }
       },
       {
+        "anchor": "\"parentview\"",
         "meaning": "The view root one level up (companion to parent).",
         "name": "parentview",
         "source": {
@@ -2872,6 +2890,7 @@
         }
       },
       {
+        "anchor": "\"self\"",
         "meaning": "The widget/clone's own bound prop (e.g. a page, or the current clone item).",
         "name": "self",
         "source": {
@@ -2880,6 +2899,7 @@
         }
       },
       {
+        "anchor": "prop_create_root(\"ui\")",
         "meaning": "Global per-glw_root_t UI prop tree ($ui.width, $ui.aspect, $ui.keyboard, $ui.pointerVisible, ...); resolves because the prop node itself is named \"ui\", not via an explicit named-root tag.",
         "name": "ui",
         "source": {
@@ -2888,6 +2908,7 @@
         }
       },
       {
+        "anchor": "\"view\"",
         "meaning": "Per-view-file scratch root, fresh each time the .view file is loaded.",
         "name": "view",
         "source": {
@@ -3095,6 +3116,7 @@
       },
       {
         "aliases": [],
+        "condition": "#if NUM_FADERS > 0",
         "name": "fader",
         "registered": true,
         "source": {
@@ -3335,6 +3357,7 @@
       },
       {
         "aliases": [],
+        "condition": "#if NUM_STENCILERS > 0",
         "name": "stencil",
         "registered": true,
         "source": {
@@ -3436,6 +3459,6 @@
     ]
   },
   "js": {},
-  "movianRevision": "803a53a6f473e51f864b0336140a956442020b2e",
+  "movianRevision": "6042a3b5e7514f68723e81d39e5cc10ccf947517",
   "schemaVersion": 1
 }

--- a/generated/movian-metadata.json
+++ b/generated/movian-metadata.json
@@ -1,0 +1,3441 @@
+{
+  "generatedBy": "support/devtools/metadata/gen.py",
+  "glw": {
+    "attributes": [
+      {
+        "attribConst": "GLW_ATTRIB_X_SPACING",
+        "confidence": "medium",
+        "fn": null,
+        "name": "Xspacing",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1472
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_Y_SPACING",
+        "confidence": "medium",
+        "fn": null,
+        "name": "Yspacing",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1473
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_IMAGE_ADDITIVE",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "additive",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1409
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "align",
+        "noSubscription": false,
+        "setter": "set_align",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1490
+        },
+        "valueType": "enum"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_alpha",
+        "name": "alpha",
+        "noSubscription": false,
+        "setter": "set_float",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1433
+        },
+        "valueType": "float"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_ALPHA_EDGES",
+        "confidence": "medium",
+        "fn": null,
+        "name": "alphaEdges",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1469
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_ALPHA_FALLOFF",
+        "confidence": "medium",
+        "fn": null,
+        "name": "alphaFallOff",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1461
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_ALPHA_SELF",
+        "confidence": "medium",
+        "fn": null,
+        "name": "alphaSelf",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1446
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "alt",
+        "noSubscription": false,
+        "setter": "set_alt",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1376
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": "GLW2_ALWAYS_GRAB_KNOB",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "alwaysGrabKnob",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1389
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_ANGLE",
+        "confidence": "medium",
+        "fn": null,
+        "name": "angle",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1451
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "args",
+        "noSubscription": false,
+        "setter": "set_args",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1493
+        },
+        "valueType": "block"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_ASPECT",
+        "confidence": "medium",
+        "fn": null,
+        "name": "aspect",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1460
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_IMAGE_SET_ASPECT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "aspectConstraint",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1408
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_AUDIO_VOLUME",
+        "confidence": "medium",
+        "fn": null,
+        "name": "audioVolume",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1459
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW2_AUTO_FOCUS_LIMIT",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "autoFocusLimit",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1395
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_AUTOREFOCUSABLE",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "autoRefocusable",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1385
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_AUTOFADE",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "autofade",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1392
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_AUTOHIDE",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "autohide",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1390
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BEVEL_BOTTOM",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "bevelBottom",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1407
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BEVEL_LEFT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "bevelLeft",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1404
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BEVEL_RIGHT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "bevelRight",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1406
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BEVEL_TOP",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "bevelTop",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1405
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_BACKGROUND_ALPHA",
+        "confidence": "medium",
+        "fn": null,
+        "name": "bgalpha",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1447
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_BACKGROUND_COLOR",
+        "confidence": "high",
+        "fn": null,
+        "name": "bgcolor",
+        "noSubscription": false,
+        "setter": "set_float3",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1481
+        },
+        "valueType": "vec3"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_blur",
+        "name": "blur",
+        "noSubscription": false,
+        "setter": "set_float",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1434
+        },
+        "valueType": "float"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_BLUR_FALLOFF",
+        "confidence": "medium",
+        "fn": null,
+        "name": "blurFallOff",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1462
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GTB_BOLD",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "bold",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1422
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_BORDER",
+        "confidence": "high",
+        "fn": null,
+        "name": "border",
+        "noSubscription": false,
+        "setter": "set_int16_4",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1487
+        },
+        "valueType": "vec4i"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BORDER_ONLY",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "borderOnly",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1410
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "caption",
+        "noSubscription": false,
+        "setter": "set_caption",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1372
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_CENTER",
+        "confidence": "medium",
+        "fn": null,
+        "name": "center",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1458
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_CHILD_ASPECT",
+        "confidence": "medium",
+        "fn": null,
+        "name": "childAspect",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1457
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_CHILD_SCALE",
+        "confidence": "medium",
+        "fn": null,
+        "name": "childScale",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1464
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_CHILD_TILES_X",
+        "confidence": "medium",
+        "fn": null,
+        "name": "childTilesX",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1466
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_CHILD_TILES_Y",
+        "confidence": "medium",
+        "fn": null,
+        "name": "childTilesY",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1467
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW2_CLICKABLE",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "clickable",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1398
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_RGB",
+        "confidence": "high",
+        "fn": null,
+        "name": "color",
+        "noSubscription": false,
+        "setter": "set_float3",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1476
+        },
+        "valueType": "vec3"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_COLOR1",
+        "confidence": "high",
+        "fn": null,
+        "name": "color1",
+        "noSubscription": false,
+        "setter": "set_float3",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1479
+        },
+        "valueType": "vec3"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_COLOR2",
+        "confidence": "high",
+        "fn": null,
+        "name": "color2",
+        "noSubscription": false,
+        "setter": "set_float3",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1480
+        },
+        "valueType": "vec3"
+      },
+      {
+        "attribConst": "GLW_IMAGE_CORNER_BOTTOMLEFT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "cornerBottomLeft",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1416
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_CORNER_BOTTOMRIGHT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "cornerBottomRight",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1417
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_RADIUS",
+        "confidence": "medium",
+        "fn": null,
+        "name": "cornerRadius",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1474
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_IMAGE_CORNER_TOPLEFT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "cornerTopLeft",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1414
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_CORNER_TOPRIGHT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "cornerTopRight",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1415
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_CURSOR",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "cursor",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1396
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_DEBUG",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "debug",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1382
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "set_description_rstr",
+        "name": "description",
+        "noSubscription": false,
+        "setter": "set_rstring",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1370
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": "GTB_DIR_REQUEST",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "dirRequest",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1428
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_divider",
+        "name": "divider",
+        "noSubscription": false,
+        "setter": "set_int",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1439
+        },
+        "valueType": "int"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "effect",
+        "noSubscription": false,
+        "setter": "set_transition_effect",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1491
+        },
+        "valueType": "enum"
+      },
+      {
+        "attribConst": "GTB_ELLIPSIZE",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "ellipsize",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1421
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_ENABLED",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "enabled",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1388
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_EXPANSION",
+        "confidence": "medium",
+        "fn": null,
+        "name": "expansion",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1452
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW2_EXPEDITE_SUBSCRIPTIONS",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "expediteSubscriptions",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1393
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_FHP_SPILL",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "fhpSpill",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1399
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GTB_FILE_REQUEST",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "fileRequest",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1427
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_FILL",
+        "confidence": "medium",
+        "fn": null,
+        "name": "fill",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1463
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW2_CONSTRAINT_IGNORE_W",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "filterConstraintWeight",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1381
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_CONSTRAINT_IGNORE_X",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "filterConstraintX",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1379
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_CONSTRAINT_IGNORE_Y",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "filterConstraintY",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1380
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_IMAGE_FIXED_SIZE",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "fixedSize",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1403
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_FOCUS_ON_CLICK",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "focusOnClick",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1384
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_focus_weight",
+        "name": "focusable",
+        "noSubscription": false,
+        "setter": "set_float",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1436
+        },
+        "valueType": "float"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "font",
+        "noSubscription": false,
+        "setter": "set_font",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1373
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "fragmentShader",
+        "noSubscription": false,
+        "setter": "set_fs",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1374
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_height",
+        "name": "height",
+        "noSubscription": false,
+        "setter": "set_int",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1437
+        },
+        "valueType": "int"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "hidden",
+        "noSubscription": false,
+        "setter": "mod_hidden",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1378
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_HOMOGENOUS",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "homogenous",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1387
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "set_how_rstr",
+        "name": "how",
+        "noSubscription": false,
+        "setter": "set_rstring",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1369
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "set_id_rstr",
+        "name": "id",
+        "noSubscription": false,
+        "setter": "set_rstring",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1368
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": "GTB_ITALIC",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "italic",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1423
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_PROP_ITEM_MODEL",
+        "confidence": "high",
+        "fn": null,
+        "name": "itemModel",
+        "noSubscription": true,
+        "setter": "set_propref",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1496
+        },
+        "valueType": "propref"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BORDER_LEFT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "leftBorder",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1411
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "margin",
+        "noSubscription": false,
+        "setter": "set_margin",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1488
+        },
+        "valueType": "vec4i"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_INT_MAX",
+        "confidence": "medium",
+        "fn": null,
+        "name": "max",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1454
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_MAX_WIDTH",
+        "confidence": "medium",
+        "fn": null,
+        "name": "maxWidth",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1445
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_MAX_LINES",
+        "confidence": "medium",
+        "fn": null,
+        "name": "maxlines",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1442
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_INT_MIN",
+        "confidence": "medium",
+        "fn": null,
+        "name": "min",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1453
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW2_NAV_FOCUSABLE",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "navFocusable",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1386
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_POSITIONAL_NAVIGATION",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "navPositional",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1397
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_NAV_WRAP",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "navWrap",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1394
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_VIDEO_NO_AUDIO",
+        "confidence": "high",
+        "fn": "mod_video_flags",
+        "name": "noAudio",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1431
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_NO_INITIAL_TRANS",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "noInitialTransform",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1383
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GTB_OSK_PASSWORD",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "oskPassword",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1426
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GTB_OUTLINE",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "outline",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1424
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_PADDING",
+        "confidence": "high",
+        "fn": null,
+        "name": "padding",
+        "noSubscription": false,
+        "setter": "set_int16_4",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1486
+        },
+        "valueType": "vec4i"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_PROP_PARENT_MODEL",
+        "confidence": "high",
+        "fn": null,
+        "name": "parentModel",
+        "noSubscription": true,
+        "setter": "set_propref",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1498
+        },
+        "valueType": "propref"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "set_parent_url_rstr",
+        "name": "parentUrl",
+        "noSubscription": false,
+        "setter": "set_rstring",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1371
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": "GTB_PASSWORD",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "password",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1420
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GTB_PERMANENT_CURSOR",
+        "confidence": "high",
+        "fn": "mod_text_flags",
+        "name": "permanentCursor",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1425
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_PLANE",
+        "confidence": "high",
+        "fn": null,
+        "name": "plane",
+        "noSubscription": false,
+        "setter": "set_float4",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1484
+        },
+        "valueType": "vec4"
+      },
+      {
+        "attribConst": "GLW_VIDEO_PRIMARY",
+        "confidence": "high",
+        "fn": "mod_video_flags",
+        "name": "primary",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1430
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_PRIORITY",
+        "confidence": "medium",
+        "fn": null,
+        "name": "priority",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1470
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_IMAGE_BORDER_RIGHT",
+        "confidence": "high",
+        "fn": "mod_img_flags",
+        "name": "rightBorder",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1412
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_ROTATION",
+        "confidence": "high",
+        "fn": null,
+        "name": "rotation",
+        "noSubscription": false,
+        "setter": "set_float4",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1483
+        },
+        "valueType": "vec4"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_SATURATION",
+        "confidence": "medium",
+        "fn": null,
+        "name": "saturation",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1448
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_SCALING",
+        "confidence": "high",
+        "fn": null,
+        "name": "scaling",
+        "noSubscription": false,
+        "setter": "set_float3",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1478
+        },
+        "valueType": "vec3"
+      },
+      {
+        "attribConst": "GLW2_SELECT_ON_FOCUS",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "selectOnFocus",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1400
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW2_SELECT_ON_HOVER",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "selectOnHover",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1401
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_PROP_SELF",
+        "confidence": "high",
+        "fn": null,
+        "name": "self",
+        "noSubscription": true,
+        "setter": "set_propref",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1494
+        },
+        "valueType": "propref"
+      },
+      {
+        "attribConst": "GLW2_SHADOW",
+        "confidence": "high",
+        "fn": "mod_flags2",
+        "name": "shadow",
+        "noSubscription": false,
+        "setter": "mod_flag",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1391
+        },
+        "valueType": "bool"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_SIZE",
+        "confidence": "medium",
+        "fn": null,
+        "name": "size",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1444
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_SIZE_SCALE",
+        "confidence": "medium",
+        "fn": null,
+        "name": "sizeScale",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1443
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "source",
+        "noSubscription": false,
+        "setter": "set_source",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1375
+        },
+        "valueType": "string"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_SPACING",
+        "confidence": "medium",
+        "fn": null,
+        "name": "spacing",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1471
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_INT_STEP",
+        "confidence": "medium",
+        "fn": null,
+        "name": "step",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1455
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": null,
+        "name": "style",
+        "noSubscription": false,
+        "setter": "set_style",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1366
+        },
+        "valueType": "style"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_TENTATIVE_VALUE",
+        "confidence": "high",
+        "fn": null,
+        "name": "tentative",
+        "noSubscription": true,
+        "setter": "set_propref",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1500
+        },
+        "valueType": "propref"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_TIME",
+        "confidence": "medium",
+        "fn": null,
+        "name": "time",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1449
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_TRANSITION_TIME",
+        "confidence": "medium",
+        "fn": null,
+        "name": "transitionTime",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1450
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_TRANSLATION",
+        "confidence": "high",
+        "fn": null,
+        "name": "translation",
+        "noSubscription": false,
+        "setter": "set_float3",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1477
+        },
+        "valueType": "vec3"
+      },
+      {
+        "attribConst": "GLW_ATTRIB_VALUE",
+        "confidence": "medium",
+        "fn": null,
+        "name": "value",
+        "noSubscription": false,
+        "setter": "set_number",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1456
+        },
+        "valueType": "number"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_weight",
+        "name": "weight",
+        "noSubscription": false,
+        "setter": "set_float",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1435
+        },
+        "valueType": "float"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_width",
+        "name": "width",
+        "noSubscription": false,
+        "setter": "set_int",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1438
+        },
+        "valueType": "int"
+      },
+      {
+        "attribConst": null,
+        "confidence": "high",
+        "fn": "glw_set_zoffset",
+        "name": "zoffset",
+        "noSubscription": false,
+        "setter": "set_int",
+        "source": {
+          "file": "src/ui/glw/glw_view_attrib.c",
+          "line": 1440
+        },
+        "valueType": "int"
+      }
+    ],
+    "functions": [
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_rgb_to_string",
+        "name": "RGBToString",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7372
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_pluralise",
+        "name": "_pl",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7353
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_abs",
+        "name": "abs",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7363
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_bind",
+        "name": "bind",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7323
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_browse",
+        "name": "browse",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7330
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_canScroll",
+        "name": "canScroll",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7327
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_canSelectNext",
+        "name": "canSelectNext",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7356
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_canSelectPrev",
+        "name": "canSelectPrevious",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7357
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_changed",
+        "name": "changed",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7303
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_clamp",
+        "name": "clamp",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7350
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_cloneIndex",
+        "name": "cloneIndex",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7362
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_cloner",
+        "name": "cloner",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7279
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_coreAttach",
+        "name": "coreAttach",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7280
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_count",
+        "name": "count",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7341
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_createchild",
+        "name": "createChild",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7313
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_currentEvent",
+        "name": "currentEvent",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7300
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_delay",
+        "name": "delay",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7335
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_delete",
+        "name": "delete",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7314
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_deliverEvent",
+        "name": "deliverEvent",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7298
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_deliverRef",
+        "name": "deliverRef",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7299
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_delta",
+        "name": "delta",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7324
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_dumpdynamicstatements",
+        "name": "dumpDynamicStatements",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7375
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_enqueueTrack",
+        "name": "enqueuetrack",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7291
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_event",
+        "name": "event",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7295
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_eventWithProp",
+        "name": "eventWithProp",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7368
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_fireEvent",
+        "name": "fireEvent",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7294
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_fmt",
+        "name": "fmt",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7352
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_focus",
+        "name": "focus",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7366
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_focusedChild",
+        "name": "focusedChild",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7319
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_focusedClone",
+        "name": "focusedClone",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7320
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_focusedIndex",
+        "name": "focusedIndex",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7321
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_getCaption",
+        "name": "getCaption",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7322
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_getHeight",
+        "name": "getHeight",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7348
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_getLayer",
+        "name": "getLayer",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7346
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_getWidth",
+        "name": "getWidth",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7347
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_iir",
+        "name": "iir",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7304
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_inject_events",
+        "name": "injectEventsFrom",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7371
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_int",
+        "name": "int",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7349
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isError",
+        "name": "isError",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7338
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isFocused",
+        "name": "isFocused",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7315
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isHovered",
+        "name": "isHovered",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7317
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isLink",
+        "name": "isLink",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7331
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isLoaded",
+        "name": "isLoaded",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7337
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isLoading",
+        "name": "isLoading",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7336
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isFocused",
+        "name": "isNavFocused",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7316
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isPreloaded",
+        "name": "isPreloaded",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7326
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isPressed",
+        "name": "isPressed",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7318
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isset",
+        "name": "isSet",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7308
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isVisible",
+        "name": "isVisible",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7325
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_isvoid",
+        "name": "isVoid",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7309
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_join",
+        "name": "join",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7351
+        },
+        "variadic": true
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_lookup",
+        "name": "lookup",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7370
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_makeUri",
+        "name": "makeUri",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7355
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_monotime",
+        "name": "monotime",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7334
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_multiopt",
+        "name": "multiopt",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7354
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_navOpen",
+        "name": "navOpen",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7289
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_newstyle",
+        "name": "newstyle",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7282
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_onEvent",
+        "name": "onEvent",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7288
+        },
+        "variadic": true
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_onInactivity",
+        "name": "onInactivity",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7302
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_playTrackFromSource",
+        "name": "playTrackFromSource",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7290
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_primary_color",
+        "name": "primaryColor",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7339
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_propGrouper",
+        "name": "propGrouper",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7343
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_propName",
+        "name": "propName",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7364
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_propSelect",
+        "name": "propSelect",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7365
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_propSorter",
+        "name": "propSorter",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7344
+        },
+        "variadic": true
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_propWindow",
+        "name": "propWindow",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7345
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_rand",
+        "name": "rand",
+        "nargs": 0,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7359
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_scurve",
+        "name": "scurve",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7305
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_select",
+        "name": "select",
+        "nargs": 3,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7328
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_selectAudioTrack",
+        "name": "selectAudioTrack",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7292
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_selectSubtitleTrack",
+        "name": "selectSubtitleTrack",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7293
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_selectedElement",
+        "name": "selectedElement",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7360
+        },
+        "variadic": false
+      },
+      {
+        "ctor": true,
+        "dtor": true,
+        "impl": "glwf_set",
+        "name": "set",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7361
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_setDefaultFont",
+        "name": "setDefaultFont",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7358
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_sin",
+        "name": "sin",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7332
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_sinewave",
+        "name": "sinewave",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7333
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_space",
+        "name": "space",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7283
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_strftime",
+        "name": "strftime",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7307
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_style",
+        "name": "style",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7281
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_suggestFocus",
+        "name": "suggestFocus",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7340
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_targetedEvent",
+        "name": "targetedEvent",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7297
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_timeAgo",
+        "name": "timeAgo",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7369
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_toggle",
+        "name": "toggle",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7367
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_trace",
+        "name": "trace",
+        "nargs": 2,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7329
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_translate",
+        "name": "translate",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7306
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_value2duration",
+        "name": "value2duration",
+        "nargs": -1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7310
+        },
+        "variadic": true
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_value2quantity",
+        "name": "value2quantity",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7312
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_value2size",
+        "name": "value2size",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7311
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_vectorize",
+        "name": "vectorize",
+        "nargs": 1,
+        "preproc": false,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7342
+        },
+        "variadic": false
+      },
+      {
+        "ctor": false,
+        "dtor": false,
+        "impl": "glwf_widget",
+        "name": "widget",
+        "nargs": 1,
+        "preproc": true,
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 7278
+        },
+        "variadic": false
+      }
+    ],
+    "operators": [
+      {
+        "category": "boolean",
+        "semantics": "Short-circuit-free boolean and/or/xor over token2bool() results -- this DSL's RPN evaluator resolves both operands before combining.",
+        "source": {
+          "file": "src/ui/glw/glw_view_lexer.c",
+          "line": 247
+        },
+        "symbols": [
+          "&&",
+          "||",
+          "^^"
+        ],
+        "token": "TOKEN_BOOLEAN_AND / TOKEN_BOOLEAN_OR / TOKEN_BOOLEAN_XOR"
+      },
+      {
+        "category": "arithmetic",
+        "semantics": "Numeric arithmetic; '+' is overloaded for string concatenation when either operand is a string.",
+        "source": {
+          "file": "src/ui/glw/glw_view_lexer.c",
+          "line": 142
+        },
+        "symbols": [
+          "+",
+          "-",
+          "*",
+          "/",
+          "%"
+        ],
+        "token": "TOKEN_ADD / TOKEN_SUB / TOKEN_MULTIPLY / TOKEN_DIVIDE / TOKEN_MODULO"
+      },
+      {
+        "category": "assignment",
+        "semantics": "Reference assignment: the right side is not resolved to a value, it stays a property reference. Assigning a bare property with ':=' creates a live prop-symlink; assigning to self/args/itemModel/parentModel/tentative passes the actual prop_t* into the setter.",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 2758
+        },
+        "symbols": [
+          ":="
+        ],
+        "token": "TOKEN_REF_ASSIGNMENT"
+      },
+      {
+        "category": "assignment",
+        "semantics": "Link assignment: always creates a one-way, continuously-live prop_link_ex() link from the right-hand property to the left. The left side may be a bare identifier inside an args/block scope, auto-created as a child prop of the current target.",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 2763
+        },
+        "symbols": [
+          "<-"
+        ],
+        "token": "TOKEN_LINK_ASSIGNMENT"
+      },
+      {
+        "category": "assignment",
+        "semantics": "Normal assignment. If the right side is a property path it is resolved through a live subscription (re-evaluates whenever the underlying prop changes), unless the target attribute is flagged GLW_ATTRIB_FLAG_NO_SUBSCRIPTION (self, itemModel, parentModel, tentative).",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 2743
+        },
+        "symbols": [
+          "="
+        ],
+        "token": "TOKEN_ASSIGNMENT"
+      },
+      {
+        "category": "comparison",
+        "semantics": "Numeric/string comparison via token_cmp()-style helpers; mixed int/float compares by value.",
+        "source": {
+          "file": "src/ui/glw/glw_view_lexer.c",
+          "line": 289
+        },
+        "symbols": [
+          "==",
+          "!=",
+          "<",
+          ">"
+        ],
+        "token": "TOKEN_EQ / TOKEN_NEQ / TOKEN_LT / TOKEN_GT"
+      },
+      {
+        "category": "other",
+        "semantics": "'cond ? a : b': resolves cond via token2bool(), then (unlike '??') does not eagerly resolve both branches -- pushes the unresolved chosen branch.",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 1087
+        },
+        "symbols": [
+          "?:"
+        ],
+        "token": "TOKEN_TENARY"
+      },
+      {
+        "category": "assignment",
+        "semantics": "Conditional assignment: identical to '=', except if the resolved right-hand value is void the assignment is skipped entirely and the left side keeps its previous value.",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 2748
+        },
+        "symbols": [
+          "?="
+        ],
+        "token": "TOKEN_COND_ASSIGNMENT"
+      },
+      {
+        "category": "other",
+        "semantics": "'a ?? b': resolves a; if a is void, evaluates to b, else to a. Idiom for falling back to a default only when a prop is genuinely unset.",
+        "source": {
+          "file": "src/ui/glw/glw_view_lexer.c",
+          "line": 301
+        },
+        "symbols": [
+          "??"
+        ],
+        "token": "TOKEN_NULL_COALESCE"
+      },
+      {
+        "category": "assignment",
+        "semantics": "Debug assignment: functionally identical to '=' for the common case; in the direct prop-to-prop link case it passes debug=1 into prop_link_ex(), turning on subscription-debug tracing for that link.",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 2753
+        },
+        "symbols": [
+          "_=_"
+        ],
+        "token": "TOKEN_DEBUG_ASSIGNMENT"
+      }
+    ],
+    "scopes": [
+      {
+        "meaning": "Arguments passed in via the args: attribute.",
+        "name": "args",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 57
+        }
+      },
+      {
+        "meaning": "Scratch root local to one cloner()-generated clone instance.",
+        "name": "clone",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 58
+        }
+      },
+      {
+        "meaning": "Global core-service props (e.g. $core.stpp, $core.popups, $core.clipboard).",
+        "name": "core",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 59
+        }
+      },
+      {
+        "meaning": "Prop root's absolute global tree; rarely used directly in views.",
+        "name": "global",
+        "source": {
+          "file": "src/prop/prop_core.c",
+          "line": 2769
+        }
+      },
+      {
+        "meaning": "The navigator ($nav.currentpage, $nav.pages), wired in via PROP_TAG_NAMED_ROOT.",
+        "name": "nav",
+        "source": {
+          "file": "src/ui/glw/glw_view_eval.c",
+          "line": 831
+        }
+      },
+      {
+        "meaning": "The enclosing scope's self, one level up -- set when a loader/widget block rebinds self.",
+        "name": "parent",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 55
+        }
+      },
+      {
+        "meaning": "The view root one level up (companion to parent).",
+        "name": "parentview",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 60
+        }
+      },
+      {
+        "meaning": "The widget/clone's own bound prop (e.g. a page, or the current clone item).",
+        "name": "self",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 54
+        }
+      },
+      {
+        "meaning": "Global per-glw_root_t UI prop tree ($ui.width, $ui.aspect, $ui.keyboard, $ui.pointerVisible, ...); resolves because the prop node itself is named \"ui\", not via an explicit named-root tag.",
+        "name": "ui",
+        "source": {
+          "file": "src/ui/glw/glw_x11.c",
+          "line": 1431
+        }
+      },
+      {
+        "meaning": "Per-view-file scratch root, fresh each time the .view file is loaded.",
+        "name": "view",
+        "source": {
+          "file": "src/ui/glw/glw_scope.c",
+          "line": 56
+        }
+      }
+    ],
+    "widgets": [
+      {
+        "aliases": [],
+        "name": "array",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_array.c",
+          "line": 750
+        },
+        "symbol": "glw_array"
+      },
+      {
+        "aliases": [],
+        "name": "backdrop",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_image.c",
+          "line": 1559
+        },
+        "symbol": "glw_backdrop"
+      },
+      {
+        "aliases": [],
+        "name": "bar",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_bar.c",
+          "line": 181
+        },
+        "symbol": "glw_bar"
+      },
+      {
+        "aliases": [],
+        "name": "bloom",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_bloom.c",
+          "line": 298
+        },
+        "symbol": "glw_bloom"
+      },
+      {
+        "aliases": [],
+        "name": "border",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_primitives.c",
+          "line": 245
+        },
+        "symbol": "glw_border"
+      },
+      {
+        "aliases": [],
+        "name": "clip",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_clip.c",
+          "line": 153
+        },
+        "symbol": "glw_clip"
+      },
+      {
+        "aliases": [],
+        "name": "clist",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_clist.c",
+          "line": 283
+        },
+        "symbol": "glw_clist"
+      },
+      {
+        "aliases": [
+          "hbox"
+        ],
+        "name": "container_x",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_container.c",
+          "line": 995
+        },
+        "symbol": "glw_container_x"
+      },
+      {
+        "aliases": [
+          "vbox"
+        ],
+        "name": "container_y",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_container.c",
+          "line": 1011
+        },
+        "symbol": "glw_container_y"
+      },
+      {
+        "aliases": [
+          "zbox"
+        ],
+        "name": "container_z",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_container.c",
+          "line": 1027
+        },
+        "symbol": "glw_container_z"
+      },
+      {
+        "aliases": [],
+        "name": "coverflow",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_coverflow.c",
+          "line": 234
+        },
+        "symbol": "glw_coverflow"
+      },
+      {
+        "aliases": [],
+        "name": "cube",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_cube.c",
+          "line": 102
+        },
+        "symbol": "glw_cube"
+      },
+      {
+        "aliases": [],
+        "name": "cursor",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_cursor.c",
+          "line": 244
+        },
+        "symbol": "glw_cursor"
+      },
+      {
+        "aliases": [],
+        "name": "deck",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_deck.c",
+          "line": 493
+        },
+        "symbol": "glw_deck"
+      },
+      {
+        "aliases": [],
+        "name": "detachable",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_detachable.c",
+          "line": 112
+        },
+        "symbol": "glw_detachable"
+      },
+      {
+        "aliases": [],
+        "name": "displacement",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_displacement.c",
+          "line": 201
+        },
+        "symbol": "glw_displacement"
+      },
+      {
+        "aliases": [],
+        "name": "dummy",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_dummy.c",
+          "line": 46
+        },
+        "symbol": "glw_dummy"
+      },
+      {
+        "aliases": [],
+        "name": "expander_x",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_expander.c",
+          "line": 217
+        },
+        "symbol": "glw_expander_x"
+      },
+      {
+        "aliases": [],
+        "name": "expander_y",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_expander.c",
+          "line": 228
+        },
+        "symbol": "glw_expander_y"
+      },
+      {
+        "aliases": [],
+        "name": "fader",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_clip.c",
+          "line": 292
+        },
+        "symbol": "glw_fader"
+      },
+      {
+        "aliases": [],
+        "name": "flicker",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_flicker.c",
+          "line": 98
+        },
+        "symbol": "glw_flicker"
+      },
+      {
+        "aliases": [],
+        "name": "freefloat",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_freefloat.c",
+          "line": 276
+        },
+        "symbol": "glw_freefloat"
+      },
+      {
+        "aliases": [],
+        "name": "frontdrop",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_image.c",
+          "line": 1590
+        },
+        "symbol": "glw_frontdrop"
+      },
+      {
+        "aliases": [],
+        "name": "icon",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_image.c",
+          "line": 1528
+        },
+        "symbol": "glw_icon"
+      },
+      {
+        "aliases": [],
+        "name": "image",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_image.c",
+          "line": 1498
+        },
+        "symbol": "glw_image"
+      },
+      {
+        "aliases": [],
+        "name": "keyintercept",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_keyintercept.c",
+          "line": 224
+        },
+        "symbol": "glw_keyintercept"
+      },
+      {
+        "aliases": [],
+        "name": "label",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_text_bitmap.c",
+          "line": 1514
+        },
+        "symbol": "glw_label"
+      },
+      {
+        "aliases": [],
+        "name": "layer",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_layer.c",
+          "line": 175
+        },
+        "symbol": "glw_layer"
+      },
+      {
+        "aliases": [],
+        "name": "linebox",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_primitives.c",
+          "line": 288
+        },
+        "symbol": "glw_linebox"
+      },
+      {
+        "aliases": [],
+        "name": "list_x",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_list.c",
+          "line": 747
+        },
+        "symbol": "glw_list_x"
+      },
+      {
+        "aliases": [],
+        "name": "list_y",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_list.c",
+          "line": 723
+        },
+        "symbol": "glw_list_y"
+      },
+      {
+        "aliases": [],
+        "name": "loader",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_view_loader.c",
+          "line": 411
+        },
+        "symbol": "glw_view_loader"
+      },
+      {
+        "aliases": [],
+        "name": "mirror",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_mirror.c",
+          "line": 92
+        },
+        "symbol": "glw_mirror"
+      },
+      {
+        "aliases": [],
+        "name": "playfield",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_playfield.c",
+          "line": 327
+        },
+        "symbol": "glw_playfield"
+      },
+      {
+        "aliases": [],
+        "name": "popup",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_popup.c",
+          "line": 192
+        },
+        "symbol": "glw_popup"
+      },
+      {
+        "aliases": [],
+        "name": "quad",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_primitives.c",
+          "line": 232
+        },
+        "symbol": "glw_quad"
+      },
+      {
+        "aliases": [],
+        "name": "repeatedimage",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_image.c",
+          "line": 1621
+        },
+        "symbol": "glw_repeatedimage"
+      },
+      {
+        "aliases": [],
+        "name": "resizer",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_resizer.c",
+          "line": 119
+        },
+        "symbol": "glw_resizer"
+      },
+      {
+        "aliases": [],
+        "name": "rotator",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_rotator.c",
+          "line": 70
+        },
+        "symbol": "glw_rotator"
+      },
+      {
+        "aliases": [],
+        "name": "segway",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_segway.c",
+          "line": 151
+        },
+        "symbol": "glw_segway"
+      },
+      {
+        "aliases": [],
+        "name": "slider_x",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_slider.c",
+          "line": 706
+        },
+        "symbol": "glw_slider_x"
+      },
+      {
+        "aliases": [],
+        "name": "slider_y",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_slider.c",
+          "line": 723
+        },
+        "symbol": "glw_slider_y"
+      },
+      {
+        "aliases": [],
+        "name": "slideshow",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_slideshow.c",
+          "line": 325
+        },
+        "symbol": "glw_slideshow"
+      },
+      {
+        "aliases": [],
+        "name": "stencil",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_clip.c",
+          "line": 495
+        },
+        "symbol": "glw_stencil"
+      },
+      {
+        "aliases": [],
+        "name": "style",
+        "registered": false,
+        "source": {
+          "file": "src/ui/glw/glw_style.c",
+          "line": 1026
+        },
+        "symbol": "glw_style"
+      },
+      {
+        "aliases": [],
+        "name": "table",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_container.c",
+          "line": 1037
+        },
+        "symbol": "glw_table"
+      },
+      {
+        "aliases": [],
+        "name": "text",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_text_bitmap.c",
+          "line": 1544
+        },
+        "symbol": "glw_text"
+      },
+      {
+        "aliases": [],
+        "name": "throbber",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_throbber.c",
+          "line": 271
+        },
+        "symbol": "glw_throbber"
+      },
+      {
+        "aliases": [],
+        "name": "throbber3d",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_throbber.c",
+          "line": 141
+        },
+        "symbol": "glw_throbber3d"
+      },
+      {
+        "aliases": [],
+        "name": "throbbertri",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_throbber.c",
+          "line": 385
+        },
+        "symbol": "glw_throbber_tri"
+      },
+      {
+        "aliases": [],
+        "name": "underscan",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_underscan.c",
+          "line": 80
+        },
+        "symbol": "glw_underscan"
+      },
+      {
+        "aliases": [],
+        "name": "video",
+        "registered": true,
+        "source": {
+          "file": "src/ui/glw/glw_video_common.c",
+          "line": 1007
+        },
+        "symbol": "glw_video"
+      },
+      {
+        "aliases": [],
+        "name": "view",
+        "registered": false,
+        "source": {
+          "file": "src/ui/glw/glw_view.c",
+          "line": 98
+        },
+        "symbol": "glw_view"
+      }
+    ]
+  },
+  "js": {},
+  "movianRevision": "803a53a6f473e51f864b0336140a956442020b2e",
+  "schemaVersion": 1
+}

--- a/support/devtools/mdevlib/cli.py
+++ b/support/devtools/mdevlib/cli.py
@@ -702,17 +702,20 @@ def build_parser() -> argparse.ArgumentParser:
         "viewdoc",
         help="diff the GLW attribute/function tables against the "
              "movian-view-design reference docs (issue #88)",
-        description="Extracts attribute names from glw_view_attrib.c's "
-                    "attribtab[] and expression-function names from "
-                    "glw_view_eval.c's funcvec[], and (with --check) diffs "
-                    "them against the names documented in the "
-                    "movian-view-design skill's glw-widget-catalog.md / "
-                    "glw-view-language.md. Reports missing-from-doc "
-                    "(in source, undocumented) and gone-from-source "
-                    "(documented, not implemented); exit 1 on any drift. "
-                    "Without --check, dumps the source-side inventories.")
+        description="Reads attribute and expression-function names from "
+                    "generated/movian-metadata.json's glw.attributes / "
+                    "glw.functions (issue #98's generated artifact -- run "
+                    "support/devtools/metadata/gen.py to (re)build it from "
+                    "glw_view_attrib.c's attribtab[] / glw_view_eval.c's "
+                    "funcvec[]), and (with --check) diffs them against the "
+                    "names documented in the movian-view-design skill's "
+                    "glw-widget-catalog.md / glw-view-language.md. Reports "
+                    "missing-from-doc (in the artifact, undocumented) and "
+                    "gone-from-source (documented, not in the artifact); "
+                    "exit 1 on any drift. Without --check, dumps the "
+                    "artifact-side inventories.")
     viewdoc_.add_argument("--check", action="store_true",
-                          help="diff source tables against the docs; "
+                          help="diff artifact tables against the docs; "
                                "exit 1 on any drift")
     viewdoc_.add_argument("--json", action="store_true",
                           help="machine-readable JSON output")

--- a/support/devtools/mdevlib/viewdoc.py
+++ b/support/devtools/mdevlib/viewdoc.py
@@ -1,45 +1,45 @@
-"""viewdoc -- drift detector between the GLW C source tables and the
-movian-view-design skill's reference docs (issue #88).
+"""viewdoc -- drift detector between the movian-metadata artifact and the
+movian-view-design skill's reference docs (issue #88, rewired onto the
+artifact by issue #98).
 
-Compares, by name only (no C parsing beyond the two tables' regular
-`{"name", ...}` shape):
+Compares, by name only:
 
-- attribute names in glw_view_attrib.c's `attribtab[]`
+- attribute names in `generated/movian-metadata.json`'s `glw.attributes`
+  (itself scanned from glw_view_attrib.c's `attribtab[]` by
+  `support/devtools/metadata/gen.py`)
   vs names documented in the widget catalog's "Global attributes" table
   (.claude/skills/movian-view-design/references/glw-widget-catalog.md);
-- expression-function names in glw_view_eval.c's `funcvec[]`
+- expression-function names in the artifact's `glw.functions`
+  (scanned from glw_view_eval.c's `funcvec[]`)
   vs names documented in the language reference's function table
   (.claude/skills/movian-view-design/references/glw-view-language.md).
 
 Reports two drift directions per table:
-- missing-from-doc: in the source table, absent from the doc
+- missing-from-doc: in the artifact, absent from the doc
   (someone added an attribute/function without documenting it);
-- gone-from-source: documented, absent from the source table
-  (the doc claims something this tree does not implement).
+- gone-from-source: documented, absent from the artifact
+  (the doc claims something this tree does not implement, OR the
+  artifact is stale -- run `support/devtools/metadata/gen.py --check`
+  first to rule that out; this module trusts the committed artifact,
+  it does not re-scan the C source itself).
 
 Exit 0 only when both directions are empty for both tables.
 """
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
 from .harness import REPO_ROOT, MdevError
 
-ATTRIB_C = REPO_ROOT / "src" / "ui" / "glw" / "glw_view_attrib.c"
-EVAL_C = REPO_ROOT / "src" / "ui" / "glw" / "glw_view_eval.c"
+METADATA_ARTIFACT = REPO_ROOT / "generated" / "movian-metadata.json"
 
 REFS_DIR = (REPO_ROOT / ".claude" / "skills" / "movian-view-design"
             / "references")
 LANG_DOC = REFS_DIR / "glw-view-language.md"
 CATALOG_DOC = REFS_DIR / "glw-widget-catalog.md"
-
-ATTRIB_TABLE_DECL = "token_attrib_t attribtab[] = {"
-FUNC_TABLE_DECL = "token_func_t funcvec[] = {"
-
-# `{"name", ...}` entry inside a C table initializer.
-C_NAME_RE = re.compile(r'\{\s*"([A-Za-z0-9_]+)"')
 
 BACKTICK_RE = re.compile(r"`([^`]+)`")
 NAME_TOKEN_RE = re.compile(r"^[A-Za-z0-9_]+$")
@@ -48,23 +48,22 @@ NAME_TOKEN_RE = re.compile(r"^[A-Za-z0-9_]+$")
 CELL_SPLIT_RE = re.compile(r"(?<!\\)\|")
 
 
-def source_table_names(path: Path, table_decl: str) -> list[str]:
-    """Names from one C table: scan from the line containing `table_decl`
-    to the next line that closes the initializer (`};`)."""
-    if not path.is_file():
-        raise MdevError("source file not found: %s" % path)
-    names: list[str] = []
-    in_table = False
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not in_table:
-            if table_decl in line:
-                in_table = True
-            continue
-        if line.strip() == "};":
-            return names
-        names.extend(C_NAME_RE.findall(line))
-    raise MdevError("table %r not found (or unterminated) in %s"
-                    % (table_decl, path))
+def load_artifact() -> dict:
+    if not METADATA_ARTIFACT.is_file():
+        raise MdevError(
+            "metadata artifact not found: %s (run "
+            "support/devtools/metadata/gen.py first)" % METADATA_ARTIFACT
+        )
+    return json.loads(METADATA_ARTIFACT.read_text(encoding="utf-8"))
+
+
+def artifact_names(artifact: dict, section: str) -> list[str]:
+    """Names from one `glw.<section>` list in the metadata artifact."""
+    try:
+        records = artifact["glw"][section]
+    except KeyError:
+        raise MdevError("metadata artifact missing glw.%s" % section)
+    return [r["name"] for r in records]
 
 
 def doc_section(path: Path, heading: str) -> str:
@@ -120,8 +119,9 @@ def diff_names(source: list[str], documented: list[str]) -> dict:
 
 def run_check() -> dict:
     """Both diffs. Keys: attributes, functions; each a diff_names() dict."""
-    attrib_src = source_table_names(ATTRIB_C, ATTRIB_TABLE_DECL)
-    func_src = source_table_names(EVAL_C, FUNC_TABLE_DECL)
+    artifact = load_artifact()
+    attrib_src = artifact_names(artifact, "attributes")
+    func_src = artifact_names(artifact, "functions")
 
     # Catalog's "Global attributes" table: names live in column 1
     # ("attributes"), one comma-separated backtick span per group row.
@@ -140,10 +140,9 @@ def run_check() -> dict:
 
 
 def inventory() -> dict:
-    """Source-side name inventories (no doc comparison)."""
+    """Artifact-side name inventories (no doc comparison)."""
+    artifact = load_artifact()
     return {
-        "attributes": sorted(set(source_table_names(ATTRIB_C,
-                                                    ATTRIB_TABLE_DECL))),
-        "functions": sorted(set(source_table_names(EVAL_C,
-                                                   FUNC_TABLE_DECL))),
+        "attributes": sorted(set(artifact_names(artifact, "attributes"))),
+        "functions": sorted(set(artifact_names(artifact, "functions"))),
     }

--- a/support/devtools/metadata/curated_operators.json
+++ b/support/devtools/metadata/curated_operators.json
@@ -1,0 +1,72 @@
+[
+  {
+    "symbols": ["="],
+    "token": "TOKEN_ASSIGNMENT",
+    "category": "assignment",
+    "semantics": "Normal assignment. If the right side is a property path it is resolved through a live subscription (re-evaluates whenever the underlying prop changes), unless the target attribute is flagged GLW_ATTRIB_FLAG_NO_SUBSCRIPTION (self, itemModel, parentModel, tentative).",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2743}
+  },
+  {
+    "symbols": ["?="],
+    "token": "TOKEN_COND_ASSIGNMENT",
+    "category": "assignment",
+    "semantics": "Conditional assignment: identical to '=', except if the resolved right-hand value is void the assignment is skipped entirely and the left side keeps its previous value.",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2748}
+  },
+  {
+    "symbols": ["_=_"],
+    "token": "TOKEN_DEBUG_ASSIGNMENT",
+    "category": "assignment",
+    "semantics": "Debug assignment: functionally identical to '=' for the common case; in the direct prop-to-prop link case it passes debug=1 into prop_link_ex(), turning on subscription-debug tracing for that link.",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2753}
+  },
+  {
+    "symbols": [":="],
+    "token": "TOKEN_REF_ASSIGNMENT",
+    "category": "assignment",
+    "semantics": "Reference assignment: the right side is not resolved to a value, it stays a property reference. Assigning a bare property with ':=' creates a live prop-symlink; assigning to self/args/itemModel/parentModel/tentative passes the actual prop_t* into the setter.",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2758}
+  },
+  {
+    "symbols": ["<-"],
+    "token": "TOKEN_LINK_ASSIGNMENT",
+    "category": "assignment",
+    "semantics": "Link assignment: always creates a one-way, continuously-live prop_link_ex() link from the right-hand property to the left. The left side may be a bare identifier inside an args/block scope, auto-created as a child prop of the current target.",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2763}
+  },
+  {
+    "symbols": ["??"],
+    "token": "TOKEN_NULL_COALESCE",
+    "category": "other",
+    "semantics": "'a ?? b': resolves a; if a is void, evaluates to b, else to a. Idiom for falling back to a default only when a prop is genuinely unset.",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 301}
+  },
+  {
+    "symbols": ["?:"],
+    "token": "TOKEN_TENARY",
+    "category": "other",
+    "semantics": "'cond ? a : b': resolves cond via token2bool(), then (unlike '??') does not eagerly resolve both branches -- pushes the unresolved chosen branch.",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 1087}
+  },
+  {
+    "symbols": ["&&", "||", "^^"],
+    "token": "TOKEN_BOOLEAN_AND / TOKEN_BOOLEAN_OR / TOKEN_BOOLEAN_XOR",
+    "category": "boolean",
+    "semantics": "Short-circuit-free boolean and/or/xor over token2bool() results -- this DSL's RPN evaluator resolves both operands before combining.",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 247}
+  },
+  {
+    "symbols": ["==", "!=", "<", ">"],
+    "token": "TOKEN_EQ / TOKEN_NEQ / TOKEN_LT / TOKEN_GT",
+    "category": "comparison",
+    "semantics": "Numeric/string comparison via token_cmp()-style helpers; mixed int/float compares by value.",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 289}
+  },
+  {
+    "symbols": ["+", "-", "*", "/", "%"],
+    "token": "TOKEN_ADD / TOKEN_SUB / TOKEN_MULTIPLY / TOKEN_DIVIDE / TOKEN_MODULO",
+    "category": "arithmetic",
+    "semantics": "Numeric arithmetic; '+' is overloaded for string concatenation when either operand is a string.",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 142}
+  }
+]

--- a/support/devtools/metadata/curated_operators.json
+++ b/support/devtools/metadata/curated_operators.json
@@ -4,6 +4,7 @@
     "token": "TOKEN_ASSIGNMENT",
     "category": "assignment",
     "semantics": "Normal assignment. If the right side is a property path it is resolved through a live subscription (re-evaluates whenever the underlying prop changes), unless the target attribute is flagged GLW_ATTRIB_FLAG_NO_SUBSCRIPTION (self, itemModel, parentModel, tentative).",
+    "anchor": "TOKEN_ASSIGNMENT",
     "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2743}
   },
   {
@@ -11,6 +12,7 @@
     "token": "TOKEN_COND_ASSIGNMENT",
     "category": "assignment",
     "semantics": "Conditional assignment: identical to '=', except if the resolved right-hand value is void the assignment is skipped entirely and the left side keeps its previous value.",
+    "anchor": "TOKEN_COND_ASSIGNMENT",
     "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2748}
   },
   {
@@ -18,6 +20,7 @@
     "token": "TOKEN_DEBUG_ASSIGNMENT",
     "category": "assignment",
     "semantics": "Debug assignment: functionally identical to '=' for the common case; in the direct prop-to-prop link case it passes debug=1 into prop_link_ex(), turning on subscription-debug tracing for that link.",
+    "anchor": "TOKEN_DEBUG_ASSIGNMENT",
     "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2753}
   },
   {
@@ -25,6 +28,7 @@
     "token": "TOKEN_REF_ASSIGNMENT",
     "category": "assignment",
     "semantics": "Reference assignment: the right side is not resolved to a value, it stays a property reference. Assigning a bare property with ':=' creates a live prop-symlink; assigning to self/args/itemModel/parentModel/tentative passes the actual prop_t* into the setter.",
+    "anchor": "TOKEN_REF_ASSIGNMENT",
     "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2758}
   },
   {
@@ -32,6 +36,7 @@
     "token": "TOKEN_LINK_ASSIGNMENT",
     "category": "assignment",
     "semantics": "Link assignment: always creates a one-way, continuously-live prop_link_ex() link from the right-hand property to the left. The left side may be a bare identifier inside an args/block scope, auto-created as a child prop of the current target.",
+    "anchor": "TOKEN_LINK_ASSIGNMENT",
     "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 2763}
   },
   {
@@ -39,34 +44,39 @@
     "token": "TOKEN_NULL_COALESCE",
     "category": "other",
     "semantics": "'a ?? b': resolves a; if a is void, evaluates to b, else to a. Idiom for falling back to a default only when a prop is genuinely unset.",
-    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 301}
+    "anchor": "TOKEN_NULL_COALESCE",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 302}
   },
   {
     "symbols": ["?:"],
     "token": "TOKEN_TENARY",
     "category": "other",
     "semantics": "'cond ? a : b': resolves cond via token2bool(), then (unlike '??') does not eagerly resolve both branches -- pushes the unresolved chosen branch.",
-    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 1087}
+    "anchor": "eval_tenary",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 1088}
   },
   {
     "symbols": ["&&", "||", "^^"],
     "token": "TOKEN_BOOLEAN_AND / TOKEN_BOOLEAN_OR / TOKEN_BOOLEAN_XOR",
     "category": "boolean",
     "semantics": "Short-circuit-free boolean and/or/xor over token2bool() results -- this DSL's RPN evaluator resolves both operands before combining.",
-    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 247}
+    "anchor": "TOKEN_BOOLEAN_AND",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 248}
   },
   {
     "symbols": ["==", "!=", "<", ">"],
     "token": "TOKEN_EQ / TOKEN_NEQ / TOKEN_LT / TOKEN_GT",
     "category": "comparison",
     "semantics": "Numeric/string comparison via token_cmp()-style helpers; mixed int/float compares by value.",
-    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 289}
+    "anchor": "TOKEN_EQ",
+    "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 290}
   },
   {
     "symbols": ["+", "-", "*", "/", "%"],
     "token": "TOKEN_ADD / TOKEN_SUB / TOKEN_MULTIPLY / TOKEN_DIVIDE / TOKEN_MODULO",
     "category": "arithmetic",
     "semantics": "Numeric arithmetic; '+' is overloaded for string concatenation when either operand is a string.",
+    "anchor": "TOKEN_ADD",
     "source": {"file": "src/ui/glw/glw_view_lexer.c", "line": 142}
   }
 ]

--- a/support/devtools/metadata/curated_scopes.json
+++ b/support/devtools/metadata/curated_scopes.json
@@ -2,51 +2,61 @@
   {
     "name": "self",
     "meaning": "The widget/clone's own bound prop (e.g. a page, or the current clone item).",
+    "anchor": "\"self\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 54}
   },
   {
     "name": "parent",
     "meaning": "The enclosing scope's self, one level up -- set when a loader/widget block rebinds self.",
+    "anchor": "\"parent\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 55}
   },
   {
     "name": "view",
     "meaning": "Per-view-file scratch root, fresh each time the .view file is loaded.",
+    "anchor": "\"view\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 56}
   },
   {
     "name": "args",
     "meaning": "Arguments passed in via the args: attribute.",
+    "anchor": "\"args\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 57}
   },
   {
     "name": "clone",
     "meaning": "Scratch root local to one cloner()-generated clone instance.",
+    "anchor": "\"clone\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 58}
   },
   {
     "name": "core",
     "meaning": "Global core-service props (e.g. $core.stpp, $core.popups, $core.clipboard).",
+    "anchor": "\"core\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 59}
   },
   {
     "name": "parentview",
     "meaning": "The view root one level up (companion to parent).",
+    "anchor": "\"parentview\"",
     "source": {"file": "src/ui/glw/glw_scope.c", "line": 60}
   },
   {
     "name": "ui",
     "meaning": "Global per-glw_root_t UI prop tree ($ui.width, $ui.aspect, $ui.keyboard, $ui.pointerVisible, ...); resolves because the prop node itself is named \"ui\", not via an explicit named-root tag.",
+    "anchor": "prop_create_root(\"ui\")",
     "source": {"file": "src/ui/glw/glw_x11.c", "line": 1431}
   },
   {
     "name": "nav",
     "meaning": "The navigator ($nav.currentpage, $nav.pages), wired in via PROP_TAG_NAMED_ROOT.",
+    "anchor": "PROP_TAG_NAMED_ROOT",
     "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 831}
   },
   {
     "name": "global",
     "meaning": "Prop root's absolute global tree; rarely used directly in views.",
+    "anchor": "strcmp(name, \"global\")",
     "source": {"file": "src/prop/prop_core.c", "line": 2769}
   }
 ]

--- a/support/devtools/metadata/curated_scopes.json
+++ b/support/devtools/metadata/curated_scopes.json
@@ -1,0 +1,52 @@
+[
+  {
+    "name": "self",
+    "meaning": "The widget/clone's own bound prop (e.g. a page, or the current clone item).",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 54}
+  },
+  {
+    "name": "parent",
+    "meaning": "The enclosing scope's self, one level up -- set when a loader/widget block rebinds self.",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 55}
+  },
+  {
+    "name": "view",
+    "meaning": "Per-view-file scratch root, fresh each time the .view file is loaded.",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 56}
+  },
+  {
+    "name": "args",
+    "meaning": "Arguments passed in via the args: attribute.",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 57}
+  },
+  {
+    "name": "clone",
+    "meaning": "Scratch root local to one cloner()-generated clone instance.",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 58}
+  },
+  {
+    "name": "core",
+    "meaning": "Global core-service props (e.g. $core.stpp, $core.popups, $core.clipboard).",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 59}
+  },
+  {
+    "name": "parentview",
+    "meaning": "The view root one level up (companion to parent).",
+    "source": {"file": "src/ui/glw/glw_scope.c", "line": 60}
+  },
+  {
+    "name": "ui",
+    "meaning": "Global per-glw_root_t UI prop tree ($ui.width, $ui.aspect, $ui.keyboard, $ui.pointerVisible, ...); resolves because the prop node itself is named \"ui\", not via an explicit named-root tag.",
+    "source": {"file": "src/ui/glw/glw_x11.c", "line": 1431}
+  },
+  {
+    "name": "nav",
+    "meaning": "The navigator ($nav.currentpage, $nav.pages), wired in via PROP_TAG_NAMED_ROOT.",
+    "source": {"file": "src/ui/glw/glw_view_eval.c", "line": 831}
+  },
+  {
+    "name": "global",
+    "meaning": "Prop root's absolute global tree; rarely used directly in views.",
+    "source": {"file": "src/prop/prop_core.c", "line": 2769}
+  }
+]

--- a/support/devtools/metadata/gen.py
+++ b/support/devtools/metadata/gen.py
@@ -23,7 +23,9 @@ committed metadata artifact for the GLW view language, grown from
 
 Every record carries `source: {file, line}` pointing at the defining line
 in the C source (scanned, not hand-typed -- see the table-entry scanner
-below) or, for curated sections, a hand-verified anchor.
+below) or, for curated sections, a hand-verified anchor. Records discovered
+under a C preprocessor guard additionally carry optional `condition` text;
+active nested guards are joined with ` && `.
 
 Python 3 stdlib only. Determinism: every list is sorted by its primary key
 name, `json.dumps(..., sort_keys=True, indent=2)`, trailing newline.
@@ -73,7 +75,8 @@ GC_NAME2_RE = re.compile(r'\.gc_name2\s*=\s*"([^"]+)"')
 REGISTER_RE = re.compile(r'GLW_REGISTER_CLASS\((\w+)\)')
 
 # Value type + confidence inferred from attribtab[]'s setter function (2nd
-# field). "high" = the setter is unambiguous about the wire type; "medium"
+# field). A `|`-joined value type is a union; an `[]` suffix means a vector of
+# that type. "high" = the setter is unambiguous about the wire type; "medium"
 # = the setter is polymorphic (set_number dispatches to the target class's
 # own gc_set_int/gc_set_float switch, so the actual type is class-specific).
 VALUE_TYPE_MAP: dict[str, tuple[str, str]] = {
@@ -82,7 +85,7 @@ VALUE_TYPE_MAP: dict[str, tuple[str, str]] = {
     "set_caption": ("string", "high"),
     "set_font": ("string", "high"),
     "set_fs": ("string", "high"),
-    "set_source": ("string", "high"),
+    "set_source": ("string|string[]", "high"),
     "set_alt": ("string", "high"),
     "mod_hidden": ("bool", "high"),
     "mod_flag": ("bool", "high"),
@@ -201,6 +204,48 @@ def scan_array_block(path: Path, decl_marker: str,
     return entries
 
 
+PREPROC_GUARD_RE = re.compile(r"^\s*#\s*(if|ifdef|ifndef|else|endif)\b")
+
+
+def preprocessor_conditions(lines: list[str], path: Path) -> list[str | None]:
+    """Return the active raw preprocessor guard text for every source line.
+
+    `#else` is represented as the inverse of the guard it replaces. This is
+    deliberately descriptive rather than an attempt to evaluate C macros.
+    """
+    guard_stack: list[str] = []
+    conditions: list[str | None] = []
+    for line_no, line in enumerate(lines, 1):
+        match = PREPROC_GUARD_RE.match(line)
+        if match:
+            directive = match.group(1)
+            if directive in ("if", "ifdef", "ifndef"):
+                guard_stack.append(line.strip())
+            elif directive == "else":
+                if not guard_stack:
+                    raise GenError("#else without an active guard at %s:%d"
+                                   % (path, line_no))
+                guard_stack[-1] = "!(%s)" % guard_stack[-1]
+            else:
+                if not guard_stack:
+                    raise GenError("#endif without an active guard at %s:%d"
+                                   % (path, line_no))
+                guard_stack.pop()
+        conditions.append(" && ".join(guard_stack) or None)
+    if guard_stack:
+        raise GenError("unterminated preprocessor guard in %s" % path)
+    return conditions
+
+
+def combine_conditions(*conditions: str | None) -> str | None:
+    """Join distinct active guard strings while preserving source order."""
+    terms: list[str] = []
+    for condition in conditions:
+        if condition and condition not in terms:
+            terms.append(condition)
+    return " && ".join(terms) or None
+
+
 def split_fields(text: str) -> list[str]:
     """Top-level comma-separated fields of one entry's inner text (paren/
     bracket depth tracked so a field like `foo(a, b)` -- not used by either
@@ -302,6 +347,8 @@ def build_attributes() -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 def build_functions() -> list[dict[str, Any]]:
+    lines = EVAL_C.read_text(encoding="utf-8").splitlines()
+    conditions = preprocessor_conditions(lines, EVAL_C)
     entries = scan_array_block(EVAL_C, FUNC_TABLE_DECL)
     records: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -321,7 +368,7 @@ def build_functions() -> list[dict[str, Any]]:
         preproc = (fields[5] if len(fields) > 5 and fields[5] != "NULL"
                    else None)
 
-        records.append({
+        record = {
             "name": name,
             "nargs": nargs,
             "variadic": nargs == -1,
@@ -330,7 +377,11 @@ def build_functions() -> list[dict[str, Any]]:
             "dtor": dtor is not None,
             "preproc": preproc is not None,
             "source": {"file": rel(EVAL_C), "line": line},
-        })
+        }
+        condition = conditions[line - 1]
+        if condition:
+            record["condition"] = condition
+        records.append(record)
     records.sort(key=lambda r: r["name"])
     return records
 
@@ -342,14 +393,22 @@ def build_functions() -> list[dict[str, Any]]:
 def build_widgets() -> list[dict[str, Any]]:
     files = sorted(GLW_DIR.glob("glw_*.c"))
 
-    registered: set[str] = set()
+    file_contents: dict[Path, tuple[list[str], list[str | None]]] = {}
     for f in files:
-        registered.update(REGISTER_RE.findall(f.read_text(encoding="utf-8")))
+        lines = f.read_text(encoding="utf-8").splitlines()
+        file_contents[f] = (lines, preprocessor_conditions(lines, f))
+
+    registrations: dict[str, list[str | None]] = {}
+    for f in files:
+        lines, conditions = file_contents[f]
+        for i, line in enumerate(lines):
+            for match in REGISTER_RE.finditer(line):
+                registrations.setdefault(match.group(1), []).append(conditions[i])
 
     records: list[dict[str, Any]] = []
     seen: set[str] = set()
     for f in files:
-        lines = f.read_text(encoding="utf-8").splitlines()
+        lines, conditions = file_contents[f]
         n = len(lines)
         i = 0
         while i < n:
@@ -380,13 +439,18 @@ def build_widgets() -> list[dict[str, Any]]:
             if gc_name in seen:
                 raise GenError("duplicate widget gc_name: %s" % gc_name)
             seen.add(gc_name)
-            records.append({
+            record = {
                 "name": gc_name,
                 "aliases": [gc_name2] if gc_name2 else [],
                 "symbol": symbol,
-                "registered": symbol in registered,
+                "registered": symbol in registrations,
                 "source": {"file": rel(f), "line": gc_name_line},
-            })
+            }
+            condition = combine_conditions(
+                conditions[gc_name_line - 1], *registrations.get(symbol, []))
+            if condition:
+                record["condition"] = condition
+            records.append(record)
             i = j
     records.sort(key=lambda r: r["name"])
     return records
@@ -403,17 +467,39 @@ def load_curated(path: Path, required_keys: set[str]) -> list[dict[str, Any]]:
     if not isinstance(data, list):
         raise GenError("%s: expected a top-level JSON array" % path)
     for entry in data:
-        missing = required_keys - entry.keys()
+        if not isinstance(entry, dict):
+            raise GenError("%s: entry is not an object: %r" % (path, entry))
+        entry_name = entry.get("name")
+        if entry_name is None:
+            symbols = entry.get("symbols")
+            entry_name = symbols[0] if isinstance(symbols, list) and symbols else entry
+        missing = (required_keys | {"anchor"}) - entry.keys()
         if missing:
-            raise GenError("%s: entry missing keys %s: %r"
-                            % (path, sorted(missing), entry))
+            raise GenError("%s: entry %r missing keys %s"
+                           % (path, entry_name, sorted(missing)))
         src = entry["source"]
         if not isinstance(src, dict) or "file" not in src or "line" not in src:
-            raise GenError("%s: entry has malformed source: %r" % (path, entry))
+            raise GenError("%s: entry %r has malformed source"
+                           % (path, entry_name))
+        anchor = entry["anchor"]
+        if not isinstance(anchor, str) or not anchor:
+            raise GenError("%s: entry %r has malformed anchor: %r"
+                           % (path, entry_name, anchor))
         src_path = REPO_ROOT / src["file"]
         if not src_path.is_file():
-            raise GenError("%s: source.file does not exist: %s"
-                            % (path, src["file"]))
+            raise GenError("%s: entry %r source.file does not exist: %s"
+                           % (path, entry_name, src["file"]))
+        line = src["line"]
+        if not isinstance(line, int) or isinstance(line, bool) or line < 1:
+            raise GenError("%s: entry %r has invalid source.line: %r"
+                           % (path, entry_name, line))
+        lines = src_path.read_text(encoding="utf-8").splitlines()
+        if line > len(lines):
+            raise GenError("%s: entry %r source.line is out of range: %s:%d"
+                           % (path, entry_name, src["file"], line))
+        if anchor not in lines[line - 1]:
+            raise GenError("%s: entry %r anchor %r not found at %s:%d"
+                           % (path, entry_name, anchor, src["file"], line))
     return data
 
 
@@ -515,10 +601,8 @@ def cmd_check(args: argparse.Namespace) -> int:
 
 
 def _without_line(record: dict[str, Any]) -> dict[str, Any]:
-    """`record` with `source.line` blanked out -- an unrelated insertion
-    earlier in the same C table shifts every later entry's line number,
-    which is real but not "drift" worth reporting as a changed record; the
-    added/removed name lists already carry that signal."""
+    """`record` with `source.line` blanked out to classify semantic changes
+    separately from line-only stale anchors (which are reported as lineOnly)."""
     clone = dict(record)
     src = dict(clone.get("source") or {})
     src["line"] = None
@@ -542,9 +626,13 @@ def diff_artifacts(committed: dict[str, Any],
             n for n in (set(f) & set(c))
             if _without_line(f[n]) != _without_line(c[n])
         )
-        if added or removed or changed:
+        line_only = sorted(
+            n for n in (set(f) & set(c))
+            if f[n] != c[n] and _without_line(f[n]) == _without_line(c[n])
+        )
+        if added or removed or changed or line_only:
             result[section] = {"added": added, "removed": removed,
-                                "changed": changed}
+                                "changed": changed, "lineOnly": line_only}
     if committed.get("js") != fresh.get("js"):
         result["js"] = {"committed": committed.get("js"),
                          "fresh": fresh.get("js")}
@@ -558,13 +646,16 @@ def diff_artifacts(committed: dict[str, Any],
 def format_diff(diff: dict[str, Any]) -> list[str]:
     lines = []
     for section, d in diff.items():
-        if "added" in d or "removed" in d or "changed" in d:
+        if ("added" in d or "removed" in d or "changed" in d
+                or "lineOnly" in d):
             for name in d.get("added", []):
                 lines.append("added (%s): %s" % (section, name))
             for name in d.get("removed", []):
                 lines.append("removed (%s): %s" % (section, name))
             for name in d.get("changed", []):
                 lines.append("changed (%s): %s" % (section, name))
+            for name in d.get("lineOnly", []):
+                lines.append("line-moved (%s): %s" % (section, name))
         else:
             lines.append("changed (%s)" % section)
     return lines

--- a/support/devtools/metadata/gen.py
+++ b/support/devtools/metadata/gen.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""movian-metadata generator (issue #98).
+
+Generates `generated/movian-metadata.json` (schema v1): the single
+committed metadata artifact for the GLW view language, grown from
+`support/devtools/mdevlib/viewdoc.py` (issue #88). Sections:
+
+- glw.functions   -- `token_func_t funcvec[]`, src/ui/glw/glw_view_eval.c
+                      (name, nargs/variadic, ctor/dtor/preproc presence).
+- glw.attributes  -- `token_attrib_t attribtab[]`, src/ui/glw/glw_view_attrib.c
+                      (name, valueType inferred from the setter function,
+                      raw setter/attribConst/fn fields, noSubscription flag).
+- glw.widgets     -- every `glw_class_t` designated initializer
+                      (`.gc_name`/`.gc_name2`) across src/ui/glw/glw_*.c,
+                      cross-referenced against `GLW_REGISTER_CLASS(...)`
+                      call sites for the `registered` flag. Includes two
+                      classes that define `.gc_name` but are never
+                      registered (`view`, `style` -- internal-only, not
+                      resolvable by name from a `.view` file).
+- glw.operators   -- curated, `curated_operators.json` next to this file.
+- glw.scopes      -- curated, `curated_scopes.json` next to this file.
+- js.*            -- v1-wave stub (empty), see issue #96 follow-ups E-I.
+
+Every record carries `source: {file, line}` pointing at the defining line
+in the C source (scanned, not hand-typed -- see the table-entry scanner
+below) or, for curated sections, a hand-verified anchor.
+
+Python 3 stdlib only. Determinism: every list is sorted by its primary key
+name, `json.dumps(..., sort_keys=True, indent=2)`, trailing newline.
+`movianRevision` is the current `git rev-parse HEAD` -- it is the one field
+that legitimately changes between two regenerations on different commits,
+so `--check` compares content with `movianRevision` normalized out (see
+`_strip_revision`) rather than requiring a pinned value.
+
+Usage:
+    gen.py            -- regenerate generated/movian-metadata.json in place
+    gen.py --check    -- regenerate in memory and diff against the
+                          committed artifact (ignoring movianRevision);
+                          nonzero exit and a printed diff on drift
+    gen.py --json     -- with --check, print the diff as JSON instead
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+METADATA_DIR = Path(__file__).resolve().parent
+ARTIFACT_PATH = REPO_ROOT / "generated" / "movian-metadata.json"
+
+ATTRIB_C = REPO_ROOT / "src" / "ui" / "glw" / "glw_view_attrib.c"
+EVAL_C = REPO_ROOT / "src" / "ui" / "glw" / "glw_view_eval.c"
+GLW_DIR = REPO_ROOT / "src" / "ui" / "glw"
+
+CURATED_OPERATORS = METADATA_DIR / "curated_operators.json"
+CURATED_SCOPES = METADATA_DIR / "curated_scopes.json"
+
+SCHEMA_VERSION = 1
+GENERATED_BY = "support/devtools/metadata/gen.py"
+
+ATTRIB_TABLE_DECL = "token_attrib_t attribtab[] = {"
+FUNC_TABLE_DECL = "token_func_t funcvec[] = {"
+
+WIDGET_DECL_RE = re.compile(r'^(?:static\s+)?glw_class_t\s+(\w+)\s*=\s*\{')
+GC_NAME_RE = re.compile(r'\.gc_name\s*=\s*"([^"]+)"')
+GC_NAME2_RE = re.compile(r'\.gc_name2\s*=\s*"([^"]+)"')
+REGISTER_RE = re.compile(r'GLW_REGISTER_CLASS\((\w+)\)')
+
+# Value type + confidence inferred from attribtab[]'s setter function (2nd
+# field). "high" = the setter is unambiguous about the wire type; "medium"
+# = the setter is polymorphic (set_number dispatches to the target class's
+# own gc_set_int/gc_set_float switch, so the actual type is class-specific).
+VALUE_TYPE_MAP: dict[str, tuple[str, str]] = {
+    "set_style": ("style", "high"),
+    "set_rstring": ("string", "high"),
+    "set_caption": ("string", "high"),
+    "set_font": ("string", "high"),
+    "set_fs": ("string", "high"),
+    "set_source": ("string", "high"),
+    "set_alt": ("string", "high"),
+    "mod_hidden": ("bool", "high"),
+    "mod_flag": ("bool", "high"),
+    "set_float": ("float", "high"),
+    "set_int": ("int", "high"),
+    "set_number": ("number", "medium"),
+    "set_float3": ("vec3", "high"),
+    "set_float4": ("vec4", "high"),
+    "set_int16_4": ("vec4i", "high"),
+    "set_margin": ("vec4i", "high"),
+    "set_align": ("enum", "high"),
+    "set_transition_effect": ("enum", "high"),
+    "set_args": ("block", "high"),
+    "set_propref": ("propref", "high"),
+}
+
+
+class GenError(Exception):
+    pass
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Generic C array-of-struct-initializer scanner, shared by attribtab[] and
+# funcvec[]: both are `static const token_*_t name[] = { {...}, {...}, };`
+# tables whose entries are plain comma-separated identifier/literal fields
+# (no nested braces) but may span multiple physical lines (attribtab's
+# GLW_ATTRIB_FLAG_NO_SUBSCRIPTION entries do). Returns a list of
+# (raw_entry_text, first_line_of_entry) tuples, one per top-level `{...}`.
+# ---------------------------------------------------------------------------
+
+def scan_array_block(path: Path, decl_marker: str,
+                      close_marker: str = "};") -> list[tuple[str, int]]:
+    if not path.is_file():
+        raise GenError("source file not found: %s" % path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    start_idx = None
+    for i, line in enumerate(lines):
+        if decl_marker in line:
+            start_idx = i
+            break
+    if start_idx is None:
+        raise GenError("table %r not found in %s" % (decl_marker, path))
+
+    end_idx = None
+    for i in range(start_idx + 1, len(lines)):
+        if lines[i].strip() == close_marker:
+            end_idx = i
+            break
+    if end_idx is None:
+        raise GenError("closing %r not found after %r in %s"
+                        % (close_marker, decl_marker, path))
+
+    entries: list[tuple[str, int]] = []
+    depth = 0
+    buf: list[str] = []
+    entry_line = 0
+    in_str = False
+    str_q = ""
+
+    for i_line in range(start_idx + 1, end_idx):
+        line_no = i_line + 1  # 1-based
+        text = lines[i_line]
+        j = 0
+        n = len(text)
+        while j < n:
+            c = text[j]
+            if in_str:
+                buf.append(c)
+                if c == "\\" and j + 1 < n:
+                    j += 1
+                    buf.append(text[j])
+                elif c == str_q:
+                    in_str = False
+                j += 1
+                continue
+            if c == "/" and j + 1 < n and text[j + 1] == "/":
+                break  # line comment: rest of physical line is not code
+            if c in ('"', "'"):
+                if depth > 0:
+                    in_str = True
+                    str_q = c
+                    buf.append(c)
+                j += 1
+                continue
+            if c == "{":
+                if depth == 0:
+                    buf = []
+                    entry_line = line_no
+                else:
+                    buf.append(c)
+                depth += 1
+                j += 1
+                continue
+            if c == "}":
+                depth -= 1
+                if depth < 0:
+                    raise GenError("unbalanced '}' at %s:%d" % (path, line_no))
+                if depth == 0:
+                    entries.append(("".join(buf), entry_line))
+                else:
+                    buf.append(c)
+                j += 1
+                continue
+            if depth > 0:
+                buf.append(c)
+            j += 1
+
+    if depth != 0:
+        raise GenError("unbalanced braces scanning %r in %s"
+                        % (decl_marker, path))
+    return entries
+
+
+def split_fields(text: str) -> list[str]:
+    """Top-level comma-separated fields of one entry's inner text (paren/
+    bracket depth tracked so a field like `foo(a, b)` -- not used by either
+    table today, but kept generic -- doesn't get split)."""
+    fields: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    in_str = False
+    str_q = ""
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if in_str:
+            buf.append(c)
+            if c == "\\" and i + 1 < n:
+                i += 1
+                buf.append(text[i])
+            elif c == str_q:
+                in_str = False
+            i += 1
+            continue
+        if c in ('"', "'"):
+            in_str = True
+            str_q = c
+            buf.append(c)
+            i += 1
+            continue
+        if c in "([":
+            depth += 1
+            buf.append(c)
+            i += 1
+            continue
+        if c in ")]":
+            depth -= 1
+            buf.append(c)
+            i += 1
+            continue
+        if c == "," and depth == 0:
+            fields.append("".join(buf).strip())
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        fields.append(tail)
+    return [f for f in fields if f]
+
+
+def unquote(field: str) -> str:
+    if len(field) >= 2 and field[0] == '"' and field[-1] == '"':
+        return field[1:-1]
+    return field
+
+
+# ---------------------------------------------------------------------------
+# glw.attributes -- attribtab[]
+# ---------------------------------------------------------------------------
+
+def build_attributes() -> list[dict[str, Any]]:
+    entries = scan_array_block(ATTRIB_C, ATTRIB_TABLE_DECL)
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for text, line in entries:
+        fields = split_fields(text)
+        if not fields:
+            continue
+        name = unquote(fields[0])
+        if name in seen:
+            raise GenError("duplicate attribute name in source: %s" % name)
+        seen.add(name)
+
+        setter = fields[1] if len(fields) > 1 else None
+        attrib_const = (fields[2] if len(fields) > 2 and fields[2] != "0"
+                         else None)
+        fn = fields[3] if len(fields) > 3 and fields[3] != "NULL" else None
+        no_sub = (len(fields) > 4
+                  and fields[4] == "GLW_ATTRIB_FLAG_NO_SUBSCRIPTION")
+        value_type, confidence = VALUE_TYPE_MAP.get(setter, ("unknown", "low"))
+
+        records.append({
+            "name": name,
+            "valueType": value_type,
+            "confidence": confidence,
+            "setter": setter,
+            "attribConst": attrib_const,
+            "fn": fn,
+            "noSubscription": no_sub,
+            "source": {"file": rel(ATTRIB_C), "line": line},
+        })
+    records.sort(key=lambda r: r["name"])
+    return records
+
+
+# ---------------------------------------------------------------------------
+# glw.functions -- funcvec[]
+# ---------------------------------------------------------------------------
+
+def build_functions() -> list[dict[str, Any]]:
+    entries = scan_array_block(EVAL_C, FUNC_TABLE_DECL)
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for text, line in entries:
+        fields = split_fields(text)
+        if not fields:
+            continue
+        name = unquote(fields[0])
+        if name in seen:
+            raise GenError("duplicate function name in source: %s" % name)
+        seen.add(name)
+
+        nargs = int(fields[1]) if len(fields) > 1 else None
+        impl = fields[2] if len(fields) > 2 else None
+        ctor = fields[3] if len(fields) > 3 and fields[3] != "NULL" else None
+        dtor = fields[4] if len(fields) > 4 and fields[4] != "NULL" else None
+        preproc = (fields[5] if len(fields) > 5 and fields[5] != "NULL"
+                   else None)
+
+        records.append({
+            "name": name,
+            "nargs": nargs,
+            "variadic": nargs == -1,
+            "impl": impl,
+            "ctor": ctor is not None,
+            "dtor": dtor is not None,
+            "preproc": preproc is not None,
+            "source": {"file": rel(EVAL_C), "line": line},
+        })
+    records.sort(key=lambda r: r["name"])
+    return records
+
+
+# ---------------------------------------------------------------------------
+# glw.widgets -- glw_class_t designated initializers across glw_*.c
+# ---------------------------------------------------------------------------
+
+def build_widgets() -> list[dict[str, Any]]:
+    files = sorted(GLW_DIR.glob("glw_*.c"))
+
+    registered: set[str] = set()
+    for f in files:
+        registered.update(REGISTER_RE.findall(f.read_text(encoding="utf-8")))
+
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for f in files:
+        lines = f.read_text(encoding="utf-8").splitlines()
+        n = len(lines)
+        i = 0
+        while i < n:
+            m = WIDGET_DECL_RE.match(lines[i].strip())
+            if not m:
+                i += 1
+                continue
+            symbol = m.group(1)
+            depth = lines[i].count("{") - lines[i].count("}")
+            gc_name = None
+            gc_name_line = None
+            gc_name2 = None
+            j = i + 1
+            while j < n and depth > 0:
+                line = lines[j]
+                depth += line.count("{") - line.count("}")
+                nm = GC_NAME_RE.search(line)
+                if nm and gc_name is None:
+                    gc_name = nm.group(1)
+                    gc_name_line = j + 1
+                nm2 = GC_NAME2_RE.search(line)
+                if nm2:
+                    gc_name2 = nm2.group(1)
+                j += 1
+            if gc_name is None:
+                raise GenError("glw_class_t %s in %s has no .gc_name"
+                                % (symbol, f))
+            if gc_name in seen:
+                raise GenError("duplicate widget gc_name: %s" % gc_name)
+            seen.add(gc_name)
+            records.append({
+                "name": gc_name,
+                "aliases": [gc_name2] if gc_name2 else [],
+                "symbol": symbol,
+                "registered": symbol in registered,
+                "source": {"file": rel(f), "line": gc_name_line},
+            })
+            i = j
+    records.sort(key=lambda r: r["name"])
+    return records
+
+
+# ---------------------------------------------------------------------------
+# glw.operators / glw.scopes -- curated, hand-authored next to this file
+# ---------------------------------------------------------------------------
+
+def load_curated(path: Path, required_keys: set[str]) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise GenError("curated input file not found: %s" % path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise GenError("%s: expected a top-level JSON array" % path)
+    for entry in data:
+        missing = required_keys - entry.keys()
+        if missing:
+            raise GenError("%s: entry missing keys %s: %r"
+                            % (path, sorted(missing), entry))
+        src = entry["source"]
+        if not isinstance(src, dict) or "file" not in src or "line" not in src:
+            raise GenError("%s: entry has malformed source: %r" % (path, entry))
+        src_path = REPO_ROOT / src["file"]
+        if not src_path.is_file():
+            raise GenError("%s: source.file does not exist: %s"
+                            % (path, src["file"]))
+    return data
+
+
+def build_operators() -> list[dict[str, Any]]:
+    ops = load_curated(CURATED_OPERATORS,
+                        {"symbols", "token", "category", "semantics", "source"})
+    ops.sort(key=lambda r: r["symbols"][0])
+    return ops
+
+
+def build_scopes() -> list[dict[str, Any]]:
+    scopes = load_curated(CURATED_SCOPES, {"name", "meaning", "source"})
+    scopes.sort(key=lambda r: r["name"])
+    return scopes
+
+
+# ---------------------------------------------------------------------------
+# top level
+# ---------------------------------------------------------------------------
+
+def git_revision() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def build_artifact() -> dict[str, Any]:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "movianRevision": git_revision(),
+        "generatedBy": GENERATED_BY,
+        "glw": {
+            "functions": build_functions(),
+            "attributes": build_attributes(),
+            "widgets": build_widgets(),
+            "operators": build_operators(),
+            "scopes": build_scopes(),
+        },
+        "js": {},
+    }
+
+
+def dumps(artifact: dict[str, Any]) -> str:
+    return json.dumps(artifact, ensure_ascii=False, indent=2,
+                       sort_keys=True) + "\n"
+
+
+def _strip_revision(artifact: dict[str, Any]) -> dict[str, Any]:
+    """A copy of `artifact` with movianRevision normalized out -- the one
+    field that legitimately differs between two regenerations run on
+    different commits (see module docstring)."""
+    clone = dict(artifact)
+    clone["movianRevision"] = None
+    return clone
+
+
+def cmd_generate(_args: argparse.Namespace) -> int:
+    artifact = build_artifact()
+    ARTIFACT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ARTIFACT_PATH.write_text(dumps(artifact), encoding="utf-8")
+    print("wrote %s" % rel(ARTIFACT_PATH))
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    fresh = build_artifact()
+    if not ARTIFACT_PATH.is_file():
+        print("mdev-metadata: committed artifact not found: %s"
+              % ARTIFACT_PATH, file=sys.stderr)
+        return 1
+    committed = json.loads(ARTIFACT_PATH.read_text(encoding="utf-8"))
+
+    fresh_norm = _strip_revision(fresh)
+    committed_norm = _strip_revision(committed)
+
+    if fresh_norm == committed_norm:
+        if args.json:
+            print(json.dumps({"metadata": "ok"}, indent=2))
+        else:
+            print("METADATA OK (movianRevision: committed=%s current=%s)"
+                  % (committed.get("movianRevision"),
+                     fresh.get("movianRevision")))
+        return 0
+
+    diff = diff_artifacts(committed_norm, fresh_norm)
+    if args.json:
+        print(json.dumps({"metadata": "drift", "diff": diff},
+                          ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print("METADATA DRIFT")
+        for line in format_diff(diff):
+            print(line)
+    return 1
+
+
+def _without_line(record: dict[str, Any]) -> dict[str, Any]:
+    """`record` with `source.line` blanked out -- an unrelated insertion
+    earlier in the same C table shifts every later entry's line number,
+    which is real but not "drift" worth reporting as a changed record; the
+    added/removed name lists already carry that signal."""
+    clone = dict(record)
+    src = dict(clone.get("source") or {})
+    src["line"] = None
+    clone["source"] = src
+    return clone
+
+
+def diff_artifacts(committed: dict[str, Any],
+                    fresh: dict[str, Any]) -> dict[str, Any]:
+    """Section-by-section (by name/symbols key) added/removed/changed
+    report for every glw.* list, so drift is falsifiable and legible in
+    both directions (added-since-commit vs removed-since-commit)."""
+    result: dict[str, Any] = {}
+    for section, key in (("functions", "name"), ("attributes", "name"),
+                          ("widgets", "name")):
+        c = {r[key]: r for r in committed["glw"][section]}
+        f = {r[key]: r for r in fresh["glw"][section]}
+        added = sorted(set(f) - set(c))
+        removed = sorted(set(c) - set(f))
+        changed = sorted(
+            n for n in (set(f) & set(c))
+            if _without_line(f[n]) != _without_line(c[n])
+        )
+        if added or removed or changed:
+            result[section] = {"added": added, "removed": removed,
+                                "changed": changed}
+    if committed.get("js") != fresh.get("js"):
+        result["js"] = {"committed": committed.get("js"),
+                         "fresh": fresh.get("js")}
+    for section in ("operators", "scopes"):
+        if committed["glw"][section] != fresh["glw"][section]:
+            result[section] = {"note": "curated section changed on disk "
+                                        "vs committed artifact"}
+    return result
+
+
+def format_diff(diff: dict[str, Any]) -> list[str]:
+    lines = []
+    for section, d in diff.items():
+        if "added" in d or "removed" in d or "changed" in d:
+            for name in d.get("added", []):
+                lines.append("added (%s): %s" % (section, name))
+            for name in d.get("removed", []):
+                lines.append("removed (%s): %s" % (section, name))
+            for name in d.get("changed", []):
+                lines.append("changed (%s): %s" % (section, name))
+        else:
+            lines.append("changed (%s)" % section)
+    return lines
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gen.py",
+        description="Generate/check generated/movian-metadata.json "
+                     "(issue #98).")
+    parser.add_argument("--check", action="store_true",
+                         help="diff regenerated content against the "
+                              "committed artifact (movianRevision "
+                              "ignored); exit 1 on drift")
+    parser.add_argument("--json", action="store_true",
+                         help="machine-readable JSON output (--check only)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.check:
+            return cmd_check(args)
+        return cmd_generate(args)
+    except GenError as error:
+        print("gen.py: %s" % error, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements (#98), part of the language-tooling umbrella (#96).

## What

- **`support/devtools/metadata/gen.py`** (Python stdlib only) — generates a single committed metadata artifact from the stable C registries; `--check` regenerates in memory and diffs against the committed file (with `movianRevision` normalized out), reporting added/removed/changed names per section, exit 1 on drift.
- **`generated/movian-metadata.json`** — schema v1: `glw.functions` (90, from `funcvec[]` — nargs/variadic/ctor/dtor/preproc), `glw.attributes` (116, from `attribtab[]` — valueType inferred from the setter, honest `confidence: medium` for the polymorphic `set_number` group), `glw.widgets` (53 `glw_class_t` designated initializers — 51 registered + the internal `view`/`style` pseudo-classes flagged `registered: false`), curated `glw.operators`/`glw.scopes` (every anchor re-verified against live source), `js` stub for the v1 wave. Every record carries a real `source{file,line}`.
- **`mdevlib/viewdoc.py`** rewired to consume the artifact instead of re-scanning the C source (identical CLI, exit semantics, and byte-identical output in all four invocation shapes).

## Verification

Executor self-run + independent fresh-context verifier, both green on the full DoD:

- `gen.py --check` exit 0 on clean tree; regenerated content differs from committed only in `movianRevision`.
- Drift falsifiable in both directions at both layers (fake/removed C-table entries → named drift, exit 1; doc-side deletion/fake row → named drift via `mdev viewdoc --check`, exit 1; all induced edits restored).
- Counts independently recomputed from source: funcvec=90, attribtab=116, `.gc_name`=53, unique `GLW_REGISTER_CLASS`=51 — all match the artifact.
- `mdev viewdoc` / `--json` / `--check` / `--check --json` byte-identical vs the pre-change baseline at the merge base.
- Anchor sampling (functions/attributes/widgets incl. both pseudo-classes + curated entries): all `source.file:line` resolve to the defining line.
- Stdlib purity confirmed.

## Noted, not touched

- `glw-widget-catalog.md` (#88) counting note is stale: it misses `glw_style.c`'s unregistered `style` pseudo-class (53rd `gc_name`). Candidate doc follow-up.
- `.gitignore` lacks `__pycache__`/`*.pyc`.
- `aligntab[]`/`transitiontab[]` enum value sets not scanned (v1-wave enrichment, see #96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
