### PR TITLE
tests/tooling: corpus include-fragment loose lane (#106)

### DIFF
--- a/tests/tooling/glw/run_corpus.sh
+++ b/tests/tooling/glw/run_corpus.sh
@@ -100,10 +100,27 @@ check_one() {
   fi
 }
 
-echo "== glwskins/flat (strict: must exit 0, empty stderr) =="
+# Include-fragments: files that are only ever #include/#import-ed into a
+# document that has already imported theme.view, so they call macros
+# (e.g. ListItemBevel from theme.view) that do not exist in a standalone
+# parse. The real runtime rejects a standalone parse of these the same
+# way, so a clean-exit expectation would be FALSE parity; they run in the
+# loose lane (must not crash, well-formed error allowed). See issue #106.
+is_fragment() {
+  case "$1" in
+    glwskins/flat/menu/sidebar_common.view) return 0 ;;
+  esac
+  return 1
+}
+
+echo "== glwskins/flat (strict: must exit 0, empty stderr; fragments loose) =="
 for f in $(find glwskins/flat -name '*.view'); do
   n_flat=$((n_flat + 1))
-  check_one "$f" 1
+  if is_fragment "$f"; then
+    check_one "$f" 0
+  else
+    check_one "$f" 1
+  fi
 done
 
 echo "== glwskins/old (loose: must not crash) =="

--- a/tests/tooling/glw/run_corpus.sh
+++ b/tests/tooling/glw/run_corpus.sh
@@ -44,9 +44,14 @@ n_other=0
 n_fixtures=0
 
 check_one() {
-  # $1 = view path, $2 = 1 if this is a strict flat-corpus file
+  # $1 = view path
+  # $2 = 1 if --check must exit 0 with empty stderr (strict parse)
+  # $3 = 1 if --tokens must exit 0 with empty stderr (strict lex);
+  #      include-fragments keep this at 1: --tokens stops before macro
+  #      preprocessing, so a missing macro cannot excuse a lexer error.
   view=$1
   strict=$2
+  strict_tokens=$3
 
   out=$("$ANALYZE" --check "$view" 2>/tmp/movian-analyze-corpus.stderr)
   rc=$?
@@ -86,7 +91,7 @@ check_one() {
     echo "CRASH in --tokens (signal $((trc - 128))): $view" >&2
     crash=$((crash + 1))
     fail=1
-  elif [ "$strict" = 1 ]; then
+  elif [ "$strict_tokens" = 1 ]; then
     if [ "$trc" != 0 ]; then
       echo "FLAT CORPUS REGRESSION (--tokens exit $trc, expected 0): $view" >&2
       flat_fail=$((flat_fail + 1))
@@ -104,8 +109,10 @@ check_one() {
 # document that has already imported theme.view, so they call macros
 # (e.g. ListItemBevel from theme.view) that do not exist in a standalone
 # parse. The real runtime rejects a standalone parse of these the same
-# way, so a clean-exit expectation would be FALSE parity; they run in the
-# loose lane (must not crash, well-formed error allowed). See issue #106.
+# way, so a clean --check expectation would be FALSE parity; --check runs
+# in the loose lane (must not crash, well-formed error allowed) while
+# --tokens stays strict (lexing stops before macro preprocessing, so a
+# missing macro cannot excuse a lexer error). See issue #106.
 is_fragment() {
   case "$1" in
     glwskins/flat/menu/sidebar_common.view) return 0 ;;
@@ -117,9 +124,9 @@ echo "== glwskins/flat (strict: must exit 0, empty stderr; fragments loose) =="
 for f in $(find glwskins/flat -name '*.view'); do
   n_flat=$((n_flat + 1))
   if is_fragment "$f"; then
-    check_one "$f" 0
+    check_one "$f" 0 1
   else
-    check_one "$f" 1
+    check_one "$f" 1 1
   fi
 done
 
@@ -127,7 +134,7 @@ echo "== glwskins/old (loose: must not crash) =="
 if [ -d glwskins/old ]; then
   for f in $(find glwskins/old -name '*.view'); do
     n_other=$((n_other + 1))
-    check_one "$f" 0
+    check_one "$f" 0 0
   done
 fi
 
@@ -143,14 +150,14 @@ for f in tests/tooling/glw/fixtures/*.view; do
       continue
       ;;
   esac
-  check_one "$f" 0
+  check_one "$f" 0 0
 done
 
 echo "== tests/tooling/glw/golden (strict: must exit 0, empty stderr) =="
 for f in tests/tooling/glw/golden/*.view; do
   [ -f "$f" ] || continue
   n_flat=$((n_flat + 1))
-  check_one "$f" 1
+  check_one "$f" 1 1
 done
 
 rm -f /tmp/movian-analyze-corpus.stderr /tmp/movian-analyze-corpus.tokens.stderr


### PR DESCRIPTION
Fixes (#106): `make movian-analyze-corpus` is red on movian6 HEAD since the #101+#103 merge — the metadata artifact's presence activated the shim's widget-name validation, exposing that `glwskins/flat/menu/sidebar_common.view` (an include-fragment using theme.view macros) never standalone-parses. Verified: CORPUS GUARD OK, 99 flat+golden / 92 old / 11 fixtures, 0 crashes, 0 regressions, 0 golden mismatches; the fragment still correctly exits 1 standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)