### PR TITLE
httpcontrol: mark /api/input/action events as keypresses (#114)

### DIFF
--- a/src/api/httpcontrol.c
+++ b/src/api/httpcontrol.c
@@ -230,7 +230,12 @@ hc_action(http_connection_t *hc, const char *remain, void *opaque,
   if(remain == NULL)
     return 404;
 
-  event_to_ui(event_create_action_str(remain));
+  event_t *e = event_create_action_str(remain);
+  // The HTTP control API acts as a remote control; mark its events as
+  // keypresses like the other remote paths (lirc, devevent, stdin,
+  // libcec) so GLW engages keyboard mode and focus becomes visible.
+  e->e_flags |= EVENT_KEYPRESS;
+  event_to_ui(e);
   return HTTP_STATUS_OK;
 }
 


### PR DESCRIPTION
One-line behavior fix for (#114): `hc_action` now sets `EVENT_KEYPRESS` on the event it posts, matching every other remote-control input path (lirc `src/ipc/lirc.c:126`, devevent, stdin, libcec).

Without the flag, GLW never engages keyboard mode in HTTP-driven sessions (`isFocused()` is gated on `gr_keyboard_mode`, `src/ui/glw/glw_view_eval.c:5008`), so no focus ring is ever visible or verifiable through the mdev harness.

**Verified live** (debug build, fresh `mdev preview` instance, #89 pilot page):
- before: arrows via `/api/input/action/*` never revealed any focus highlight on any page (home grid, popup rows, pilot page);
- after: first `down` engages keyboard mode (consumed by the mode switch, existing glw.c behavior), subsequent arrows visibly move focus (episode row 1 → row 2 → season card), screenshots confirm the highlight.

Found while driving the (#89) mockup→view pilot loop; also unblocks focus-state checks planned for (#90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)