### PR TITLE
devtools/docs: editor integration for movian-lsp + mdev lsp doctor (#100)

### DIFF
--- a/.claude/skills/movian-view-design/SKILL.md
+++ b/.claude/skills/movian-view-design/SKILL.md
@@ -28,6 +28,11 @@ guide is still a tracked follow-up; this file itself covers the
 edit/reload loop and the core mechanisms it depends on, each with its
 source anchor.
 
+For editor diagnostics, hover, and `#include` definitions, see
+`docs/Guides/language-tooling.md`; from the repository root, build
+`movian-analyze` and run `./support/devtools/mdev lsp doctor` before
+configuring an editor.
+
 ## The edit/reload loop
 
 For a view already reachable in a running app (e.g. anything under

--- a/.lsp.json
+++ b/.lsp.json
@@ -1,0 +1,10 @@
+{
+  "servers": {
+    "movian-lsp": {
+      "command": "python3",
+      "args": ["support/devtools/movian-lsp", "--stdio"],
+      "fileTypes": [".view"],
+      "rootMarkers": [".git"]
+    }
+  }
+}

--- a/docs/Guides/language-tooling.md
+++ b/docs/Guides/language-tooling.md
@@ -1,0 +1,147 @@
+# Movian `.view` language tooling
+
+`movian-lsp` supplies diagnostics, hover information, document symbols, and
+`#include`/`#import` definitions for GLW `.view` files. It runs from a Movian
+checkout, so each configuration below assumes the editor and checkout share a
+Linux or WSL environment.
+
+## Prepare the checkout
+
+From the repository root, build the analyzer that the server delegates syntax
+and semantic checks to, then run the preflight:
+
+```sh
+./support/configure-linux-debug.sh
+make BUILD=debug -j$(nproc) movian-analyze
+./support/devtools/mdev lsp doctor
+```
+
+The doctor requires Python 3.10 or newer, confirms that
+`generated/movian-metadata.json` is fresh, and performs one framed stdio LSP
+`initialize`/`shutdown` exchange. Re-run it after changing the build or
+metadata inputs.
+
+## Oh My Pi (OMP)
+
+OMP v17 discovers a project-root `.lsp.json` before its lower-priority LSP
+locations. This checkout includes a ready-to-use template at
+[`/.lsp.json`](../../.lsp.json): keep it at the root of the Movian checkout,
+then open that checkout with `omp` and open a `.view` file. The relative server
+path is intentionally resolved from the project root.
+
+```json
+{
+  "servers": {
+    "movian-lsp": {
+      "command": "python3",
+      "args": ["support/devtools/movian-lsp", "--stdio"],
+      "fileTypes": [".view"],
+      "rootMarkers": [".git"]
+    }
+  }
+}
+```
+
+Use OMP and the checkout in the same WSL distribution; this template does not
+provide Windows-to-WSL URI mapping. OMP's current [LSP configuration
+guide](https://github.com/can1357/oh-my-pi/blob/0f9fceeea483caad531a32b050ac38558516cb5c/docs/lsp-config.md)
+documents the project config precedence and schema.
+
+## Optional — requires a third-party generic client (VS Code Remote WSL)
+
+VS Code does not attach an arbitrary stdio language server through settings
+alone, so this optional path uses the maintained third-party [Generic LSP
+Proxy](https://marketplace.visualstudio.com/items?itemName=mjmorales.generic-lsp-proxy)
+extension (`mjmorales.generic-lsp-proxy`). At the 2026-07-17 check it had a
+2026-06-28 v2.1.1 Marketplace publication and its public repository had no
+open issues. This is not a Movian extension; review that extension's current
+maintenance status before relying on it.
+
+1. Open this checkout with **Remote - WSL**, trust the workspace, and install
+   Generic LSP Proxy into the WSL remote extension host (not only the local
+   Windows host).
+2. From the repository root in WSL, run
+   `realpath support/devtools/movian-lsp`. Copy the resulting absolute WSL
+   path into the proxy configuration. The proxy does not set its server
+   process's working directory, so a relative script path is not portable.
+3. Create `.vscode/settings.json` with this settings snippet:
+
+   ```json
+   {
+     "genericLspProxy.configPath": ".vscode/lsp-proxy.json"
+   }
+   ```
+
+4. Create `.vscode/lsp-proxy.json` with the following object, substituting
+   your path from step 2:
+
+   ```json
+   {
+     "languageId": "movian-view",
+     "command": "python3",
+     "args": [
+       "/absolute/WSL/path/to/movian/support/devtools/movian-lsp",
+       "--stdio"
+     ],
+     "fileExtensions": [".view"],
+     "transport": "stdio"
+   }
+   ```
+
+The proxy starts this configuration by `.view` extension even if VS Code shows
+the file as Plain Text. Its [configuration documentation](https://github.com/mjmorales/vscode-generic-lsp-proxy#configuration)
+describes the workspace config file and fields. Movian does not ship or package
+a VS Code extension.
+
+## Neovim
+
+Add this to `init.lua` (or an equivalent Lua file). It registers `.view` and
+starts one `movian-lsp` client rooted at the checkout containing `.git`:
+
+```lua
+vim.filetype.add({ extension = { view = "movian-view" } })
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "movian-view",
+  callback = function(event)
+    local root = vim.fs.root(event.buf, { ".git" })
+    if not root then
+      return
+    end
+    vim.lsp.start({
+      name = "movian-lsp",
+      cmd = { "python3", root .. "/support/devtools/movian-lsp", "--stdio" },
+      root_dir = root,
+    }, { bufnr = event.buf })
+  end,
+})
+```
+
+This uses Neovim's built-in [`vim.lsp.start`](https://neovim.io/doc/user/lsp.html#vim.lsp.start())
+API; no Neovim LSP plugin is required.
+
+## Helix
+
+Create `.helix/languages.toml` in the checkout (or merge the same tables into
+your user `languages.toml`). First obtain the absolute path with
+`realpath support/devtools/movian-lsp`, then substitute it below:
+
+```toml
+[language-server.movian-lsp]
+command = "python3"
+args = ["/absolute/WSL/or/Linux/path/to/movian/support/devtools/movian-lsp", "--stdio"]
+
+[[language]]
+name = "movian-view"
+scope = "source.movian-view"
+file-types = ["view"]
+roots = [".git"]
+language-servers = ["movian-lsp"]
+comment-tokens = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+```
+
+Helix merges a project's `.helix/languages.toml` with user and built-in
+configuration; its [language configuration documentation](https://docs.helix-editor.com/languages.html)
+defines the `language-server`, `file-types`, `roots`, and `language-servers`
+fields used here.

--- a/support/devtools/lsp/editors/movian-view.language-configuration.json
+++ b/support/devtools/lsp/editors/movian-view.language-configuration.json
@@ -1,0 +1,63 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": [
+      "/*",
+      "*/"
+    ]
+  },
+  "brackets": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [
+        "string",
+        "comment"
+      ]
+    }
+  ],
+  "surroundingPairs": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ],
+    [
+      "\"",
+      "\""
+    ]
+  ]
+}

--- a/support/devtools/lsp/editors/movian-view.tmLanguage.json
+++ b/support/devtools/lsp/editors/movian-view.tmLanguage.json
@@ -56,6 +56,17 @@
               "match": "\\\\."
             }
           ]
+        },
+        {
+          "name": "string.quoted.single.movian-view",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.movian-view",
+              "match": "\\\\."
+            }
+          ]
         }
       ]
     },
@@ -63,7 +74,11 @@
       "patterns": [
         {
           "name": "keyword.control.movian-view",
-          "match": "\\b(?:else|if|in|true|false|null)\\b"
+          "match": "\\bvoid\\b"
+        },
+        {
+          "name": "constant.language.movian-view",
+          "match": "\\b(?:true|false)\\b"
         }
       ]
     },

--- a/support/devtools/lsp/editors/movian-view.tmLanguage.json
+++ b/support/devtools/lsp/editors/movian-view.tmLanguage.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Movian View",
+  "scopeName": "source.movian-view",
+  "fileTypes": [
+    "view"
+  ],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#preprocessor"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#numbers"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.movian-view",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.block.movian-view",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "preprocessor": {
+      "patterns": [
+        {
+          "name": "meta.preprocessor.movian-view",
+          "match": "^\\s*#\\s*(?:define|elif|else|endif|if|ifdef|ifndef|import|include)\\b.*$"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.movian-view",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.movian-view",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.movian-view",
+          "match": "\\b(?:else|if|in|true|false|null)\\b"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.movian-view",
+          "match": "\\b(?:0[xX][0-9A-Fa-f]+|[0-9]+(?:\\.[0-9]+)?)\\b"
+        }
+      ]
+    }
+  }
+}

--- a/support/devtools/mdevlib/cli.py
+++ b/support/devtools/mdevlib/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from . import harness
+from . import lspdoctor
 from . import viewdoc
 from .harness import Instance, MdevError
 
@@ -550,6 +551,14 @@ def cmd_viewdoc(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# lsp (issue #100 -- editor integration preflight)
+# ---------------------------------------------------------------------------
+
+def cmd_lsp_doctor(_args: argparse.Namespace) -> int:
+    return lspdoctor.run()
+
+
+# ---------------------------------------------------------------------------
 # parser
 # ---------------------------------------------------------------------------
 
@@ -720,6 +729,17 @@ def build_parser() -> argparse.ArgumentParser:
     viewdoc_.add_argument("--json", action="store_true",
                           help="machine-readable JSON output")
     viewdoc_.set_defaults(func=cmd_viewdoc)
+
+    lsp = sub.add_parser(
+        "lsp",
+        help="movian-lsp editor-integration tools",
+    )
+    lsp_sub = lsp.add_subparsers(dest="lsp_command", required=True)
+    doctor = lsp_sub.add_parser(
+        "doctor",
+        help="check movian-lsp prerequisites and one stdio initialize round-trip",
+    )
+    doctor.set_defaults(func=cmd_lsp_doctor)
 
     return parser
 

--- a/support/devtools/mdevlib/lspdoctor.py
+++ b/support/devtools/mdevlib/lspdoctor.py
@@ -1,0 +1,148 @@
+"""Preflight checks for the repository's stdio movian-lsp server."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+MINIMUM_PYTHON = (3, 10)
+
+
+def _one_line(value: object) -> str:
+    """Keep doctor failures useful in terminals and scripts alike."""
+    return " ".join(str(value).strip().split()) or "unknown failure"
+
+
+def _fail(check: str, reason: str) -> int:
+    print("FAIL %s: %s" % (check, _one_line(reason)))
+    return 1
+
+
+def _check_python() -> tuple[bool, str]:
+    version = sys.version_info
+    if version[:2] < MINIMUM_PYTHON:
+        return False, ("requires Python %d.%d or newer (movian-lsp uses "
+                       "PEP 604 type syntax)" % MINIMUM_PYTHON)
+    return True, "%d.%d.%d" % version[:3]
+
+
+def _check_analyzer() -> tuple[bool, str]:
+    analyzer = REPOSITORY_ROOT / "build.debug" / "movian-analyze"
+    if not analyzer.is_file() or not os.access(analyzer, os.X_OK):
+        return False, ("build.debug/movian-analyze is not an executable "
+                       "file; run ./support/configure-linux-debug.sh && "
+                       "make BUILD=debug -j$(nproc) movian-analyze")
+    try:
+        completed = subprocess.run(
+            ["make", "BUILD=debug", "-n", "movian-analyze"],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, "make BUILD=debug -n movian-analyze could not run: %s" % exc
+    if completed.returncode:
+        return False, ("make BUILD=debug -n movian-analyze failed; run "
+                       "./support/configure-linux-debug.sh")
+    return True, "build.debug/movian-analyze is executable and make target resolves"
+
+
+def _check_metadata() -> tuple[bool, str]:
+    generator = REPOSITORY_ROOT / "support" / "devtools" / "metadata" / "gen.py"
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(generator), "--check"],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, "gen.py --check could not run: %s" % exc
+    if completed.returncode:
+        combined = completed.stdout + completed.stderr
+        if "METADATA DRIFT" in combined:
+            return False, ("generated/movian-metadata.json is stale; run "
+                           "python3 support/devtools/metadata/gen.py")
+        return False, ("gen.py --check failed; run python3 "
+                       "support/devtools/metadata/gen.py --check")
+    return True, "generated/movian-metadata.json is fresh"
+
+
+def _load_lsp_client() -> type[Any]:
+    client_path = REPOSITORY_ROOT / "tests" / "tooling" / "lsp" / "lsp_client.py"
+    spec = importlib.util.spec_from_file_location("movian_lsp_doctor_client",
+                                                   client_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load %s" % client_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.LspClient
+
+
+def _check_lsp_initialize() -> tuple[bool, str]:
+    server = REPOSITORY_ROOT / "support" / "devtools" / "movian-lsp"
+    if not server.is_file():
+        return False, "support/devtools/movian-lsp is missing"
+
+    client: Any | None = None
+    try:
+        client = _load_lsp_client()(server, REPOSITORY_ROOT)
+        initialized = client.request(
+            1,
+            "initialize",
+            {"rootUri": REPOSITORY_ROOT.as_uri()},
+        )
+        if not isinstance(initialized, dict):
+            raise RuntimeError("initialize returned a non-object result")
+        server_info = initialized.get("serverInfo")
+        if not isinstance(server_info, dict) or server_info.get("name") != "movian-lsp":
+            raise RuntimeError("initialize did not identify movian-lsp")
+        if not client.frames or not client.frames[0].startswith(b"Content-Length:"):
+            raise RuntimeError("initialize reply was not Content-Length framed")
+
+        client.notify("initialized", {})
+        if client.request(2, "shutdown", {}) is not None:
+            raise RuntimeError("shutdown returned a non-null result")
+        client.notify("exit", {})
+        exit_code, stderr = client.close_after_exit()
+        if exit_code:
+            raise RuntimeError("server exited with status %d" % exit_code)
+        if stderr.strip():
+            raise RuntimeError("server wrote stderr: %s" % stderr)
+        version = server_info.get("version", "unknown")
+        return True, ("Content-Length JSON-RPC initialize reply from "
+                      "movian-lsp %s" % version)
+    except Exception as exc:
+        return False, _one_line(exc)
+    finally:
+        if client is not None and client.process.poll() is None:
+            client.process.kill()
+            try:
+                client.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+
+def run() -> int:
+    """Run dependency-ordered checks, stopping before derivative failures."""
+    for name, check in (
+        ("python", _check_python),
+        ("movian-analyze", _check_analyzer),
+        ("metadata", _check_metadata),
+        ("lsp-initialize", _check_lsp_initialize),
+    ):
+        ok, detail = check()
+        if not ok:
+            return _fail(name, detail)
+        print("OK %s: %s" % (name, detail))
+    return 0

--- a/support/devtools/mdevlib/lspdoctor.py
+++ b/support/devtools/mdevlib/lspdoctor.py
@@ -40,19 +40,23 @@ def _check_analyzer() -> tuple[bool, str]:
                        "make BUILD=debug -j$(nproc) movian-analyze")
     try:
         completed = subprocess.run(
-            ["make", "BUILD=debug", "-n", "movian-analyze"],
+            ["make", "BUILD=debug", "-q", "movian-analyze"],
             cwd=REPOSITORY_ROOT,
             capture_output=True,
             text=True,
             timeout=30,
             check=False,
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return False, "make BUILD=debug -n movian-analyze could not run: %s" % exc
+    except (OSError, subprocess.TimeoutExpired):
+        return False, ("make BUILD=debug -q movian-analyze could not run; "
+                       "run ./support/configure-linux-debug.sh")
+    if completed.returncode == 1:
+        return False, ("build.debug/movian-analyze is stale; run make "
+                       "BUILD=debug -j$(nproc) movian-analyze")
     if completed.returncode:
-        return False, ("make BUILD=debug -n movian-analyze failed; run "
+        return False, ("make BUILD=debug -q movian-analyze failed; run "
                        "./support/configure-linux-debug.sh")
-    return True, "build.debug/movian-analyze is executable and make target resolves"
+    return True, "build.debug/movian-analyze is executable and up to date"
 
 
 def _check_metadata() -> tuple[bool, str]:


### PR DESCRIPTION
Implements (#100), the final item of the language-tooling umbrella (#96). Depends on merged (#97)/(#98)/(#99).

## What

- `docs/Guides/language-tooling.md` — setup guide: OMP (project-root `.lsp.json`, schema verified against current oh-my-pi docs), VS Code Remote WSL (optional path via the maintained third-party Generic LSP Proxy extension — we ship no extension of our own), Neovim (`vim.lsp.start`), Helix (`languages.toml`).
- `.lsp.json` — ready-to-use OMP config at the checkout root.
- `mdev lsp doctor` — preflight: Python ≥3.10, `movian-analyze` built + make target resolves, metadata artifact fresh (`gen.py --check`), one framed stdio `initialize`/`shutdown` round-trip; exit 0 healthy, one named one-line reason per failure.
- Plain TextMate grammar + language-configuration for `.view` (no packaging).
- One additive pointer in the movian-view-design skill.

## Verification

Fresh-context verifier, 8/8: healthy doctor (all four OK lines); induced failures — analyzer moved aside → `FAIL movian-analyze: …` and metadata drift → `FAIL metadata: … stale`, both restored to green; `.lsp.json` paths exist; every guide path/command audited; editor JSONs parse; skill diff additive-only (+5/−0); #99 harness still green in-tree.

**Live acceptance on the stand (orchestrator session, following ONLY the guide):** OMP discovered `movian-lsp` for `.view` from `.lsp.json` (visible in its LSP panel), reported the injected-error diagnostic `[movian-glw] Unexpected end of file` at the right line, hover returned metadata-artifact content (with `glw_view_attrib.c` provenance), and go-to-definition on `#import "skin://theme.view"` resolved to `glwskins/flat/theme.view`.

## Process notes

Executor stop-on-divergence caught a research-pack error ("VS Code settings-only" is impossible — no built-in generic LSP client); the spec fork was resolved on the issue before resuming. Cross-vendor round: Codex executor → Claude verifier → orchestrator review pass BEFORE this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
