### PR TITLE
httpserver: skip '?' in trailing-slash query parsing (#102)

### DIFF
--- a/src/networking/http_server.c
+++ b/src/networking/http_server.c
@@ -297,7 +297,7 @@ http_resolve(http_connection_t *hc, char **remainp, char **argsp)
 
   case '/':
     if(v[1] == '?') {
-      *argsp = v + 1;
+      *argsp = v + 2;
       break;
     }
 


### PR DESCRIPTION
Fixes the trailing-slash query bug triaged as (#102).

## What

`http_resolve()` (src/networking/http_server.c) mishandled the `"<path>/?query"` form: in the `v[1] == '?'` branch, `*argsp = v + 1` pointed AT the `'?'` instead of past it, so the query parser produced an arg named `?url` instead of `url`. Result: `GET /api/open/?url=...` returned 200 with the "Open URL" HTML form instead of navigating — silently, for every leaf endpoint registered via `http_path_add`. The two sibling branches (`<path>?query`, `<path>/remain?query`) already skipped the `'?'` correctly. One-line fix: `v + 2`.

## Verification (fresh-context verifier, live instance)

- Trailing-slash form: `curl '/api/open/?url=page:settings'` → `302 Found` + nav trace `Opening page:settings` in the log (previously: 200 + HTML form, no navigation).
- No-slash regression: `/api/open?url=page:home` → 302 + `Opening page:home`.
- Remain+query regression: `/api/prop/global/media?action=print` → 200 (path resolution intact).
- Bare path: `/api/screenshot/raw` → 200.
- Incremental debug build clean; the diff is +1/−1 in `http_server.c`.

## Process note

Pilot of a cross-vendor executor: the fix was implemented by a Codex executor (GPT-5.6) against the issue spec, then independently verified by a fresh-context Claude verifier; commit applied by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
