### PR TITLE
metadata: enumValues for aligntab/transitiontab (#110)

### DIFF
--- a/generated/movian-metadata.json
+++ b/generated/movian-metadata.json
@@ -44,6 +44,18 @@
       {
         "attribConst": null,
         "confidence": "high",
+        "enumValues": [
+          "center",
+          "left",
+          "right",
+          "top",
+          "bottom",
+          "topLeft",
+          "topRight",
+          "bottomLeft",
+          "bottomRight",
+          "justified"
+        ],
         "fn": null,
         "name": "align",
         "noSubscription": false,
@@ -655,6 +667,13 @@
       {
         "attribConst": null,
         "confidence": "high",
+        "enumValues": [
+          "blend",
+          "flipHorizontal",
+          "flipVertical",
+          "slideHorizontal",
+          "slideVertical"
+        ],
         "fn": null,
         "name": "effect",
         "noSubscription": false,
@@ -3459,6 +3478,6 @@
     ]
   },
   "js": {},
-  "movianRevision": "6042a3b5e7514f68723e81d39e5cc10ccf947517",
+  "movianRevision": "468e6ea61c6a2351d128e59b35ecea65ddfa252c",
   "schemaVersion": 1
 }

--- a/support/devtools/mdevlib/cli.py
+++ b/support/devtools/mdevlib/cli.py
@@ -518,11 +518,16 @@ def cmd_viewdoc(args: argparse.Namespace) -> int:
     if not args.check:
         # No --check: dump the source-side inventories (handy for doc work).
         inv = viewdoc.inventory()
+        enum_values = viewdoc.attribute_enum_values()
         if args.json:
-            print(json.dumps(inv, ensure_ascii=False, indent=2))
+            print(json.dumps({**inv, "attributeEnumValues": enum_values},
+                             ensure_ascii=False, indent=2))
         else:
             for kind, names in inv.items():
                 print("%s (%d): %s" % (kind, len(names), " ".join(names)))
+            for name, values in enum_values.items():
+                print("attribute %s values: %s"
+                      % (name, " | ".join(values)))
         return 0
 
     result = viewdoc.run_check()

--- a/support/devtools/mdevlib/viewdoc.py
+++ b/support/devtools/mdevlib/viewdoc.py
@@ -146,3 +146,13 @@ def inventory() -> dict:
         "attributes": sorted(set(artifact_names(artifact, "attributes"))),
         "functions": sorted(set(artifact_names(artifact, "functions"))),
     }
+
+
+def attribute_enum_values() -> dict[str, list[str]]:
+    """Attribute enum values from the artifact, in attribute/source order."""
+    artifact = load_artifact()
+    return {
+        record["name"]: record["enumValues"]
+        for record in artifact["glw"]["attributes"]
+        if "enumValues" in record
+    }

--- a/support/devtools/metadata/gen.py
+++ b/support/devtools/metadata/gen.py
@@ -9,7 +9,9 @@ committed metadata artifact for the GLW view language, grown from
                       (name, nargs/variadic, ctor/dtor/preproc presence).
 - glw.attributes  -- `token_attrib_t attribtab[]`, src/ui/glw/glw_view_attrib.c
                       (name, valueType inferred from the setter function,
-                      raw setter/attribConst/fn fields, noSubscription flag).
+                      raw setter/attribConst/fn fields, noSubscription flag,
+                      and optional enumValues in C source order for setters
+                      backed by an explicitly mapped strtab).
 - glw.widgets     -- every `glw_class_t` designated initializer
                       (`.gc_name`/`.gc_name2`) across src/ui/glw/glw_*.c,
                       cross-referenced against `GLW_REGISTER_CLASS(...)`
@@ -100,6 +102,14 @@ VALUE_TYPE_MAP: dict[str, tuple[str, str]] = {
     "set_transition_effect": ("enum", "high"),
     "set_args": ("block", "high"),
     "set_propref": ("propref", "high"),
+}
+
+# Enum provenance is intentionally explicit: each setter maps to the C strtab
+# that defines its legal values. Attribute records using a mapped setter carry
+# optional `enumValues`, preserving the table's source order.
+ENUM_TABLE_MAP: dict[str, str] = {
+    "set_align": "aligntab",
+    "set_transition_effect": "transitiontab",
 }
 
 
@@ -307,8 +317,26 @@ def unquote(field: str) -> str:
 # glw.attributes -- attribtab[]
 # ---------------------------------------------------------------------------
 
+def scan_strtab(table_name: str) -> list[str]:
+    entries = scan_array_block(
+        ATTRIB_C, "struct strtab %s[] = {" % table_name)
+    values: list[str] = []
+    for text, line in entries:
+        fields = split_fields(text)
+        if not fields or len(fields[0]) < 2 or not (
+                fields[0].startswith('"') and fields[0].endswith('"')):
+            raise GenError("invalid string entry in strtab %s at %s:%d"
+                           % (table_name, ATTRIB_C, line))
+        values.append(unquote(fields[0]))
+    return values
+
+
 def build_attributes() -> list[dict[str, Any]]:
     entries = scan_array_block(ATTRIB_C, ATTRIB_TABLE_DECL)
+    enum_values = {
+        setter: scan_strtab(table_name)
+        for setter, table_name in ENUM_TABLE_MAP.items()
+    }
     records: list[dict[str, Any]] = []
     seen: set[str] = set()
     for text, line in entries:
@@ -328,7 +356,7 @@ def build_attributes() -> list[dict[str, Any]]:
                   and fields[4] == "GLW_ATTRIB_FLAG_NO_SUBSCRIPTION")
         value_type, confidence = VALUE_TYPE_MAP.get(setter, ("unknown", "low"))
 
-        records.append({
+        record = {
             "name": name,
             "valueType": value_type,
             "confidence": confidence,
@@ -337,7 +365,10 @@ def build_attributes() -> list[dict[str, Any]]:
             "fn": fn,
             "noSubscription": no_sub,
             "source": {"file": rel(ATTRIB_C), "line": line},
-        })
+        }
+        if setter in enum_values:
+            record["enumValues"] = enum_values[setter]
+        records.append(record)
     records.sort(key=lambda r: r["name"])
     return records
 


### PR DESCRIPTION
Implements (#110), v1-wave remainder of the closed umbrella (#96).

Attribute records whose setter is `set_align`/`set_transition_effect` now carry `enumValues` in C source order, extracted from the strtabs at `glw_view_attrib.c:1014`/`1048` via an explicit setter→table map; malformed strtab entries fail generation. `mdev viewdoc` renders the lists.

Verified by a fresh-context verifier, 5/5: regen idempotent + METADATA OK; exact value lists quoted from the artifact; falsifiability probe (fake aligntab row → `changed (attributes): align`, revert → green); viewdoc line present; metadata check green.

Process note: this task ran as a harness A/B (same model `gpt-5.6-sol:high`, same spec) — `codex exec` vs `omp`. Both arms passed independent verification 5/5; this is the codex arm's diff (1 round, smaller diff, entry validation). Full comparison in the issue journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)