### PR TITLE
devtools: movian-lsp MVP — stdio LSP for GLW views (#99)

### DIFF
--- a/support/devtools/lsp/__init__.py
+++ b/support/devtools/lsp/__init__.py
@@ -1,0 +1,5 @@
+"""Movian's stdio Language Server Protocol implementation for GLW views."""
+
+from .server import LspServer
+
+__all__ = ["LspServer"]

--- a/support/devtools/lsp/server.py
+++ b/support/devtools/lsp/server.py
@@ -1,0 +1,929 @@
+"""A small, stdlib-only stdio LSP server for Movian GLW view files.
+
+The semantic authority stays in ``movian-analyze``.  This module only owns
+the editor-facing pieces the analyzer intentionally does not know about:
+buffer snapshots, UTF-16 ranges, JSON-RPC framing, metadata hover text, and
+the last-good lexer-token fallback needed while a document is being edited.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO, Iterable
+from urllib.parse import unquote, urlparse
+
+
+JSON = dict[str, Any]
+
+DEFAULT_DEBOUNCE_MS = 150
+ANALYZER_TIMEOUT_SECONDS = 2.0
+DIAGNOSTIC_SOURCE = "movian-glw"
+
+# LSP SymbolKind values.  Keeping the numeric protocol values local avoids a
+# dependency on a Python LSP package.
+SYMBOL_FILE = 1
+SYMBOL_NAMESPACE = 3
+SYMBOL_CLASS = 5
+SYMBOL_PROPERTY = 7
+SYMBOL_FUNCTION = 12
+
+
+def normalize_text(text: str) -> str:
+    """Apply LSP full-text-sync newline normalization."""
+
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def utf16_length(text: str) -> int:
+    """Return the number of UTF-16 code units in *text*.
+
+    LSP positions use UTF-16 code units, not Python's Unicode code points.
+    Tabs are intentionally left as one unit; visual tab expansion belongs to
+    the editor, not the protocol position model.
+    """
+
+    return sum(2 if ord(char) > 0xFFFF else 1 for char in text)
+
+
+def range_for_line(text: str, line: int) -> JSON:
+    """Make the issue-defined full-line LSP range for a zero-based line."""
+
+    lines = text.split("\n")
+    if line < 0 or line >= len(lines):
+        return {
+            "start": {"line": max(line, 0), "character": 0},
+            "end": {"line": max(line, 0), "character": 0},
+        }
+    return {
+        "start": {"line": line, "character": 0},
+        "end": {"line": line, "character": utf16_length(lines[line])},
+    }
+
+
+def uri_to_path(uri: str) -> Path | None:
+    """Translate a file URI to a local path without accepting other schemes."""
+
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return None
+    path = unquote(parsed.path)
+    if parsed.netloc and parsed.netloc not in ("", "localhost"):
+        path = "//%s%s" % (parsed.netloc, path)
+    return Path(path)
+
+
+def path_to_uri(path: Path) -> str:
+    return path.resolve(strict=False).as_uri()
+
+
+def same_path(left: Path | None, right: Path | None) -> bool:
+    if left is None or right is None:
+        return False
+    try:
+        return left.resolve(strict=False) == right.resolve(strict=False)
+    except OSError:
+        return os.path.abspath(str(left)) == os.path.abspath(str(right))
+
+
+def word_at_utf16_position(line: str, character: int) -> str | None:
+    """Return the GLW-like identifier under a UTF-16 LSP character offset."""
+
+    units = 0
+    index = len(line)
+    for candidate, char in enumerate(line):
+        width = 2 if ord(char) > 0xFFFF else 1
+        if character < units + width:
+            index = candidate
+            break
+        if character == units + width:
+            index = candidate + 1
+            break
+        units += width
+
+    for match in re.finditer(r"[A-Za-z_][A-Za-z0-9_]*", line):
+        if match.start() <= index < match.end():
+            return match.group(0)
+    return None
+
+
+@dataclass
+class Document:
+    uri: str
+    path: Path | None
+    text: str
+    version: int | None
+    generation: int = 0
+    analyzed_generation: int = -1
+    timer: threading.Timer | None = None
+    tokens: list[JSON] = field(default_factory=list)
+    token_text: str = ""
+    last_good_tokens: list[JSON] = field(default_factory=list)
+    last_good_text: str = ""
+    using_token_fallback: bool = False
+    diagnostic_uris: set[str] = field(default_factory=set)
+    lock: threading.RLock = field(default_factory=threading.RLock,
+                                  repr=False)
+    analysis_lock: threading.Lock = field(default_factory=threading.Lock,
+                                          repr=False)
+
+
+class Metadata:
+    """Lookup indexes over the committed ``movian-metadata`` artifact."""
+
+    def __init__(self, artifact_path: Path) -> None:
+        with artifact_path.open(encoding="utf-8") as artifact_file:
+            artifact = json.load(artifact_file)
+        glw = artifact.get("glw", {})
+        self.functions = {
+            record["name"]: record for record in glw.get("functions", [])
+        }
+        self.attributes = {
+            record["name"]: record for record in glw.get("attributes", [])
+        }
+        self.widgets: dict[str, JSON] = {}
+        for record in glw.get("widgets", []):
+            self.widgets[record["name"]] = record
+            for alias in record.get("aliases", []):
+                self.widgets[alias] = record
+
+    def hover(self, word: str) -> str | None:
+        if word in self.functions:
+            record = self.functions[word]
+            if record.get("variadic"):
+                signature = "%s(...args)" % record["name"]
+            else:
+                signature = "%s(%s)" % (
+                    record["name"],
+                    ", ".join("arg%d" % (index + 1)
+                              for index in range(record.get("nargs", 0))),
+                )
+            lines = [
+                "```glw",
+                signature,
+                "```",
+                "",
+                "GLW function from Movian metadata.",
+            ]
+            self._append_source(lines, record)
+            self._append_condition(lines, record)
+            return "\n".join(lines)
+
+        if word in self.attributes:
+            record = self.attributes[word]
+            lines = [
+                "```glw",
+                "%s: %s" % (record["name"], record["valueType"]),
+                "```",
+                "",
+                "GLW attribute from Movian metadata.",
+            ]
+            self._append_source(lines, record)
+            self._append_condition(lines, record)
+            return "\n".join(lines)
+
+        if word in self.widgets:
+            record = self.widgets[word]
+            lines = [
+                "```glw",
+                record["name"],
+                "```",
+                "",
+                "GLW widget from Movian metadata.",
+                "Registered: %s." % ("yes" if record.get("registered")
+                                      else "no"),
+            ]
+            aliases = record.get("aliases", [])
+            if aliases:
+                lines.append("Aliases: %s." % ", ".join("`%s`" % alias
+                                                       for alias in aliases))
+            self._append_source(lines, record)
+            self._append_condition(lines, record)
+            return "\n".join(lines)
+        return None
+
+    @staticmethod
+    def _append_source(lines: list[str], record: JSON) -> None:
+        source = record.get("source", {})
+        if source.get("file") and source.get("line"):
+            lines.append("Defined in `%s:%s`." %
+                         (source["file"], source["line"]))
+
+    @staticmethod
+    def _append_condition(lines: list[str], record: JSON) -> None:
+        condition = record.get("condition")
+        if condition:
+            lines.append("Available under `%s`." % condition)
+
+
+class LspServer:
+    """Own GLW LSP state while delegating parsing to ``movian-analyze``."""
+
+    def __init__(self, input_stream: BinaryIO | None = None,
+                 output_stream: BinaryIO | None = None,
+                 *, debounce_ms: int = DEFAULT_DEBOUNCE_MS) -> None:
+        self.repo_root = Path(__file__).resolve().parents[3]
+        self.workspace_root = self.repo_root
+        self.analyzer = self.repo_root / "build.debug" / "movian-analyze"
+        self.skin_root = self.repo_root / "glwskins" / "flat"
+        self.metadata = Metadata(self.repo_root / "generated" /
+                                 "movian-metadata.json")
+        self.debounce_seconds = debounce_ms / 1000.0
+        self.input = input_stream if input_stream is not None else sys.stdin.buffer
+        self.output = output_stream if output_stream is not None else sys.stdout.buffer
+        self.documents: dict[str, Document] = {}
+        self.documents_lock = threading.RLock()
+        self.output_lock = threading.Lock()
+        self.shutdown_requested = False
+        self.exiting = False
+
+    # ------------------------------------------------------------------
+    # JSON-RPC framing and dispatch
+    # ------------------------------------------------------------------
+
+    def run(self) -> int:
+        while not self.exiting:
+            try:
+                message = self._read_message()
+            except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+                self._send_error(None, -32700, "Parse error: %s" % exc)
+                continue
+            if message is None:
+                break
+            if not isinstance(message, dict):
+                self._send_error(None, -32600, "Invalid Request")
+                continue
+            self._dispatch(message)
+        self._cancel_all_timers()
+        return 0 if self.shutdown_requested else 1
+
+    def _read_message(self) -> JSON | None:
+        headers: dict[str, str] = {}
+        saw_header = False
+        while True:
+            line = self.input.readline()
+            if line == b"":
+                if not saw_header:
+                    return None
+                raise ValueError("unexpected EOF in JSON-RPC headers")
+            saw_header = True
+            if line in (b"\r\n", b"\n"):
+                break
+            try:
+                key, value = line.decode("ascii").split(":", 1)
+            except ValueError as exc:
+                raise ValueError("malformed JSON-RPC header") from exc
+            headers[key.strip().lower()] = value.strip()
+        if "content-length" not in headers:
+            raise ValueError("missing Content-Length header")
+        length = int(headers["content-length"])
+        if length < 0:
+            raise ValueError("negative Content-Length")
+        payload = self.input.read(length)
+        if len(payload) != length:
+            raise ValueError("unexpected EOF in JSON-RPC payload")
+        return json.loads(payload.decode("utf-8"))
+
+    def _send(self, message: JSON) -> None:
+        payload = json.dumps(message, ensure_ascii=False,
+                             separators=(",", ":")).encode("utf-8")
+        frame = ("Content-Length: %d\r\n\r\n" % len(payload)).encode("ascii")
+        with self.output_lock:
+            self.output.write(frame)
+            self.output.write(payload)
+            self.output.flush()
+
+    def _send_response(self, request_id: Any, result: Any) -> None:
+        self._send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+    def _send_error(self, request_id: Any, code: int, message: str) -> None:
+        self._send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        })
+
+    def _notify(self, method: str, params: JSON) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _dispatch(self, message: JSON) -> None:
+        method = message.get("method")
+        request_id = message.get("id")
+        is_request = "id" in message
+        if not isinstance(method, str):
+            if is_request:
+                self._send_error(request_id, -32600, "Invalid Request")
+            return
+
+        try:
+            if method == "initialize":
+                result = self._initialize(message.get("params", {}))
+            elif method == "initialized":
+                result = None
+            elif method == "shutdown":
+                self.shutdown_requested = True
+                self._cancel_all_timers()
+                result = None
+            elif method == "exit":
+                self.exiting = True
+                return
+            elif method == "textDocument/didOpen":
+                self._did_open(message.get("params", {}))
+                result = None
+            elif method == "textDocument/didChange":
+                self._did_change(message.get("params", {}))
+                result = None
+            elif method == "textDocument/didClose":
+                self._did_close(message.get("params", {}))
+                result = None
+            elif method == "textDocument/documentSymbol":
+                result = self._document_symbols(message.get("params", {}))
+            elif method == "textDocument/hover":
+                result = self._hover(message.get("params", {}))
+            elif method == "textDocument/definition":
+                result = self._definition(message.get("params", {}))
+            elif method == "workspace/symbol":
+                result = self._workspace_symbols(message.get("params", {}))
+            else:
+                if is_request:
+                    self._send_error(request_id, -32601,
+                                     "Method not found: %s" % method)
+                return
+        except (KeyError, TypeError, ValueError) as exc:
+            if is_request:
+                self._send_error(request_id, -32602,
+                                 "Invalid params: %s" % exc)
+            return
+        except Exception as exc:  # never leak an exception through stdout
+            print("movian-lsp: %s" % exc, file=sys.stderr)
+            if is_request:
+                self._send_error(request_id, -32603, "Internal error")
+            return
+
+        if is_request:
+            self._send_response(request_id, result)
+
+    def _initialize(self, params: JSON) -> JSON:
+        workspace = self._workspace_from_initialize(params)
+        if workspace is not None:
+            self.workspace_root = workspace
+        return {
+            "capabilities": {
+                "textDocumentSync": 1,
+                "documentSymbolProvider": True,
+                "hoverProvider": True,
+                "definitionProvider": True,
+                "workspaceSymbolProvider": True,
+            },
+            "serverInfo": {"name": "movian-lsp", "version": "0.1.0"},
+        }
+
+    @staticmethod
+    def _workspace_from_initialize(params: JSON) -> Path | None:
+        candidates: list[str] = []
+        root_uri = params.get("rootUri")
+        if isinstance(root_uri, str):
+            candidates.append(root_uri)
+        for folder in params.get("workspaceFolders") or []:
+            if isinstance(folder, dict) and isinstance(folder.get("uri"), str):
+                candidates.append(folder["uri"])
+        root_path = params.get("rootPath")
+        if isinstance(root_path, str):
+            candidates.append(path_to_uri(Path(root_path)))
+        for candidate in candidates:
+            path = uri_to_path(candidate)
+            if path is not None:
+                return path.resolve(strict=False)
+        return None
+
+    # ------------------------------------------------------------------
+    # Text-document lifecycle and analyzer bridge
+    # ------------------------------------------------------------------
+
+    def _did_open(self, params: JSON) -> None:
+        text_document = params["textDocument"]
+        uri = text_document["uri"]
+        if not isinstance(uri, str):
+            raise ValueError("textDocument.uri must be a string")
+        path = uri_to_path(uri)
+        if path is not None:
+            path = path.resolve(strict=False)
+        document = Document(
+            uri=uri,
+            path=path,
+            text=normalize_text(text_document.get("text", "")),
+            version=text_document.get("version"),
+        )
+        with self.documents_lock:
+            previous = self.documents.get(uri)
+            self.documents[uri] = document
+        if previous is not None:
+            self._cancel_timer(previous)
+        self._schedule_analysis(document)
+
+    def _did_change(self, params: JSON) -> None:
+        text_document = params["textDocument"]
+        uri = text_document["uri"]
+        document = self._document(uri)
+        if document is None:
+            return
+        changes = params.get("contentChanges") or []
+        if not changes or not isinstance(changes[-1], dict):
+            raise ValueError("full-text contentChanges is required")
+        text = changes[-1].get("text")
+        if not isinstance(text, str):
+            raise ValueError("contentChanges[-1].text must be a string")
+        self._cancel_timer(document)
+        with document.lock:
+            document.text = normalize_text(text)
+            document.version = text_document.get("version", document.version)
+            document.generation += 1
+            document.analyzed_generation = -1
+        self._schedule_analysis(document)
+
+    def _did_close(self, params: JSON) -> None:
+        text_document = params["textDocument"]
+        uri = text_document["uri"]
+        with self.documents_lock:
+            document = self.documents.pop(uri, None)
+        if document is None:
+            return
+        self._cancel_timer(document)
+        with document.lock:
+            uris = set(document.diagnostic_uris)
+        uris.add(document.uri)
+        for diagnostic_uri in sorted(uris):
+            self._notify("textDocument/publishDiagnostics", {
+                "uri": diagnostic_uri,
+                "diagnostics": [],
+            })
+
+    def _document(self, uri: str) -> Document | None:
+        with self.documents_lock:
+            return self.documents.get(uri)
+
+    def _schedule_analysis(self, document: Document) -> None:
+        with document.lock:
+            generation = document.generation
+            timer = threading.Timer(
+                self.debounce_seconds,
+                self._run_scheduled_analysis,
+                args=(document.uri, generation),
+            )
+            timer.daemon = True
+            document.timer = timer
+        timer.start()
+
+    def _cancel_timer(self, document: Document) -> None:
+        with document.lock:
+            timer = document.timer
+            document.timer = None
+        if timer is not None:
+            timer.cancel()
+
+    def _cancel_all_timers(self) -> None:
+        with self.documents_lock:
+            documents = list(self.documents.values())
+        for document in documents:
+            self._cancel_timer(document)
+
+    def _run_scheduled_analysis(self, uri: str, generation: int) -> None:
+        document = self._document(uri)
+        if document is not None:
+            self._analyze(document, generation)
+
+    def _ensure_analysis(self, document: Document) -> None:
+        with document.lock:
+            generation = document.generation
+            done = document.analyzed_generation == generation
+        if done:
+            return
+        self._cancel_timer(document)
+        self._analyze(document, generation)
+
+    def _analyze(self, document: Document, expected_generation: int) -> None:
+        """Run exact and tolerant analyzer modes against one buffer snapshot."""
+
+        with document.analysis_lock:
+            with document.lock:
+                if document.generation != expected_generation:
+                    return
+                text = document.text
+            temporary_path: Path | None = None
+            try:
+                temporary_path = self._write_buffer_snapshot(document, text)
+                check, check_failure = self._run_analyzer(
+                    "--check", temporary_path)
+                tokens, _tokens_failure = self._run_analyzer(
+                    "--tokens", temporary_path)
+            finally:
+                if temporary_path is not None:
+                    try:
+                        temporary_path.unlink()
+                    except FileNotFoundError:
+                        pass
+
+            diagnostics = self._diagnostics_from_check(
+                document, temporary_path, check, check_failure)
+            if isinstance(tokens, dict) and isinstance(tokens.get("tokens"), list):
+                remapped_tokens = self._remap_tokens(
+                    tokens["tokens"], temporary_path, document)
+                token_text = text
+                token_fallback = False
+            else:
+                remapped_tokens = None
+                token_text = ""
+                token_fallback = True
+
+            with document.lock:
+                if document.generation != expected_generation:
+                    return
+                document.analyzed_generation = expected_generation
+                if remapped_tokens is not None:
+                    document.tokens = remapped_tokens
+                    document.token_text = token_text
+                    document.last_good_tokens = remapped_tokens
+                    document.last_good_text = token_text
+                    document.using_token_fallback = False
+                else:
+                    document.tokens = document.last_good_tokens
+                    document.token_text = document.last_good_text
+                    document.using_token_fallback = token_fallback
+            self._publish_diagnostics(document, diagnostics)
+
+    def _write_buffer_snapshot(self, document: Document, text: str) -> Path:
+        """Write a short-lived ``.view`` clone, preferring the source directory.
+
+        Keeping the clone beside an on-disk document preserves relative
+        #include/#import resolution.  The clone is always removed after both
+        analyzer passes, so the analyzer never reads stale on-disk source.
+        """
+
+        directory: str | None = None
+        if document.path is not None and document.path.parent.is_dir():
+            directory = str(document.path.parent)
+        try:
+            descriptor, name = tempfile.mkstemp(
+                prefix=".movian-lsp-", suffix=".view", dir=directory)
+        except OSError:
+            descriptor, name = tempfile.mkstemp(
+                prefix=".movian-lsp-", suffix=".view")
+        with os.fdopen(descriptor, "wb") as snapshot:
+            snapshot.write(text.encode("utf-8"))
+        return Path(name)
+
+    def _run_analyzer(self, mode: str, temporary_path: Path) -> tuple[JSON | None, str | None]:
+        # The analyzer's error text deliberately preserves the spelling of a
+        # relative source path.  When the snapshot lives under this checkout,
+        # pass it relative to the analyzer's cwd so an include failure keeps
+        # the same file/message class as a normal in-tree ``--check`` call.
+        try:
+            analyzer_path = str(temporary_path.relative_to(self.repo_root))
+        except ValueError:
+            analyzer_path = str(temporary_path)
+        command = [
+            str(self.analyzer),
+            mode,
+            "--root",
+            str(self.workspace_root),
+            analyzer_path,
+        ]
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=self.repo_root,
+                capture_output=True,
+                timeout=ANALYZER_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None, "movian-analyze is not built at %s" % self.analyzer
+        except subprocess.TimeoutExpired:
+            return None, "movian-analyze timed out after 2 seconds"
+        except OSError as exc:
+            return None, "unable to run movian-analyze: %s" % exc
+
+        try:
+            payload = json.loads(completed.stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return None, "movian-analyze emitted invalid JSON: %s" % exc
+        if not isinstance(payload, dict):
+            return None, "movian-analyze emitted a non-object result"
+        return payload, None
+
+    def _remap_tokens(self, tokens: Iterable[JSON], temporary_path: Path,
+                      document: Document) -> list[JSON]:
+        remapped: list[JSON] = []
+        for token in tokens:
+            if not isinstance(token, dict):
+                continue
+            copy = dict(token)
+            raw_file = copy.get("file")
+            if isinstance(raw_file, str) and self._is_temporary_file(
+                    raw_file, temporary_path):
+                copy["file"] = (str(document.path) if document.path is not None
+                                else document.uri)
+            remapped.append(copy)
+        return remapped
+
+    def _is_temporary_file(self, raw_file: str,
+                           temporary_path: Path | None) -> bool:
+        if temporary_path is None:
+            return False
+        candidate = Path(raw_file)
+        if not candidate.is_absolute():
+            candidate = self.repo_root / candidate
+        return same_path(candidate, temporary_path)
+
+    def _diagnostics_from_check(self, document: Document,
+                                temporary_path: Path | None,
+                                check: JSON | None,
+                                failure: str | None) -> dict[str, list[JSON]]:
+        if failure is not None:
+            return {
+                document.uri: [{
+                    "range": range_for_line(document.text, 0),
+                    "severity": 1,
+                    "source": DIAGNOSTIC_SOURCE,
+                    "message": failure,
+                }]
+            }
+        if check is None or check.get("ok") is True:
+            return {document.uri: []}
+        raw_file = check.get("file")
+        raw_line = check.get("line")
+        error = check.get("error")
+        if not isinstance(raw_file, str) or not isinstance(raw_line, int) \
+                or not isinstance(error, str):
+            return {
+                document.uri: [{
+                    "range": range_for_line(document.text, 0),
+                    "severity": 1,
+                    "source": DIAGNOSTIC_SOURCE,
+                    "message": "movian-analyze emitted an invalid diagnostic",
+                }]
+            }
+        path = self._analyzer_file_path(raw_file, temporary_path, document)
+        diagnostic_uri = path_to_uri(path) if path is not None else document.uri
+        diagnostic_text = self._text_for_path(document, path)
+        line = raw_line - 1 if raw_line > 0 else 0
+        return {
+            diagnostic_uri: [{
+                "range": range_for_line(diagnostic_text, line),
+                "severity": 1,
+                "source": DIAGNOSTIC_SOURCE,
+                "message": error,
+            }]
+        }
+
+    def _publish_diagnostics(self, document: Document,
+                             diagnostics: dict[str, list[JSON]]) -> None:
+        with document.lock:
+            previous_uris = set(document.diagnostic_uris)
+            document.diagnostic_uris = set(diagnostics)
+            version = document.version
+        target_uris = previous_uris | set(diagnostics) | {document.uri}
+        for uri in sorted(target_uris):
+            payload: JSON = {
+                "uri": uri,
+                "diagnostics": diagnostics.get(uri, []),
+            }
+            if version is not None and uri == document.uri:
+                payload["version"] = version
+            self._notify("textDocument/publishDiagnostics", payload)
+
+    # ------------------------------------------------------------------
+    # LSP feature handlers
+    # ------------------------------------------------------------------
+
+    def _document_symbols(self, params: JSON) -> list[JSON]:
+        uri = params["textDocument"]["uri"]
+        document = self._document(uri)
+        if document is None:
+            return []
+        self._ensure_analysis(document)
+        with document.lock:
+            tokens = list(document.tokens)
+            text = document.token_text or document.text
+        local_tokens = [token for token in tokens
+                        if self._token_is_from_document(token, document)]
+        symbols: list[JSON] = []
+        seen: set[tuple[str, int, int]] = set()
+
+        def append(name: str, kind: int, token: JSON, detail: str) -> None:
+            line = int(token.get("line", 1)) - 1
+            key = (name, kind, line)
+            if key in seen:
+                return
+            seen.add(key)
+            symbol_range = range_for_line(text, line)
+            symbols.append({
+                "name": name,
+                "kind": kind,
+                "detail": detail,
+                "range": symbol_range,
+                "selectionRange": symbol_range,
+            })
+
+        for index, token in enumerate(local_tokens):
+            token_type = token.get("type")
+            if token_type == "HASH" and index + 2 < len(local_tokens):
+                directive = local_tokens[index + 1]
+                target = local_tokens[index + 2]
+                if directive.get("type") == "IDENTIFIER" \
+                        and directive.get("value") in ("include", "import") \
+                        and target.get("type") == "RSTRING":
+                    append("#%s %s" % (directive["value"],
+                                        target.get("value", "")),
+                           SYMBOL_NAMESPACE, token, "GLW include")
+            if token_type != "IDENTIFIER":
+                continue
+            value = token.get("value")
+            if not isinstance(value, str):
+                continue
+            if value == "widget" and index + 2 < len(local_tokens):
+                paren = local_tokens[index + 1]
+                widget = local_tokens[index + 2]
+                if paren.get("type") == "LEFT_PARENTHESIS" \
+                        and widget.get("type") == "IDENTIFIER" \
+                        and isinstance(widget.get("value"), str):
+                    append(widget["value"], SYMBOL_CLASS, widget, "GLW widget")
+            elif index + 1 < len(local_tokens) \
+                    and local_tokens[index + 1].get("type") == "COLON":
+                append(value, SYMBOL_PROPERTY, token, "GLW attribute")
+            elif value in self.metadata.functions and index + 1 < len(local_tokens) \
+                    and local_tokens[index + 1].get("type") == "LEFT_PARENTHESIS":
+                append(value, SYMBOL_FUNCTION, token, "GLW function")
+        return symbols
+
+    def _hover(self, params: JSON) -> JSON | None:
+        uri = params["textDocument"]["uri"]
+        position = params["position"]
+        document = self._document(uri)
+        if document is None:
+            return None
+        self._ensure_analysis(document)
+        line_number = position["line"]
+        character = position["character"]
+        with document.lock:
+            lines = document.text.split("\n")
+        if not isinstance(line_number, int) or not isinstance(character, int) \
+                or line_number < 0 or line_number >= len(lines):
+            return None
+        word = word_at_utf16_position(lines[line_number], character)
+        if word is None:
+            return None
+        contents = self.metadata.hover(word)
+        if contents is None:
+            return None
+        return {
+            "contents": {"kind": "markdown", "value": contents},
+            "range": range_for_line(document.text, line_number),
+        }
+
+    def _definition(self, params: JSON) -> list[JSON] | None:
+        uri = params["textDocument"]["uri"]
+        position = params["position"]
+        document = self._document(uri)
+        if document is None:
+            return None
+        self._ensure_analysis(document)
+        requested_line = position["line"] + 1
+        with document.lock:
+            tokens = list(document.tokens)
+        local_tokens = [token for token in tokens
+                        if self._token_is_from_document(token, document)]
+        for index, token in enumerate(local_tokens):
+            if token.get("type") != "HASH" or token.get("line") != requested_line:
+                continue
+            if index + 2 >= len(local_tokens):
+                continue
+            directive = local_tokens[index + 1]
+            target = local_tokens[index + 2]
+            if directive.get("type") != "IDENTIFIER" \
+                    or directive.get("value") not in ("include", "import") \
+                    or target.get("type") != "RSTRING" \
+                    or not isinstance(target.get("value"), str):
+                continue
+            resolved = self._resolve_include(document, target["value"])
+            if resolved is None:
+                return None
+            return [{
+                "uri": path_to_uri(resolved),
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 0},
+                },
+            }]
+        return None
+
+    def _workspace_symbols(self, params: JSON) -> list[JSON]:
+        query = params.get("query", "")
+        if not isinstance(query, str):
+            raise ValueError("query must be a string")
+        needle = query.casefold()
+        symbols: list[JSON] = []
+        if not self.workspace_root.is_dir():
+            return symbols
+        for candidate in sorted(self.workspace_root.rglob("*.view"),
+                                key=lambda path: path.as_posix().casefold()):
+            if not candidate.is_file() or needle not in candidate.name.casefold():
+                continue
+            try:
+                relative = candidate.relative_to(self.workspace_root).as_posix()
+            except ValueError:
+                relative = candidate.name
+            symbols.append({
+                "name": candidate.name,
+                "kind": SYMBOL_FILE,
+                "containerName": str(Path(relative).parent),
+                "location": {
+                    "uri": path_to_uri(candidate),
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 0},
+                    },
+                },
+            })
+        return symbols
+
+    # ------------------------------------------------------------------
+    # Provenance and include resolution
+    # ------------------------------------------------------------------
+
+    def _token_is_from_document(self, token: JSON, document: Document) -> bool:
+        raw_file = token.get("file")
+        if not isinstance(raw_file, str):
+            return False
+        if document.path is None:
+            return raw_file == document.uri
+        return same_path(Path(raw_file), document.path)
+
+    def _analyzer_file_path(self, raw_file: str, temporary_path: Path | None,
+                            document: Document) -> Path | None:
+        if self._is_temporary_file(raw_file, temporary_path):
+            return document.path
+        if raw_file.startswith("skin://"):
+            return self.skin_root / raw_file[len("skin://"):]
+        if raw_file.startswith("dataroot://"):
+            return self.workspace_root / raw_file[len("dataroot://"):]
+        if raw_file.startswith("file://"):
+            return uri_to_path(raw_file)
+        candidate = Path(raw_file)
+        if candidate.is_absolute():
+            return candidate
+        for base in (self.repo_root, document.path.parent if document.path else None,
+                     self.workspace_root):
+            if base is not None and (base / candidate).exists():
+                return base / candidate
+        return candidate
+
+    def _text_for_path(self, document: Document, path: Path | None) -> str:
+        if same_path(path, document.path):
+            return document.text
+        if path is not None:
+            with self.documents_lock:
+                other_documents = list(self.documents.values())
+            for other in other_documents:
+                if same_path(path, other.path):
+                    with other.lock:
+                        return other.text
+            try:
+                return normalize_text(path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError):
+                pass
+        return document.text
+
+    def _resolve_include(self, document: Document, target: str) -> Path | None:
+        candidates: list[Path] = []
+        if target.startswith("skin://"):
+            suffix = target[len("skin://"):]
+            candidates.extend([
+                self.workspace_root / "glwskins" / "flat" / suffix,
+                self.skin_root / suffix,
+            ])
+        elif target.startswith("dataroot://"):
+            candidates.append(self.workspace_root / target[len("dataroot://"):])
+        elif target.startswith("file://"):
+            path = uri_to_path(target)
+            if path is not None:
+                candidates.append(path)
+        else:
+            candidate = Path(target)
+            if candidate.is_absolute():
+                candidates.append(candidate)
+            elif document.path is not None:
+                candidates.append(document.path.parent / candidate)
+            else:
+                candidates.append(self.workspace_root / candidate)
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate.resolve()
+        return None

--- a/support/devtools/lsp/server.py
+++ b/support/devtools/lsp/server.py
@@ -241,6 +241,8 @@ class LspServer:
         self.documents: dict[str, Document] = {}
         self.documents_lock = threading.RLock()
         self.output_lock = threading.Lock()
+        self.analyzer_semaphore = threading.Semaphore(
+            max(2, min(os.cpu_count() or 2, 4)))
         self.shutdown_requested = False
         self.exiting = False
 
@@ -453,17 +455,25 @@ class LspServer:
         uri = text_document["uri"]
         with self.documents_lock:
             document = self.documents.pop(uri, None)
-        if document is None:
-            return
+            if document is None:
+                return
+            with document.lock:
+                uris = set(document.diagnostic_uris)
+            claimed_by_open_documents: set[str] = set()
+            for other in self.documents.values():
+                with other.lock:
+                    claimed_by_open_documents.update(other.diagnostic_uris)
+            uris.add(document.uri)
+            uris.difference_update(claimed_by_open_documents)
+            # Keep membership locked through the clears. An in-flight analysis
+            # either publishes before close reaches this point, or observes the
+            # removed document and drops its result.
+            for diagnostic_uri in sorted(uris):
+                self._notify("textDocument/publishDiagnostics", {
+                    "uri": diagnostic_uri,
+                    "diagnostics": [],
+                })
         self._cancel_timer(document)
-        with document.lock:
-            uris = set(document.diagnostic_uris)
-        uris.add(document.uri)
-        for diagnostic_uri in sorted(uris):
-            self._notify("textDocument/publishDiagnostics", {
-                "uri": diagnostic_uri,
-                "diagnostics": [],
-            })
 
     def _document(self, uri: str) -> Document | None:
         with self.documents_lock:
@@ -516,13 +526,15 @@ class LspServer:
                 if document.generation != expected_generation:
                     return
                 text = document.text
+                analyzed_version = document.version
             temporary_path: Path | None = None
             try:
                 temporary_path = self._write_buffer_snapshot(document, text)
-                check, check_failure = self._run_analyzer(
-                    "--check", temporary_path)
-                tokens, _tokens_failure = self._run_analyzer(
-                    "--tokens", temporary_path)
+                with self.analyzer_semaphore:
+                    check, check_failure = self._run_analyzer(
+                        "--check", temporary_path)
+                    tokens, _tokens_failure = self._run_analyzer(
+                        "--tokens", temporary_path)
             finally:
                 if temporary_path is not None:
                     try:
@@ -556,7 +568,8 @@ class LspServer:
                     document.tokens = document.last_good_tokens
                     document.token_text = document.last_good_text
                     document.using_token_fallback = token_fallback
-            self._publish_diagnostics(document, diagnostics)
+            self._publish_diagnostics(document, diagnostics,
+                                      expected_generation, analyzed_version)
 
     def _write_buffer_snapshot(self, document: Document, text: str) -> Path:
         """Write a short-lived ``.view`` clone, preferring the source directory.
@@ -579,7 +592,9 @@ class LspServer:
             snapshot.write(text.encode("utf-8"))
         return Path(name)
 
-    def _run_analyzer(self, mode: str, temporary_path: Path) -> tuple[JSON | None, str | None]:
+    def _analyzer_command(self, mode: str, temporary_path: Path) -> list[str]:
+        """Build one analyzer invocation for a live-buffer snapshot."""
+
         # The analyzer's error text deliberately preserves the spelling of a
         # relative source path.  When the snapshot lives under this checkout,
         # pass it relative to the analyzer's cwd so an include failure keeps
@@ -588,13 +603,18 @@ class LspServer:
             analyzer_path = str(temporary_path.relative_to(self.repo_root))
         except ValueError:
             analyzer_path = str(temporary_path)
-        command = [
+        return [
             str(self.analyzer),
             mode,
             "--root",
             str(self.workspace_root),
+            "--skin",
+            str(self.skin_root),
             analyzer_path,
         ]
+
+    def _run_analyzer(self, mode: str, temporary_path: Path) -> tuple[JSON | None, str | None]:
+        command = self._analyzer_command(mode, temporary_path)
         try:
             completed = subprocess.run(
                 command,
@@ -684,20 +704,35 @@ class LspServer:
         }
 
     def _publish_diagnostics(self, document: Document,
-                             diagnostics: dict[str, list[JSON]]) -> None:
-        with document.lock:
-            previous_uris = set(document.diagnostic_uris)
-            document.diagnostic_uris = set(diagnostics)
-            version = document.version
-        target_uris = previous_uris | set(diagnostics) | {document.uri}
-        for uri in sorted(target_uris):
-            payload: JSON = {
-                "uri": uri,
-                "diagnostics": diagnostics.get(uri, []),
-            }
-            if version is not None and uri == document.uri:
-                payload["version"] = version
-            self._notify("textDocument/publishDiagnostics", payload)
+                             diagnostics: dict[str, list[JSON]],
+                             expected_generation: int,
+                             analyzed_version: int | None) -> None:
+        """Publish only results still owned by the same document revision."""
+
+        with self.documents_lock:
+            # A debounce cancel cannot stop an analysis that already started.
+            # Do not let such a detached document re-publish after didClose.
+            if self.documents.get(document.uri) is not document:
+                return
+            with document.lock:
+                # Pair diagnostics with the snapshot's version, not whatever
+                # didChange may have installed while the analyzer was running.
+                if document.generation != expected_generation:
+                    return
+                previous_uris = set(document.diagnostic_uris)
+                document.diagnostic_uris = set(diagnostics)
+                target_uris = previous_uris | set(diagnostics) | {document.uri}
+                # Hold both locks while writing the frames: didClose and
+                # didChange then cannot interleave a stale publish after this
+                # membership/generation check.
+                for uri in sorted(target_uris):
+                    payload: JSON = {
+                        "uri": uri,
+                        "diagnostics": diagnostics.get(uri, []),
+                    }
+                    if analyzed_version is not None and uri == document.uri:
+                        payload["version"] = analyzed_version
+                    self._notify("textDocument/publishDiagnostics", payload)
 
     # ------------------------------------------------------------------
     # LSP feature handlers
@@ -834,7 +869,8 @@ class LspServer:
             return symbols
         for candidate in sorted(self.workspace_root.rglob("*.view"),
                                 key=lambda path: path.as_posix().casefold()):
-            if not candidate.is_file() or needle not in candidate.name.casefold():
+            if candidate.name.startswith(".") or not candidate.is_file() \
+                    or needle not in candidate.name.casefold():
                 continue
             try:
                 relative = candidate.relative_to(self.workspace_root).as_posix()
@@ -924,6 +960,26 @@ class LspServer:
             else:
                 candidates.append(self.workspace_root / candidate)
         for candidate in candidates:
-            if candidate.is_file():
+            if candidate.is_file() and self._is_confined_definition_target(
+                    candidate):
                 return candidate.resolve()
         return None
+
+    def _is_confined_definition_target(self, candidate: Path) -> bool:
+        """Match the analyzer's root/skin confinement for definitions."""
+
+        try:
+            resolved_candidate = Path(os.path.realpath(candidate))
+            allowed_roots = (
+                Path(os.path.realpath(self.workspace_root)),
+                Path(os.path.realpath(self.skin_root)),
+            )
+        except OSError:
+            return False
+        for root in allowed_roots:
+            try:
+                resolved_candidate.relative_to(root)
+                return True
+            except ValueError:
+                continue
+        return False

--- a/support/devtools/movian-lsp
+++ b/support/devtools/movian-lsp
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""movian-lsp -- stdio LSP server for Movian GLW ``.view`` files.
+
+The server deliberately has no third-party dependencies so it can be used in
+the same development environments as ``mdev``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Keep support/devtools free of generated __pycache__ directories, matching
+# mdev's repository hygiene.
+sys.dont_write_bytecode = True
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+from lsp.server import LspServer  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stdio", action="store_true",
+                        help="serve Language Server Protocol over stdin/stdout")
+    args = parser.parse_args()
+    if not args.stdio:
+        parser.error("--stdio is required")
+    return LspServer().run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tooling/lsp/fixtures/utf16-crlf-emoji-tabs.json
+++ b/tests/tooling/lsp/fixtures/utf16-crlf-emoji-tabs.json
@@ -1,0 +1,10 @@
+{
+  "expected": {
+    "endCharacter": 18,
+    "line": 1,
+    "message": "Invalid char '`'",
+    "source": "movian-glw"
+  },
+  "text": "widget(label, {\r\n\tcaption: \"😀\"; `;\r\n});\r\n",
+  "uri": "file:///tmp/movian-lsp-utf16-emoji-tabs.view"
+}

--- a/tests/tooling/lsp/golden/stdio-session.json
+++ b/tests/tooling/lsp/golden/stdio-session.json
@@ -1,0 +1,32 @@
+{
+  "changedDiagnostic": {
+    "line": 60,
+    "message": "Invalid char '`'",
+    "source": "movian-glw"
+  },
+  "definition": "glwskins/flat/theme.view",
+  "hoverNeedles": {
+    "container_x": "GLW widget from Movian metadata.",
+    "source": "source: string|string[]",
+    "translate": "translate(...args)"
+  },
+  "initialize": {
+    "capabilities": {
+      "definitionProvider": true,
+      "documentSymbolProvider": true,
+      "hoverProvider": true,
+      "textDocumentSync": 1,
+      "workspaceSymbolProvider": true
+    },
+    "serverInfo": {
+      "name": "movian-lsp",
+      "version": "0.1.0"
+    }
+  },
+  "symbolNames": [
+    "#import skin://theme.view",
+    "container_z",
+    "container_x"
+  ],
+  "workspaceSymbol": "log.view"
+}

--- a/tests/tooling/lsp/lsp_client.py
+++ b/tests/tooling/lsp/lsp_client.py
@@ -1,0 +1,140 @@
+"""Tiny framed-JSON-RPC client shared by the movian-lsp smoke scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+class LspClient:
+    """Run one stdio LSP server and retain its literal stdout frames."""
+
+    _EOF = object()
+
+    def __init__(self, server_path: Path, repository_root: Path) -> None:
+        environment = dict(os.environ)
+        environment["PYTHONDONTWRITEBYTECODE"] = "1"
+        self.process = subprocess.Popen(
+            [sys.executable, str(server_path), "--stdio"],
+            cwd=repository_root,
+            env=environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        assert self.process.stdin is not None
+        assert self.process.stdout is not None
+        self._messages: queue.Queue[tuple[bytes, dict[str, Any]] | object] = \
+            queue.Queue()
+        self._pending: list[dict[str, Any]] = []
+        self.frames: list[bytes] = []
+        self.reader_error: BaseException | None = None
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+
+    def _read_stdout(self) -> None:
+        try:
+            while True:
+                header = bytearray()
+                headers: dict[str, str] = {}
+                while True:
+                    line = self.process.stdout.readline()
+                    if line == b"":
+                        self._messages.put(self._EOF)
+                        return
+                    header.extend(line)
+                    if line in (b"\r\n", b"\n"):
+                        break
+                    key, value = line.decode("ascii").split(":", 1)
+                    headers[key.strip().lower()] = value.strip()
+                length = int(headers["content-length"])
+                body = bytearray()
+                while len(body) < length:
+                    chunk = self.process.stdout.read(length - len(body))
+                    if chunk == b"":
+                        raise EOFError("short JSON-RPC body")
+                    body.extend(chunk)
+                raw = bytes(header) + bytes(body)
+                message = json.loads(bytes(body).decode("utf-8"))
+                self._messages.put((raw, message))
+        except BaseException as exc:  # surfaced by wait_for(), never hidden
+            self.reader_error = exc
+            self._messages.put(self._EOF)
+
+    def send(self, message: dict[str, Any]) -> None:
+        payload = json.dumps(message, ensure_ascii=False,
+                             separators=(",", ":")).encode("utf-8")
+        self.process.stdin.write(
+            ("Content-Length: %d\r\n\r\n" % len(payload)).encode("ascii") +
+            payload)
+        self.process.stdin.flush()
+
+    def notify(self, method: str, params: dict[str, Any]) -> None:
+        self.send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def request(self, request_id: int, method: str,
+                params: dict[str, Any]) -> Any:
+        self.send({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        })
+        response = self.wait_for(lambda message: message.get("id") == request_id)
+        if "error" in response:
+            raise AssertionError("LSP error response: %s" % response["error"])
+        return response.get("result")
+
+    def wait_for(self, predicate: Callable[[dict[str, Any]], bool],
+                 timeout: float = 5.0) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while True:
+            for index, pending in enumerate(self._pending):
+                if predicate(pending):
+                    return self._pending.pop(index)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out waiting for matching LSP message")
+            try:
+                item = self._messages.get(timeout=remaining)
+            except queue.Empty as exc:
+                raise TimeoutError("timed out waiting for LSP message") from exc
+            if item is self._EOF:
+                stderr = self.process.stderr.read().decode("utf-8", "replace") \
+                    if self.process.stderr is not None else ""
+                if self.reader_error is not None:
+                    raise RuntimeError("LSP stdout reader failed: %s" %
+                                       self.reader_error)
+                raise RuntimeError("LSP exited before its response: %s" % stderr)
+            raw, message = item
+            self.frames.append(raw)
+            if predicate(message):
+                return message
+            self._pending.append(message)
+
+    def wait_for_notification(self, method: str,
+                              predicate: Callable[[dict[str, Any]], bool],
+                              timeout: float = 5.0) -> dict[str, Any]:
+        message = self.wait_for(
+            lambda message: message.get("method") == method
+            and isinstance(message.get("params"), dict)
+            and predicate(message["params"]),
+            timeout,
+        )
+        return message["params"]
+
+    def close_after_exit(self, timeout: float = 5.0) -> tuple[int, str]:
+        assert self.process.stdin is not None
+        self.process.stdin.close()
+        exit_code = self.process.wait(timeout=timeout)
+        stderr = self.process.stderr.read().decode("utf-8", "replace") \
+            if self.process.stderr is not None else ""
+        return exit_code, stderr

--- a/tests/tooling/lsp/run_corpus.py
+++ b/tests/tooling/lsp/run_corpus.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check flat-skin diagnostics, including the documented include fragment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+
+from lsp_client import LspClient
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_SERVER = REPOSITORY_ROOT / "support" / "devtools" / "movian-lsp"
+FLAT_SKIN = REPOSITORY_ROOT / "glwskins" / "flat"
+KNOWN_INCLUDE_FRAGMENT = FLAT_SKIN / "menu" / "sidebar_common.view"
+KNOWN_FRAGMENT_ERROR = "Unknown function: ListItemBevel"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("server", nargs="?", type=Path, default=DEFAULT_SERVER)
+    args = parser.parse_args()
+    client = LspClient(args.server, REPOSITORY_ROOT)
+    views = sorted(FLAT_SKIN.rglob("*.view"))
+    fragments = 0
+    try:
+        client.request(1, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        client.notify("initialized", {})
+        for index, view in enumerate(views, 1):
+            uri = view.as_uri()
+            client.notify("textDocument/didOpen", {"textDocument": {
+                "uri": uri,
+                "languageId": "glw",
+                "version": index,
+                "text": view.read_text(encoding="utf-8"),
+            }})
+            published = client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda params: params.get("uri") == uri
+                and params.get("version") == index,
+                timeout=3.0,
+            )
+            diagnostics = published.get("diagnostics")
+            if view == KNOWN_INCLUDE_FRAGMENT:
+                fragments += 1
+                if len(diagnostics) != 1:
+                    raise AssertionError("fragment must have one diagnostic: %s" %
+                                         published)
+                diagnostic = diagnostics[0]
+                if diagnostic.get("source") != "movian-glw" \
+                        or diagnostic.get("message") != KNOWN_FRAGMENT_ERROR \
+                        or diagnostic["range"]["start"]["line"] != 10:
+                    raise AssertionError("fragment diagnostic mismatch: %s" %
+                                         published)
+            elif diagnostics != []:
+                raise AssertionError("false diagnostic in %s: %s" %
+                                     (view, published))
+            client.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+            client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda params: params.get("uri") == uri
+                and params.get("diagnostics") == [],
+                timeout=3.0,
+            )
+        if client.request(2, "shutdown", {}) is not None:
+            raise AssertionError("shutdown must return null")
+        client.notify("exit", {})
+        exit_code, stderr = client.close_after_exit()
+        if exit_code != 0 or stderr:
+            raise AssertionError("server exit=%s stderr=%r" % (exit_code, stderr))
+        if fragments != 1:
+            raise AssertionError("expected exactly one known include fragment, got %d" %
+                                 fragments)
+        print(json.dumps({
+            "clean": len(views) - fragments,
+            "files": len(views),
+            "include_fragments": fragments,
+            "status": "LSP CORPUS OK",
+        }, sort_keys=True))
+        return 0
+    except BaseException:
+        if client.process.poll() is None:
+            client.process.kill()
+            client.process.wait()
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tooling/lsp/run_diagnostics.py
+++ b/tests/tooling/lsp/run_diagnostics.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Check LSP fixture diagnostics against the exact movian-analyze contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+
+from lsp_client import LspClient
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_SERVER = REPOSITORY_ROOT / "support" / "devtools" / "movian-lsp"
+ANALYZER = REPOSITORY_ROOT / "build.debug" / "movian-analyze"
+FIXTURES = REPOSITORY_ROOT / "tests" / "tooling" / "glw" / "fixtures"
+
+
+def analyzer_result(fixture: Path) -> dict:
+    completed = subprocess.run(
+        [str(ANALYZER), "--check", str(fixture.relative_to(REPOSITORY_ROOT))],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        timeout=2.0,
+        check=False,
+    )
+    return json.loads(completed.stdout.decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("server", nargs="?", type=Path, default=DEFAULT_SERVER)
+    args = parser.parse_args()
+    client = LspClient(args.server, REPOSITORY_ROOT)
+    checked = 0
+    try:
+        client.request(1, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        client.notify("initialized", {})
+        for fixture in sorted(FIXTURES.glob("*.view")):
+            if fixture.name == "self-include.view":
+                continue  # --check intentionally has no recursion depth knob.
+            exact = analyzer_result(fixture)
+            if exact.get("ok"):
+                continue
+            if not {"file", "line", "error"} <= exact.keys():
+                raise AssertionError("invalid analyzer fixture result: %s" % exact)
+            uri = fixture.as_uri()
+            client.notify("textDocument/didOpen", {"textDocument": {
+                "uri": uri,
+                "languageId": "glw",
+                "version": 1,
+                "text": fixture.read_text(encoding="utf-8"),
+            }})
+            raw_path = Path(exact["file"])
+            expected_path = raw_path if raw_path.is_absolute() \
+                else REPOSITORY_ROOT / raw_path
+            expected_uri = expected_path.resolve().as_uri()
+            params = client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda published: published.get("uri") == expected_uri
+                and len(published.get("diagnostics", [])) == 1,
+            )
+            diagnostic = params["diagnostics"][0]
+            if diagnostic.get("source") != "movian-glw" \
+                    or diagnostic.get("message") != exact["error"] \
+                    or diagnostic["range"]["start"]["line"] != max(0, exact["line"] - 1):
+                raise AssertionError("fixture mismatch %s: analyzer=%s lsp=%s" %
+                                     (fixture, exact, diagnostic))
+            checked += 1
+            client.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+            client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda published: published.get("uri") == uri
+                and published.get("diagnostics") == [],
+            )
+        if client.request(2, "shutdown", {}) is not None:
+            raise AssertionError("shutdown must return null")
+        client.notify("exit", {})
+        exit_code, stderr = client.close_after_exit()
+        if exit_code != 0 or stderr:
+            raise AssertionError("server exit=%s stderr=%r" % (exit_code, stderr))
+        print(json.dumps({"fixtures": checked, "status": "LSP DIAGNOSTICS OK"},
+                         sort_keys=True))
+        return 0
+    except BaseException:
+        if client.process.poll() is None:
+            client.process.kill()
+            client.process.wait()
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tooling/lsp/run_review_regressions.py
+++ b/tests/tooling/lsp/run_review_regressions.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Focused regressions for the PR #108 review findings on movian-lsp."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+
+sys.dont_write_bytecode = True
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+DEVTOOLS_ROOT = REPOSITORY_ROOT / "support" / "devtools"
+if str(DEVTOOLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(DEVTOOLS_ROOT))
+
+from lsp.server import LspServer  # noqa: E402
+from lsp_client import LspClient  # noqa: E402
+
+
+SERVER = REPOSITORY_ROOT / "support" / "devtools" / "movian-lsp"
+
+
+def did_open(uri: str, text: str, version: int = 1) -> dict[str, Any]:
+    return {
+        "textDocument": {
+            "uri": uri,
+            "languageId": "glw",
+            "version": version,
+            "text": text,
+        }
+    }
+
+
+def shutdown(client: LspClient, request_id: int) -> None:
+    if client.request(request_id, "shutdown", {}) is not None:
+        raise AssertionError("shutdown must return null")
+    client.notify("exit", {})
+    exit_code, stderr = client.close_after_exit()
+    if exit_code != 0 or stderr:
+        raise AssertionError("server exit=%s stderr=%r" % (exit_code, stderr))
+
+
+def abort(client: LspClient) -> None:
+    if client.process.poll() is None:
+        client.process.kill()
+        client.process.wait()
+
+
+def assert_no_empty_diagnostics(client: LspClient, uri: str,
+                                timeout: float = 0.35) -> None:
+    try:
+        params = client.wait_for_notification(
+            "textDocument/publishDiagnostics",
+            lambda candidate: candidate.get("uri") == uri
+            and candidate.get("diagnostics") == [],
+            timeout=timeout,
+        )
+    except TimeoutError:
+        return
+    raise AssertionError("unexpected diagnostics clear for %s: %s" %
+                         (uri, params))
+
+
+def framed_messages(raw: bytes) -> list[dict[str, Any]]:
+    """Decode only the JSON-RPC frames emitted by an in-process server."""
+
+    messages: list[dict[str, Any]] = []
+    offset = 0
+    while offset < len(raw):
+        header_end = raw.find(b"\r\n\r\n", offset)
+        if header_end < 0:
+            raise AssertionError("unterminated JSON-RPC header: %r" % raw[offset:])
+        headers = raw[offset:header_end].decode("ascii").split("\r\n")
+        content_length = None
+        for header in headers:
+            key, value = header.split(":", 1)
+            if key.lower() == "content-length":
+                content_length = int(value.strip())
+                break
+        if content_length is None:
+            raise AssertionError("missing Content-Length: %r" % headers)
+        body_start = header_end + 4
+        body_end = body_start + content_length
+        if body_end > len(raw):
+            raise AssertionError("short JSON-RPC body")
+        messages.append(json.loads(raw[body_start:body_end].decode("utf-8")))
+        offset = body_end
+    return messages
+
+
+def run_f1_command_builder() -> None:
+    """The analyzer command must carry its explicit skin root."""
+
+    server = LspServer(input_stream=io.BytesIO(), output_stream=io.BytesIO())
+    server.workspace_root = REPOSITORY_ROOT / "glwskins" / "flat"
+    command = server._analyzer_command(
+        "--check", REPOSITORY_ROOT / "glwskins" / "flat" / "log.view")
+    try:
+        skin_index = command.index("--skin")
+    except ValueError as exc:
+        raise AssertionError("analyzer command omitted --skin: %s" % command) from exc
+    if command[skin_index + 1] != str(server.skin_root):
+        raise AssertionError("wrong --skin value: %s" % command)
+
+
+def run_f2_shared_import_cleanup() -> None:
+    """Closing one claimant must not clear a shared imported diagnostic URI."""
+
+    with tempfile.TemporaryDirectory(prefix="movian-lsp-f2-") as directory:
+        root = Path(directory)
+        target = root / "shared-broken.view"
+        first = root / "first.view"
+        second = root / "second.view"
+        target.write_text("`\n", encoding="utf-8")
+        import_text = '#import "shared-broken.view"\n'
+        first.write_text(import_text, encoding="utf-8")
+        second.write_text(import_text, encoding="utf-8")
+        target_uri = target.as_uri()
+        first_uri = first.as_uri()
+        second_uri = second.as_uri()
+        client = LspClient(SERVER, REPOSITORY_ROOT)
+        try:
+            client.request(1, "initialize", {"rootUri": root.as_uri()})
+            client.notify("initialized", {})
+            client.notify("textDocument/didOpen", did_open(first_uri, import_text))
+            first_diagnostics = client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda params: params.get("uri") == target_uri
+                and len(params.get("diagnostics", [])) == 1,
+            )
+            if first_diagnostics["diagnostics"][0].get("source") != "movian-glw":
+                raise AssertionError("unexpected shared diagnostic: %s" %
+                                     first_diagnostics)
+
+            client.notify("textDocument/didOpen", did_open(second_uri, import_text))
+            client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda params: params.get("uri") == target_uri
+                and len(params.get("diagnostics", [])) == 1,
+            )
+
+            client.notify("textDocument/didClose", {
+                "textDocument": {"uri": first_uri},
+            })
+            client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda params: params.get("uri") == first_uri
+                and params.get("diagnostics") == [],
+            )
+            assert_no_empty_diagnostics(client, target_uri)
+
+            client.notify("textDocument/didClose", {
+                "textDocument": {"uri": second_uri},
+            })
+            client.wait_for_notification(
+                "textDocument/publishDiagnostics",
+                lambda params: params.get("uri") == target_uri
+                and params.get("diagnostics") == [],
+            )
+            shutdown(client, 2)
+        except BaseException:
+            abort(client)
+            raise
+
+
+def run_f3_close_race() -> None:
+    """A running debounced analysis must not publish after didClose."""
+
+    with tempfile.TemporaryDirectory(prefix="movian-lsp-f3-") as directory:
+        source = Path(directory) / "race.view"
+        source.write_text("widget(label, {})\n", encoding="utf-8")
+        output = io.BytesIO()
+        server = LspServer(input_stream=io.BytesIO(), output_stream=output,
+                           debounce_ms=1)
+        server.workspace_root = source.parent
+        analyzer_started = threading.Event()
+        release_analyzer = threading.Event()
+        publish_attempted = threading.Event()
+        original_publish = server._publish_diagnostics
+
+        def controlled_analyzer(mode: str,
+                                _temporary_path: Path) -> tuple[Any, str | None]:
+            if mode == "--check":
+                analyzer_started.set()
+                if not release_analyzer.wait(timeout=2.0):
+                    raise AssertionError("test did not release analyzer")
+                return {"ok": True}, None
+            return {"tokens": []}, None
+
+        def tracked_publish(*args: Any, **kwargs: Any) -> None:
+            try:
+                original_publish(*args, **kwargs)
+            finally:
+                publish_attempted.set()
+
+        server._run_analyzer = controlled_analyzer  # type: ignore[method-assign]
+        server._publish_diagnostics = tracked_publish  # type: ignore[method-assign]
+        uri = source.as_uri()
+        try:
+            server._dispatch({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": did_open(uri, source.read_text(encoding="utf-8")),
+            })
+            if not analyzer_started.wait(timeout=2.0):
+                raise AssertionError("scheduled analysis did not start")
+
+            server._dispatch({
+                "jsonrpc": "2.0",
+                "method": "textDocument/didClose",
+                "params": {"textDocument": {"uri": uri}},
+            })
+            close_messages = framed_messages(output.getvalue())
+            expected_close = [{
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {"uri": uri, "diagnostics": []},
+            }]
+            if close_messages != expected_close:
+                raise AssertionError("unexpected didClose frames: %s" %
+                                     close_messages)
+
+            release_analyzer.set()
+            if not publish_attempted.wait(timeout=2.0):
+                raise AssertionError("analysis did not reach publish guard")
+            deadline = time.monotonic() + 0.25
+            while time.monotonic() < deadline:
+                if framed_messages(output.getvalue()) != close_messages:
+                    raise AssertionError("analysis published after didClose")
+                time.sleep(0.025)
+        finally:
+            release_analyzer.set()
+            server._cancel_all_timers()
+
+
+def run_f5_definition_confinement() -> None:
+    """Definition must reject an absolute import that escapes both roots."""
+
+    with tempfile.TemporaryDirectory(prefix="movian-lsp-f5-root-") as root_dir, \
+            tempfile.TemporaryDirectory(prefix="movian-lsp-f5-outside-") as outside_dir:
+        root = Path(root_dir)
+        outside_target = Path(outside_dir) / "outside.view"
+        source = root / "escape.view"
+        outside_target.write_text("widget(label, {})\n", encoding="utf-8")
+        source_text = '#import "%s"\n' % outside_target
+        source.write_text(source_text, encoding="utf-8")
+        client = LspClient(SERVER, REPOSITORY_ROOT)
+        try:
+            client.request(11, "initialize", {"rootUri": root.as_uri()})
+            client.notify("initialized", {})
+            client.notify("textDocument/didOpen", did_open(source.as_uri(),
+                                                              source_text))
+            result = client.request(12, "textDocument/definition", {
+                "textDocument": {"uri": source.as_uri()},
+                "position": {"line": 0, "character": 1},
+            })
+            if result is not None:
+                raise AssertionError("escaped definition was returned: %s" % result)
+            client.notify("textDocument/didClose", {
+                "textDocument": {"uri": source.as_uri()},
+            })
+            shutdown(client, 13)
+        except BaseException:
+            abort(client)
+            raise
+
+
+def run_f7_hidden_workspace_snapshot() -> None:
+    """Workspace symbols must ignore transient dot-prefixed snapshots."""
+
+    fixture_directory = REPOSITORY_ROOT / "tests" / "tooling" / "glw" / "fixtures"
+    snapshot = fixture_directory / ".movian-lsp-tmp.view"
+    if snapshot.exists():
+        raise AssertionError("refusing to overwrite existing fixture %s" % snapshot)
+    snapshot.write_text("widget(label, {})\n", encoding="utf-8")
+    client = LspClient(SERVER, REPOSITORY_ROOT)
+    try:
+        client.request(21, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        client.notify("initialized", {})
+        symbols = client.request(22, "workspace/symbol", {
+            "query": "movian-lsp-tmp",
+        })
+        if any(symbol.get("location", {}).get("uri") == snapshot.as_uri()
+               for symbol in symbols):
+            raise AssertionError("workspace/symbol returned snapshot: %s" % symbols)
+        shutdown(client, 23)
+    except BaseException:
+        abort(client)
+        raise
+    finally:
+        snapshot.unlink(missing_ok=True)
+
+
+def main() -> int:
+    run_f1_command_builder()
+    run_f2_shared_import_cleanup()
+    run_f3_close_race()
+    run_f5_definition_confinement()
+    run_f7_hidden_workspace_snapshot()
+    print(json.dumps({
+        "checks": 5,
+        "status": "LSP REVIEW REGRESSIONS OK",
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tooling/lsp/run_smoke.py
+++ b/tests/tooling/lsp/run_smoke.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Protocol and feature smoke for ``movian-lsp --stdio`` (issue #99).
+
+The main session exercises each MVP method against the real flat skin.  It
+also emits a literal-stdout-frame mode for the executor report, while the
+normal mode compares behavior with the committed golden JSON contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.dont_write_bytecode = True
+
+from lsp_client import LspClient
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_SERVER = REPOSITORY_ROOT / "support" / "devtools" / "movian-lsp"
+GOLDEN = Path(__file__).with_name("golden") / "stdio-session.json"
+UTF16_FIXTURE = Path(__file__).with_name("fixtures") / \
+    "utf16-crlf-emoji-tabs.json"
+
+
+def utf16_length(text: str) -> int:
+    return sum(2 if ord(char) > 0xFFFF else 1 for char in text)
+
+
+def position_of(text: str, word: str) -> dict[str, int]:
+    for line_number, line in enumerate(text.splitlines()):
+        column = line.find(word)
+        if column >= 0:
+            return {"line": line_number,
+                    "character": utf16_length(line[:column])}
+    raise AssertionError("%r not found" % word)
+
+
+def did_open(uri: str, text: str, version: int = 1) -> dict[str, Any]:
+    return {
+        "textDocument": {
+            "uri": uri,
+            "languageId": "glw",
+            "version": version,
+            "text": text,
+        }
+    }
+
+
+def diagnostics_for(client: LspClient, uri: str,
+                    version: int | None = None) -> dict[str, Any]:
+    return client.wait_for_notification(
+        "textDocument/publishDiagnostics",
+        lambda params: params.get("uri") == uri
+        and (version is None or params.get("version") == version),
+    )
+
+
+def assert_empty_diagnostics(client: LspClient, uri: str,
+                             version: int | None = None) -> None:
+    params = diagnostics_for(client, uri, version)
+    if params.get("diagnostics") != []:
+        raise AssertionError("expected clean diagnostics for %s: %s" %
+                             (uri, params))
+
+
+def shutdown(client: LspClient, request_id: int) -> None:
+    if client.request(request_id, "shutdown", {}) is not None:
+        raise AssertionError("shutdown must return null")
+    client.notify("exit", {})
+    exit_code, stderr = client.close_after_exit()
+    if exit_code != 0 or stderr:
+        raise AssertionError("server exit=%s stderr=%r" % (exit_code, stderr))
+
+
+def run_main_session(server: Path, golden: dict[str, Any]) -> list[bytes]:
+    client = LspClient(server, REPOSITORY_ROOT)
+    log_path = REPOSITORY_ROOT / "glwskins" / "flat" / "log.view"
+    background_path = REPOSITORY_ROOT / "glwskins" / "flat" / "background.view"
+    log_uri = log_path.as_uri()
+    background_uri = background_path.as_uri()
+    log_text = log_path.read_text(encoding="utf-8")
+    background_text = background_path.read_text(encoding="utf-8")
+    try:
+        initialized = client.request(
+            1, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        if initialized != golden["initialize"]:
+            raise AssertionError("initialize golden mismatch: %s" % initialized)
+        client.notify("initialized", {})
+
+        client.notify("textDocument/didOpen", did_open(log_uri, log_text))
+        assert_empty_diagnostics(client, log_uri, 1)
+
+        symbols = client.request(
+            2, "textDocument/documentSymbol", {"textDocument": {"uri": log_uri}})
+        names = {symbol.get("name") for symbol in symbols}
+        missing_symbols = set(golden["symbolNames"]) - names
+        if missing_symbols:
+            raise AssertionError("documentSymbol missing %s" % missing_symbols)
+
+        for request_id, word in ((3, "translate"), (4, "container_x")):
+            result = client.request(request_id, "textDocument/hover", {
+                "textDocument": {"uri": log_uri},
+                "position": position_of(log_text, word),
+            })
+            value = result["contents"]["value"] if result else ""
+            if golden["hoverNeedles"][word] not in value:
+                raise AssertionError("hover for %s did not use metadata: %s" %
+                                     (word, value))
+
+        client.notify("textDocument/didOpen", did_open(background_uri,
+                                                         background_text))
+        assert_empty_diagnostics(client, background_uri, 1)
+        source_hover = client.request(5, "textDocument/hover", {
+            "textDocument": {"uri": background_uri},
+            "position": position_of(background_text, "source"),
+        })
+        source_value = source_hover["contents"]["value"] if source_hover else ""
+        if golden["hoverNeedles"]["source"] not in source_value:
+            raise AssertionError("hover for source did not use metadata: %s" %
+                                 source_value)
+
+        definition = client.request(6, "textDocument/definition", {
+            "textDocument": {"uri": log_uri},
+            "position": {"line": 0, "character": 1},
+        })
+        if not definition:
+            raise AssertionError("#import definition was empty")
+        definition_path = Path(definition[0]["uri"].removeprefix("file://"))
+        if definition_path.resolve() != (REPOSITORY_ROOT /
+                                         golden["definition"]).resolve():
+            raise AssertionError("wrong #import definition: %s" % definition)
+
+        workspace = client.request(7, "workspace/symbol", {"query": "log.view"})
+        if not any(symbol.get("name") == golden["workspaceSymbol"]
+                   for symbol in workspace):
+            raise AssertionError("workspace/symbol did not find log.view")
+
+        client.notify("textDocument/didClose", {"textDocument": {
+            "uri": background_uri,
+        }})
+        assert_empty_diagnostics(client, background_uri)
+
+        bad_text = log_text + "`\n"
+        client.notify("textDocument/didChange", {
+            "textDocument": {"uri": log_uri, "version": 2},
+            "contentChanges": [{"text": bad_text}],
+        })
+        changed = diagnostics_for(client, log_uri, 2)
+        diagnostics = changed.get("diagnostics", [])
+        if len(diagnostics) != 1:
+            raise AssertionError("expected one exact changed diagnostic: %s" %
+                                 changed)
+        diagnostic = diagnostics[0]
+        expected = golden["changedDiagnostic"]
+        if diagnostic.get("source") != expected["source"] \
+                or diagnostic.get("message") != expected["message"] \
+                or diagnostic["range"]["start"]["line"] != expected["line"]:
+            raise AssertionError("changed diagnostic mismatch: %s" % diagnostic)
+
+        client.notify("textDocument/didClose", {"textDocument": {
+            "uri": log_uri,
+        }})
+        assert_empty_diagnostics(client, log_uri)
+        shutdown(client, 8)
+        return client.frames
+    except BaseException:
+        if client.process.poll() is None:
+            client.process.kill()
+            client.process.wait()
+        raise
+
+
+def run_fallback_session(server: Path) -> list[bytes]:
+    """Prove lexer failure retains the previous successful token stream."""
+
+    client = LspClient(server, REPOSITORY_ROOT)
+    fixture = REPOSITORY_ROOT / "tests" / "tooling" / "glw" / "fixtures" / \
+        "invalid-char.view"
+    uri = fixture.as_uri()
+    broken = fixture.read_text(encoding="utf-8")
+    clean = broken.replace("`", "0")
+    try:
+        client.request(11, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        client.notify("initialized", {})
+        client.notify("textDocument/didOpen", did_open(uri, clean))
+        assert_empty_diagnostics(client, uri, 1)
+
+        client.notify("textDocument/didChange", {
+            "textDocument": {"uri": uri, "version": 2},
+            "contentChanges": [{"text": broken}],
+        })
+        changed = diagnostics_for(client, uri, 2)
+        diagnostics = changed.get("diagnostics", [])
+        if len(diagnostics) != 1 or diagnostics[0].get("message") != "Invalid char '`'":
+            raise AssertionError("expected fixture lexer diagnostic: %s" % changed)
+
+        symbols = client.request(12, "textDocument/documentSymbol", {
+            "textDocument": {"uri": uri},
+        })
+        if not symbols or not any(symbol.get("name") == "label" for symbol in symbols):
+            raise AssertionError("last-good token fallback did not serve symbols: %s" %
+                                 symbols)
+        client.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+        assert_empty_diagnostics(client, uri)
+        shutdown(client, 13)
+        return client.frames
+    except BaseException:
+        if client.process.poll() is None:
+            client.process.kill()
+            client.process.wait()
+        raise
+
+
+def run_utf16_session(server: Path) -> list[bytes]:
+    fixture = json.loads(UTF16_FIXTURE.read_text(encoding="utf-8"))
+    client = LspClient(server, REPOSITORY_ROOT)
+    try:
+        client.request(21, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        client.notify("initialized", {})
+        client.notify("textDocument/didOpen", did_open(fixture["uri"],
+                                                         fixture["text"]))
+        params = diagnostics_for(client, fixture["uri"], 1)
+        diagnostics = params.get("diagnostics", [])
+        if len(diagnostics) != 1:
+            raise AssertionError("UTF-16 fixture expected one diagnostic: %s" %
+                                 params)
+        diagnostic = diagnostics[0]
+        expected = fixture["expected"]
+        if diagnostic.get("source") != expected["source"] \
+                or diagnostic.get("message") != expected["message"] \
+                or diagnostic["range"]["start"]["line"] != expected["line"] \
+                or diagnostic["range"]["end"]["character"] != expected["endCharacter"]:
+            raise AssertionError("UTF-16 range mismatch: %s" % diagnostic)
+        client.notify("textDocument/didClose", {"textDocument": {
+            "uri": fixture["uri"],
+        }})
+        assert_empty_diagnostics(client, fixture["uri"])
+        shutdown(client, 22)
+        return client.frames
+    except BaseException:
+        if client.process.poll() is None:
+            client.process.kill()
+            client.process.wait()
+        raise
+
+
+def print_transcript(label: str, frames: list[bytes]) -> None:
+    stream = sys.stdout.buffer
+    stream.write(("--- %s stdout frames (verbatim) ---\n" % label).encode())
+    for frame in frames:
+        stream.write(frame)
+        stream.write(b"\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("server", nargs="?", type=Path, default=DEFAULT_SERVER)
+    parser.add_argument("--transcript", action="store_true",
+                        help="print every server stdout frame verbatim")
+    args = parser.parse_args()
+    golden = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    main_frames = run_main_session(args.server, golden)
+    fallback_frames = run_fallback_session(args.server)
+    utf16_frames = run_utf16_session(args.server)
+    if args.transcript:
+        print_transcript("main", main_frames)
+        print_transcript("fallback", fallback_frames)
+        print_transcript("utf16", utf16_frames)
+    print(json.dumps({
+        "fallbackFrames": len(fallback_frames),
+        "mainFrames": len(main_frames),
+        "status": "LSP SMOKE OK",
+        "utf16Frames": len(utf16_frames),
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tooling/lsp/run_soak.py
+++ b/tests/tooling/lsp/run_soak.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Run the issue #99 1000-didChange latency/survival smoke."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.dont_write_bytecode = True
+
+from lsp_client import LspClient
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_SERVER = REPOSITORY_ROOT / "support" / "devtools" / "movian-lsp"
+
+
+def diagnostics_for(client: LspClient, uri: str, version: int) -> dict:
+    return client.wait_for_notification(
+        "textDocument/publishDiagnostics",
+        lambda params: params.get("uri") == uri and params.get("version") == version,
+        timeout=3.0,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("server", nargs="?", type=Path, default=DEFAULT_SERVER)
+    parser.add_argument("--changes", type=int, default=1000)
+    args = parser.parse_args()
+    if args.changes < 1:
+        parser.error("--changes must be positive")
+
+    universe = REPOSITORY_ROOT / "glwskins" / "flat" / "universe.view"
+    uri = universe.as_uri()
+    text = universe.read_text(encoding="utf-8")
+    client = LspClient(args.server, REPOSITORY_ROOT)
+    try:
+        client.request(1, "initialize", {"rootUri": REPOSITORY_ROOT.as_uri()})
+        client.notify("initialized", {})
+        client.notify("textDocument/didOpen", {"textDocument": {
+            "uri": uri,
+            "languageId": "glw",
+            "version": 1,
+            "text": text,
+        }})
+        opened = diagnostics_for(client, uri, 1)
+        if opened.get("diagnostics") != []:
+            raise AssertionError("universe.view must open clean: %s" % opened)
+
+        latencies_ms: list[float] = []
+        for change in range(1, args.changes + 1):
+            version = change + 1
+            started = time.monotonic()
+            client.notify("textDocument/didChange", {
+                "textDocument": {"uri": uri, "version": version},
+                "contentChanges": [{"text": text + "` %d\n" % change}],
+            })
+            params = diagnostics_for(client, uri, version)
+            latencies_ms.append((time.monotonic() - started) * 1000.0)
+            diagnostics = params.get("diagnostics", [])
+            if len(diagnostics) != 1 or diagnostics[0].get("source") != "movian-glw":
+                raise AssertionError("change %d diagnostic mismatch: %s" %
+                                     (change, params))
+
+        ordered = sorted(latencies_ms)
+        p95 = ordered[math.ceil(0.95 * len(ordered)) - 1]
+        result = {
+            "changes": args.changes,
+            "max_ms": round(max(latencies_ms), 3),
+            "p50_ms": round(statistics.median(latencies_ms), 3),
+            "p95_ms": round(p95, 3),
+        }
+        if p95 >= 300.0:
+            raise AssertionError("p95 must stay below 300 ms: %s" % result)
+
+        client.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+        client.wait_for_notification(
+            "textDocument/publishDiagnostics",
+            lambda params: params.get("uri") == uri
+            and params.get("diagnostics") == [],
+        )
+        if client.request(2, "shutdown", {}) is not None:
+            raise AssertionError("shutdown must return null")
+        client.notify("exit", {})
+        exit_code, stderr = client.close_after_exit()
+        if exit_code != 0 or stderr:
+            raise AssertionError("server exit=%s stderr=%r" % (exit_code, stderr))
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except BaseException:
+        if client.process.poll() is None:
+            client.process.kill()
+            client.process.wait()
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements (#99), part of the language-tooling umbrella (#96). Builds on the merged (#97) movian-analyze and (#98) metadata artifact.

## What

`movian-lsp` — a Python-stdlib-only stdio LSP server for GLW `.view` files (`support/devtools/lsp/server.py`, 929 lines; entrypoint `support/devtools/movian-lsp --stdio`):

- **publishDiagnostics**: exact errors from short-lived `movian-analyze --check` subprocesses (crash isolation by process boundary, 2 s kill timeout), debounced (150 ms default), buffers passed via temp file (never stale disk state), `source: "movian-glw"`.
- **documentSymbol**: from the real lexer's `--tokens` stream with per-document last-good fallback on lexer failure.
- **hover**: functions/attributes/widgets from `generated/movian-metadata.json` (union valueTypes and `condition` fields included verbatim).
- **definition**: `#include`/`#import` targets; **workspace/symbol**: view files by name (cheap MVP variant; identifier references stay in v2).
- Position policy: GLW file+line → LSP line-ranges with UTF-8→UTF-16 conversion (surrogate pairs = 2 units, tabs not expanded, CRLF normalized).
- Test harness under `tests/tooling/lsp/` (framed-JSON-RPC client, smoke/corpus/diagnostics/soak runners, UTF-16 fixtures, goldens).

## Verification

Fresh-context verifier re-ran the DoD independently, including its OWN scripted stdio session with independent JSON-RPC framing (not the executor's client):

- Flat corpus via LSP diagnostics: 97/98 clean + exactly the one expected include-fragment diagnostic (`menu/sidebar_common.view`, see #106).
- Diagnostics parity: 5/5 error fixtures relayed file/line/error verbatim from `--check`.
- Soak: 1000 didChange cycles — p50 156 ms, p95 158 ms, max 236 ms, clean shutdown.
- UTF-16: surrogate-pair/tab/CRLF fixture session green, math hand-checked.
- hover shows `string|string[]` for `source` verbatim from the artifact; `#import` definition resolves to `theme.view`.

## Process notes

- Executor stop-on-divergence surfaced a real integration regression of the #101+#103 merge (`make movian-analyze-corpus` red on HEAD) — triaged as (#106), fixed in PR #107 (independent of this branch).
- Cross-vendor round: Codex executor (GPT-5.6) → Claude fresh-context verifier; commit applied by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
